### PR TITLE
cli: change name of compressed archive

### DIFF
--- a/cmd/build.sh
+++ b/cmd/build.sh
@@ -125,7 +125,7 @@ do
 
     echo -en "\t - $goos/$goarch..."
 
-    zipfile="$filename-$build_version-$pos-$parch"
+    zipfile="wso2$filename-cli-$build_version-$pos-$parch"
     zipdir="${buildPath}/$filename"
     mkdir -p $zipdir
 


### PR DESCRIPTION
Change the name of the compressed archive from `mi` to `wso2mi-cli`.