### PR TITLE
cli: change build directory

### DIFF
--- a/cmd/build.sh
+++ b/cmd/build.sh
@@ -76,7 +76,7 @@ fi
 
 
 rootPath=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-buildDir="build/target"
+buildDir="build"
 buildPath="$rootPath/${buildDir}"
 
 echo "Cleaning build path ${buildDir}..."


### PR DESCRIPTION
Change cli build directory from `cmd/build/target` to `cmd/build` (to fix Jenkins build issue)