### PR TITLE
Add capability to build a docker image optionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# micro-integrator
+# Micro Integrator
+
+## Building the docker image
+
+You can build the docker image for micro integrator by setting the system property `docker.skip` to false when running
+maven build.
+
+```bash
+mvn clean install -Ddocker.skip=false
+```

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -130,7 +130,6 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <id>build-image</id>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -84,6 +84,7 @@
                         </goals>
                         <configuration>
                             <appendAssemblyId>false</appendAssemblyId>
+                            <tarLongFileMode>posix</tarLongFileMode>
                             <filters>
                                 <filter>${basedir}/src/assembly/filter.properties</filter>
                             </filters>
@@ -98,6 +99,71 @@
                             </archiverConfig>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>filter-dockerfiles</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <!-- # Filtered Resources -->
+                                <resource>
+                                    <directory>${basedir}/src/docker-distribution/filtered</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>Dockerfile</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                            <outputDirectory>${project.build.directory}/docker</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>build-image</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <imageName>wso2/micro-integrator</imageName>
+                            <imageTags>
+                                <imageTag>${project.version}</imageTag>
+                            </imageTags>
+                            <dockerDirectory>${basedir}/src/docker-distribution/static</dockerDirectory>
+                            <resources>
+                                <resource>
+                                    <targetPath>/</targetPath>
+                                    <directory>${project.build.directory}</directory>
+                                    <include>wso2mi-${project.version}.tar.gz</include>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <!-- TODO Enable after configuring Jenkins to push docker -->
+                    <!--<execution>-->
+                        <!--<id>push-image</id>-->
+                        <!--<phase>deploy</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>push</goal>-->
+                        <!--</goals>-->
+                        <!--<configuration>-->
+                            <!--<imageName>wso2/micro-integrator:${project.version}</imageName>-->
+                        <!--</configuration>-->
+                    <!--</execution>-->
                 </executions>
             </plugin>
         </plugins>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -134,11 +134,12 @@
                 <executions>
                     <execution>
                         <id>build-image</id>
-                        <phase>deploy</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>
                         <configuration>
+                            <skipDocker>${docker.skip}</skipDocker>
                             <imageName>wso2/micro-integrator</imageName>
                             <imageTags>
                                 <imageTag>${project.version}</imageTag>
@@ -168,5 +169,9 @@
             </plugin>
         </plugins>
     </build>
+
+    <properties>
+        <docker.skip>true</docker.skip>
+    </properties>
 
 </project>

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -43,6 +43,7 @@
     <id>wso2ei-bin</id>
     <formats>
         <format>zip</format>
+        <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>

--- a/distribution/src/docker-distribution/filtered/Dockerfile
+++ b/distribution/src/docker-distribution/filtered/Dockerfile
@@ -39,8 +39,6 @@ RUN addgroup -S ${USER_GROUP} && adduser -S -G ${USER_GROUP} ${USER}
 
 # Copy mico esb distribution to user's home directory
 ADD --chown=wso2ei:wso2ei ${MICROESB_DISTRIBUTION} ${USER_HOME}
-#RUN chown -R wso2ei:wso2ei ${MICROESB_HOME}
-#COPY ${FILES}/carbonapps  ${MICROESB_HOME}/wso2/micro-integrator/repository/deployment/server/carbonapps
 
 # set the user and work directory
 USER ${USER}

--- a/distribution/src/docker-distribution/filtered/Dockerfile
+++ b/distribution/src/docker-distribution/filtered/Dockerfile
@@ -1,0 +1,56 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  WSO2 Inc. licenses this file to you under the Apache License,
+#  Version 2.0 (the "License"); you may not use this file except
+#  in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+# ---------------------------------------------------------------------------
+
+# Base image
+FROM openjdk:8-jre-alpine
+MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+
+# User details
+ARG USER=wso2ei
+ARG USER_GROUP=wso2ei
+ARG USER_HOME=/home/${USER}
+
+# Resource directory
+ARG FILES=./files
+
+# Broker details
+ARG MICROESB_NAME=wso2mi
+ARG MICROESB_VERSION=${pom.version}
+ARG MICROESB_DISTRIBUTION=${MICROESB_NAME}-${MICROESB_VERSION}.tar.gz
+ARG MICROESB_HOME=${USER_HOME}/${MICROESB_NAME}-${MICROESB_VERSION}
+
+# Add a user group and a user
+RUN addgroup -S ${USER_GROUP} && adduser -S -G ${USER_GROUP} ${USER}
+
+# Copy mico esb distribution to user's home directory
+ADD --chown=wso2ei:wso2ei ${MICROESB_DISTRIBUTION} ${USER_HOME}
+#RUN chown -R wso2ei:wso2ei ${MICROESB_HOME}
+#COPY ${FILES}/carbonapps  ${MICROESB_HOME}/wso2/micro-integrator/repository/deployment/server/carbonapps
+
+# set the user and work directory
+USER ${USER}
+WORKDIR ${USER_HOME}
+
+# Set environment variable
+ENV MICROESB_HOME ${MICROESB_HOME}
+
+# Expose mico esb ports
+EXPOSE 8290 8253
+
+# Execute micro esb startup script
+CMD ["sh", "-c", "${MICROESB_HOME}/bin/micro-integrator.sh"]

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,8 @@
         <version.eclipse.ecj>4.4.2</version.eclipse.ecj>
         <version.com.google.code.gson>2.7</version.com.google.code.gson>
         <carbon.identity.framework.version>5.12.153</carbon.identity.framework.version>
+        <docker.maven.plugin.version>1.0.0</docker.maven.plugin.version>
+        <maven.resources.plugin.version>2.7</maven.resources.plugin.version>
     </properties>
 
     <repositories>
@@ -509,6 +511,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${maven.failsafe.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker.maven.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven.resources.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
You can now build the docker image for micro integrator by setting the system property `docker.skip` to false when running maven build.

 ```bash
mvn clean install -Ddocker.skip=false
```