### PR TITLE
cli: go fmt project

### DIFF
--- a/cmd/cmd/apiInfo.go
+++ b/cmd/cmd/apiInfo.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "fmt"
-    "github.com/olekukonko/tablewriter"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
-    "os"
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
 )
 
 var apiName string
@@ -34,64 +34,63 @@ const showAPICmdShortDesc = "Get information about APIs"
 
 var showAPICmdLongDesc = "Get information about the API specified by command line argument [api-name] If not specified, list all the apis\n"
 
-var showAPICmdExamples = 
-"Example:\n" + 
-"To get details about a specific api\n" +
-"  " + programName + " " + showCmdLiteral + " " + showAPICmdLiteral + " TestAPI\n\n" +
-"To list all the apis\n" +
-"  " + programName + " " + showCmdLiteral + " " + showAPICmdLiteral + "\n\n"
+var showAPICmdExamples = "Example:\n" +
+	"To get details about a specific api\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showAPICmdLiteral + " TestAPI\n\n" +
+	"To list all the apis\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showAPICmdLiteral + "\n\n"
 
 // apiShowCmd represents the show api command
 var apiShowCmd = &cobra.Command{
-    Use:   showAPICmdLiteral,
-    Short: showAPICmdShortDesc,
-    Long:  showAPICmdLongDesc + showAPICmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        handleAPICmdArguments(args)
-    },
+	Use:   showAPICmdLiteral,
+	Short: showAPICmdShortDesc,
+	Long:  showAPICmdLongDesc + showAPICmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		handleAPICmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(apiShowCmd)
-    apiShowCmd.SetHelpTemplate(showAPICmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showAPICmdLiteral, "[api-name]") + showAPICmdExamples + utils.GetCmdFlags("api(s)"))
+	showCmd.AddCommand(apiShowCmd)
+	apiShowCmd.SetHelpTemplate(showAPICmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showAPICmdLiteral, "[api-name]") + showAPICmdExamples + utils.GetCmdFlags("api(s)"))
 }
 
 func handleAPICmdArguments(args []string) {
-    utils.Logln(utils.LogPrefixInfo + "Show API called")
-    if len(args) == 0 {
-        executeListAPIsCmd()
-    } else if len(args) == 1 {
-        if args[0] == "help" {
-            printAPIHelp()
-        } else {
-            apiName = args[0]
-            executeGetAPICmd(apiName)
-        }
-    } else {
-        fmt.Println("Too many arguments. See the usage below")
-        printAPIHelp()
-    }
+	utils.Logln(utils.LogPrefixInfo + "Show API called")
+	if len(args) == 0 {
+		executeListAPIsCmd()
+	} else if len(args) == 1 {
+		if args[0] == "help" {
+			printAPIHelp()
+		} else {
+			apiName = args[0]
+			executeGetAPICmd(apiName)
+		}
+	} else {
+		fmt.Println("Too many arguments. See the usage below")
+		printAPIHelp()
+	}
 }
 
 func printAPIHelp() {
-    fmt.Print(showAPICmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showAPICmdLiteral, 
-        "[api-name]") + showAPICmdExamples + utils.GetCmdFlags("api(s)"))
+	fmt.Print(showAPICmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showAPICmdLiteral,
+		"[api-name]") + showAPICmdExamples + utils.GetCmdFlags("api(s)"))
 }
 
 func executeGetAPICmd(apiname string) {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixAPIs + "?apiName=" + apiname
+	finalUrl := utils.RESTAPIBase + utils.PrefixAPIs + "?apiName=" + apiname
 
-    resp, err := utils.UnmarshalData(finalUrl, &utils.API{})
+	resp, err := utils.UnmarshalData(finalUrl, &utils.API{})
 
-    if err == nil {
-        // Printing the details of the API
-        api := resp.(*utils.API)
-        printAPIInfo(*api)
-    } else {
-        fmt.Println(utils.LogPrefixError+"Getting Information of the API", err)
-    }
+	if err == nil {
+		// Printing the details of the API
+		api := resp.(*utils.API)
+		printAPIInfo(*api)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Getting Information of the API", err)
+	}
 }
 
 // Print the details of an API
@@ -99,72 +98,72 @@ func executeGetAPICmd(apiname string) {
 // @param app : API object
 func printAPIInfo(api utils.API) {
 
-    fmt.Println("Name - " + api.Name)
-    // fmt.Println("Host - " + api.Host)
-    // fmt.Println("Port - " + api.Port)
-    fmt.Println("Version - " + api.Version)
-    fmt.Println("Url - " + api.Context)
-    fmt.Println("Stats - " + api.Stats)
-    fmt.Println("Tracing - " + api.Tracing)
-    fmt.Println("Resources : ")
+	fmt.Println("Name - " + api.Name)
+	// fmt.Println("Host - " + api.Host)
+	// fmt.Println("Port - " + api.Port)
+	fmt.Println("Version - " + api.Version)
+	fmt.Println("Url - " + api.Context)
+	fmt.Println("Stats - " + api.Stats)
+	fmt.Println("Tracing - " + api.Tracing)
+	fmt.Println("Resources : ")
 
-    table := tablewriter.NewWriter(os.Stdout)
-    table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-    data := []string{"URL", "METHOD"}
-    table.Append(data)
+	data := []string{"URL", "METHOD"}
+	table.Append(data)
 
-    for _, resource := range api.Resources {
+	for _, resource := range api.Resources {
 
-        var methodSring string
+		var methodSring string
 
-        for i, method := range resource.Methods {
-            if i > 0 {
-                methodSring += "/"    
-            }
-            methodSring += method
-        }
-        data = []string{resource.Url, methodSring}
-        table.Append(data)
-    }
-    table.SetBorder(false)
-    table.SetColumnSeparator(" ")
-    table.SetAutoMergeCells(true)
-    table.Render()
+		for i, method := range resource.Methods {
+			if i > 0 {
+				methodSring += "/"
+			}
+			methodSring += method
+		}
+		data = []string{resource.Url, methodSring}
+		table.Append(data)
+	}
+	table.SetBorder(false)
+	table.SetColumnSeparator(" ")
+	table.SetAutoMergeCells(true)
+	table.Render()
 }
 
 func executeListAPIsCmd() {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixAPIs
+	finalUrl := utils.RESTAPIBase + utils.PrefixAPIs
 
-    resp, err := utils.GetArtifactList(finalUrl, &utils.APIList{})
+	resp, err := utils.GetArtifactList(finalUrl, &utils.APIList{})
 
-    if err == nil {
-        // Printing the list of available APIs
-        list := resp.(*utils.APIList)
-        printApiList(*list)        
-    } else {
-        utils.Logln(utils.LogPrefixError+"Getting List of APIs", err)
-    }
+	if err == nil {
+		// Printing the list of available APIs
+		list := resp.(*utils.APIList)
+		printApiList(*list)
+	} else {
+		utils.Logln(utils.LogPrefixError+"Getting List of APIs", err)
+	}
 }
 
 func printApiList(apiList utils.APIList) {
 
-    if apiList.Count > 0 {
-        table := tablewriter.NewWriter(os.Stdout)
-        table.SetAlignment(tablewriter.ALIGN_LEFT)
+	if apiList.Count > 0 {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-        data := []string{"NAME", "URL"}
-        table.Append(data)
+		data := []string{"NAME", "URL"}
+		table.Append(data)
 
-        for _, api := range apiList.Apis {
-            data = []string{api.Name, api.Context}
-            table.Append(data)
-        }
-        table.SetBorder(false)
-        table.SetColumnSeparator("  ")
-        table.Render()
-    } else {
-        fmt.Println("No APIs found")
-    }    
+		for _, api := range apiList.Apis {
+			data = []string{api.Name, api.Context}
+			table.Append(data)
+		}
+		table.SetBorder(false)
+		table.SetColumnSeparator("  ")
+		table.Render()
+	} else {
+		fmt.Println("No APIs found")
+	}
 }

--- a/cmd/cmd/apiList.go
+++ b/cmd/cmd/apiList.go
@@ -19,8 +19,8 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 // List APIs command related usage info
@@ -28,17 +28,17 @@ const listAPICmdLiteral = "apis"
 
 // apisListCmd represents the list apis command
 var apisListCmd = &cobra.Command{
-    Use:   listAPICmdLiteral,
-    Short: showAPICmdShortDesc,
-    Long:  showAPICmdLongDesc + showAPICmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        // defined in apiInfo.go
-        handleAPICmdArguments(args)
-    },
+	Use:   listAPICmdLiteral,
+	Short: showAPICmdShortDesc,
+	Long:  showAPICmdLongDesc + showAPICmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		// defined in apiInfo.go
+		handleAPICmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(apisListCmd)
-    apisListCmd.SetHelpTemplate(showAPICmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showAPICmdLiteral, "[apiname]") + showAPICmdExamples + utils.GetCmdFlags("api(s)"))
+	showCmd.AddCommand(apisListCmd)
+	apisListCmd.SetHelpTemplate(showAPICmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showAPICmdLiteral, "[apiname]") + showAPICmdExamples + utils.GetCmdFlags("api(s)"))
 }

--- a/cmd/cmd/carbonAppInfo.go
+++ b/cmd/cmd/carbonAppInfo.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "fmt"
-    "github.com/olekukonko/tablewriter"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
-    "os"
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
 )
 
 var appName string
@@ -34,65 +34,63 @@ const showApplicationCmdShortDesc = "Get information about Carbon Applications"
 
 var showApplicationCmdLongDesc = "Get information about the Carbon App specified by command line argument [app-name] If not specified, list all the carbon apps\n"
 
-var showApplicationCmdExamples = 
-"Example:\n" + 
-"To get details about a carbon app\n" +
-"  " + programName + " " + showCmdLiteral + " " + showApplicationCmdLiteral + " SampleApp\n\n" +
-"To list all the carbon apps\n" +
-"  " + programName + " " + showCmdLiteral + " " + showApplicationCmdLiteral + "\n\n"
-
+var showApplicationCmdExamples = "Example:\n" +
+	"To get details about a carbon app\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showApplicationCmdLiteral + " SampleApp\n\n" +
+	"To list all the carbon apps\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showApplicationCmdLiteral + "\n\n"
 
 // carbonAppShowCmd represents the show carbonApp command
 var carbonAppShowCmd = &cobra.Command{
-    Use:   showApplicationCmdLiteral,
-    Short: showApplicationCmdShortDesc,
-    Long:  showApplicationCmdLongDesc + showApplicationCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        handleApplicationCmdArguments(args)
-    },
+	Use:   showApplicationCmdLiteral,
+	Short: showApplicationCmdShortDesc,
+	Long:  showApplicationCmdLongDesc + showApplicationCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		handleApplicationCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(carbonAppShowCmd)
-    carbonAppShowCmd.SetHelpTemplate(showApplicationCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showApplicationCmdLiteral, "[app-name]") + showApplicationCmdExamples + utils.GetCmdFlags("carbonapp(s)"))
+	showCmd.AddCommand(carbonAppShowCmd)
+	carbonAppShowCmd.SetHelpTemplate(showApplicationCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showApplicationCmdLiteral, "[app-name]") + showApplicationCmdExamples + utils.GetCmdFlags("carbonapp(s)"))
 }
 
 func handleApplicationCmdArguments(args []string) {
-    utils.Logln(utils.LogPrefixInfo + "Show Carbon app called")
-    if len(args) == 0 {
-        executeListCarbonAppsCmd()
-    } else if len(args) == 1 {
-        if args[0] == "help" {
-            printAppHelp()
-        } else {
-            appName = args[0]
-            executeGetCarbonAppCmd(appName)
-        }
-    } else {
-        fmt.Println("Too many arguments. See the usage below")
-        printAppHelp()
-    }
+	utils.Logln(utils.LogPrefixInfo + "Show Carbon app called")
+	if len(args) == 0 {
+		executeListCarbonAppsCmd()
+	} else if len(args) == 1 {
+		if args[0] == "help" {
+			printAppHelp()
+		} else {
+			appName = args[0]
+			executeGetCarbonAppCmd(appName)
+		}
+	} else {
+		fmt.Println("Too many arguments. See the usage below")
+		printAppHelp()
+	}
 }
 
 func printAppHelp() {
-    fmt.Print(showApplicationCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showApplicationCmdLiteral, 
-        "[app-name]") + showApplicationCmdExamples + utils.GetCmdFlags("carbonapp(s)"))
+	fmt.Print(showApplicationCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showApplicationCmdLiteral,
+		"[app-name]") + showApplicationCmdExamples + utils.GetCmdFlags("carbonapp(s)"))
 }
 
 func executeGetCarbonAppCmd(appname string) {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixCarbonApps + "?carbonAppName=" + appname
+	finalUrl := utils.RESTAPIBase + utils.PrefixCarbonApps + "?carbonAppName=" + appname
 
-    resp, err := utils.UnmarshalData(finalUrl, &utils.CarbonApp{})
+	resp, err := utils.UnmarshalData(finalUrl, &utils.CarbonApp{})
 
-    if err == nil {
-        // Printing the details of the Carbon App
-        app := resp.(*utils.CarbonApp)
-        printCarbonAppInfo(*app)
-    } else {
-        fmt.Println(utils.LogPrefixError+"Getting Information of the Carbon App", err)
-    }
+	if err == nil {
+		// Printing the details of the Carbon App
+		app := resp.(*utils.CarbonApp)
+		printCarbonAppInfo(*app)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Getting Information of the Carbon App", err)
+	}
 }
 
 // Print the details of a Carbon app
@@ -100,57 +98,57 @@ func executeGetCarbonAppCmd(appname string) {
 // @param app : CarbonApp object
 func printCarbonAppInfo(app utils.CarbonApp) {
 
-    fmt.Println("Name - " + app.Name)
-    fmt.Println("Version - " + app.Version)
-    fmt.Println("Artifacts :")
+	fmt.Println("Name - " + app.Name)
+	fmt.Println("Version - " + app.Version)
+	fmt.Println("Artifacts :")
 
-    table := tablewriter.NewWriter(os.Stdout)
-    table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-    data := []string{"NAME", "TYPE"}
-    table.Append(data)
+	data := []string{"NAME", "TYPE"}
+	table.Append(data)
 
-    for _, artifact := range app.Artifacts {
-        data = []string{artifact.Name, artifact.Type}
-        table.Append(data)
-    }
-    table.SetBorder(false)
-    table.SetColumnSeparator(" ")
-    table.Render() // Send output
+	for _, artifact := range app.Artifacts {
+		data = []string{artifact.Name, artifact.Type}
+		table.Append(data)
+	}
+	table.SetBorder(false)
+	table.SetColumnSeparator(" ")
+	table.Render() // Send output
 }
 
 func executeListCarbonAppsCmd() {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixCarbonApps
+	finalUrl := utils.RESTAPIBase + utils.PrefixCarbonApps
 
-    resp, err := utils.GetArtifactList(finalUrl, &utils.CarbonAppList{})
+	resp, err := utils.GetArtifactList(finalUrl, &utils.CarbonAppList{})
 
-    if err == nil {
-        // Printing the list of available Carbon apps
-        list := resp.(*utils.CarbonAppList)
-        printAppList(*list)        
-    } else {
-        utils.Logln(utils.LogPrefixError+"Getting List of Carbon apps", err)
-    }
+	if err == nil {
+		// Printing the list of available Carbon apps
+		list := resp.(*utils.CarbonAppList)
+		printAppList(*list)
+	} else {
+		utils.Logln(utils.LogPrefixError+"Getting List of Carbon apps", err)
+	}
 }
 
 func printAppList(appList utils.CarbonAppList) {
 
-    if appList.Count > 0 {
-        table := tablewriter.NewWriter(os.Stdout)
-        table.SetAlignment(tablewriter.ALIGN_LEFT)
+	if appList.Count > 0 {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-        data := []string{"NAME", "VERSION"}
-        table.Append(data)
+		data := []string{"NAME", "VERSION"}
+		table.Append(data)
 
-        for _, app := range appList.CarbonApps {
-            data = []string{app.Name, app.Version}
-            table.Append(data)
-        }
-        table.SetBorder(false)
-        table.SetColumnSeparator("  ")
-        table.Render()
-    } else {
-        fmt.Println("No Carbon Apps found")
-    }    
+		for _, app := range appList.CarbonApps {
+			data = []string{app.Name, app.Version}
+			table.Append(data)
+		}
+		table.SetBorder(false)
+		table.SetColumnSeparator("  ")
+		table.Render()
+	} else {
+		fmt.Println("No Carbon Apps found")
+	}
 }

--- a/cmd/cmd/carbonAppList.go
+++ b/cmd/cmd/carbonAppList.go
@@ -19,8 +19,8 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 // List Carbon App command related usage info
@@ -28,17 +28,17 @@ const listApplicationCmdLiteral = "carbonapps"
 
 // carbonAppsListCmd represents the list carbonApps command
 var carbonAppsListCmd = &cobra.Command{
-    Use:   listApplicationCmdLiteral,
-    Short: showAPICmdShortDesc,
-    Long:  showAPICmdLongDesc + showAPICmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        // defined in carbonAppInfo.go
-        handleApplicationCmdArguments(args)
-    },
+	Use:   listApplicationCmdLiteral,
+	Short: showAPICmdShortDesc,
+	Long:  showAPICmdLongDesc + showAPICmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		// defined in carbonAppInfo.go
+		handleApplicationCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(carbonAppsListCmd)
-    carbonAppsListCmd.SetHelpTemplate(showApplicationCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showApplicationCmdLiteral, "[app-name]") + showApplicationCmdExamples + utils.GetCmdFlags("carbonapp(s)"))
+	showCmd.AddCommand(carbonAppsListCmd)
+	carbonAppsListCmd.SetHelpTemplate(showApplicationCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showApplicationCmdLiteral, "[app-name]") + showApplicationCmdExamples + utils.GetCmdFlags("carbonapp(s)"))
 }

--- a/cmd/cmd/completion.go
+++ b/cmd/cmd/completion.go
@@ -19,19 +19,19 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-    Use:   "completion",
+	Use:   "completion",
 	Short: "Generates bash completion scripts",
-    Long: `This command will generate a bash completion script`,
-    Run: func(cmd *cobra.Command, args []string) {
-        rootCmd.GenBashCompletionFile("mi_bash_completion.sh")
-    },
+	Long:  `This command will generate a bash completion script`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.GenBashCompletionFile("mi_bash_completion.sh")
+	},
 }
 
 func init() {
-    rootCmd.AddCommand(completionCmd)
+	rootCmd.AddCommand(completionCmd)
 }

--- a/cmd/cmd/endpointInfo.go
+++ b/cmd/cmd/endpointInfo.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "fmt"
-    "github.com/olekukonko/tablewriter"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
-    "os"
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
 )
 
 var endpointName string
@@ -34,64 +34,63 @@ const showEndpointCmdShortDesc = "Get information about endpoints"
 
 var showEndpointCmdLongDesc = "Get information about the endpoint specified by command line argument [endpoint-name] If not specified, list all the endpoints\n"
 
-var showEndpointCmdExamples = 
-"Example:\n" +
-"To get details about a specific endpoint\n" +
-"  " + programName + " " + showCmdLiteral + " " + showEndpointCmdLiteral + " TestEndpoint\n\n" +
-"To list all the endpoints\n" +
-"  " + programName + " " + showCmdLiteral + " " + showEndpointCmdLiteral + "\n\n"
+var showEndpointCmdExamples = "Example:\n" +
+	"To get details about a specific endpoint\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showEndpointCmdLiteral + " TestEndpoint\n\n" +
+	"To list all the endpoints\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showEndpointCmdLiteral + "\n\n"
 
 // endpointShowCmd represents the show endpoint command
 var endpointShowCmd = &cobra.Command{
-    Use:   showEndpointCmdLiteral,
-    Short: showEndpointCmdShortDesc,
-    Long:  showEndpointCmdLongDesc + showEndpointCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        handleEndpointCmdArguments(args)
-    },
+	Use:   showEndpointCmdLiteral,
+	Short: showEndpointCmdShortDesc,
+	Long:  showEndpointCmdLongDesc + showEndpointCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		handleEndpointCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(endpointShowCmd)
-    endpointShowCmd.SetHelpTemplate(showEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showEndpointCmdLiteral, "[endpoint-name]") + showEndpointCmdExamples + utils.GetCmdFlags("endpoint(s)"))
+	showCmd.AddCommand(endpointShowCmd)
+	endpointShowCmd.SetHelpTemplate(showEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showEndpointCmdLiteral, "[endpoint-name]") + showEndpointCmdExamples + utils.GetCmdFlags("endpoint(s)"))
 }
 
 func handleEndpointCmdArguments(args []string) {
-    utils.Logln(utils.LogPrefixInfo + "Show Endpoint called")
-    if len(args) == 0 {
-        executeListEndpointsCmd()
-    } else if len(args) == 1 {
-        if args[0] == "help" {
-            printEndpointHelp()
-        } else {
-            endpointName = args[0]
-            executeGetEndpointCmd(endpointName)
-        }
-    } else {
-        fmt.Println("Too many arguments. See the usage below")
-        printEndpointHelp()
-    }
+	utils.Logln(utils.LogPrefixInfo + "Show Endpoint called")
+	if len(args) == 0 {
+		executeListEndpointsCmd()
+	} else if len(args) == 1 {
+		if args[0] == "help" {
+			printEndpointHelp()
+		} else {
+			endpointName = args[0]
+			executeGetEndpointCmd(endpointName)
+		}
+	} else {
+		fmt.Println("Too many arguments. See the usage below")
+		printEndpointHelp()
+	}
 }
 
 func printEndpointHelp() {
-    fmt.Print(showEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showEndpointCmdLiteral, 
-        "[endpoint-name]") + showEndpointCmdExamples + utils.GetCmdFlags("endpoint(s)"))
+	fmt.Print(showEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showEndpointCmdLiteral,
+		"[endpoint-name]") + showEndpointCmdExamples + utils.GetCmdFlags("endpoint(s)"))
 }
 
 func executeGetEndpointCmd(endpointname string) {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixEndpoints + "?endpointName=" + endpointname
+	finalUrl := utils.RESTAPIBase + utils.PrefixEndpoints + "?endpointName=" + endpointname
 
-    resp, err := utils.UnmarshalData(finalUrl, &utils.Endpoint{})
+	resp, err := utils.UnmarshalData(finalUrl, &utils.Endpoint{})
 
-    if err == nil {
-        // Printing the details of the Endpoint
-        endpoint := resp.(*utils.Endpoint)
-        printEndpoint(*endpoint)
-    } else {
-        fmt.Println(utils.LogPrefixError+"Getting Information of Endpoint", err)
-    }
+	if err == nil {
+		// Printing the details of the Endpoint
+		endpoint := resp.(*utils.Endpoint)
+		printEndpoint(*endpoint)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Getting Information of Endpoint", err)
+	}
 }
 
 // Print the details of an Endpoint
@@ -99,45 +98,45 @@ func executeGetEndpointCmd(endpointname string) {
 // @param Endpoint : Endpoint object
 func printEndpoint(endpoint utils.Endpoint) {
 
-    fmt.Println("Name - " + endpoint.Name)
-    fmt.Println("Type - " + endpoint.Type)
-    fmt.Println("Method - " + endpoint.Method)
-    fmt.Println("Url - " + endpoint.Url)
-    fmt.Println("Stats - " + endpoint.Stats)
+	fmt.Println("Name - " + endpoint.Name)
+	fmt.Println("Type - " + endpoint.Type)
+	fmt.Println("Method - " + endpoint.Method)
+	fmt.Println("Url - " + endpoint.Url)
+	fmt.Println("Stats - " + endpoint.Stats)
 }
 
 func executeListEndpointsCmd() {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixEndpoints
+	finalUrl := utils.RESTAPIBase + utils.PrefixEndpoints
 
-    resp, err := utils.GetArtifactList(finalUrl, &utils.EndpointList{})
+	resp, err := utils.GetArtifactList(finalUrl, &utils.EndpointList{})
 
-    if err == nil {
-        // Printing the list of available Endpoints
-        list := resp.(*utils.EndpointList)
-        printEndpointsist(*list)        
-    } else {
-        utils.Logln(utils.LogPrefixError+"Getting List of Endpoints", err)
-    }
+	if err == nil {
+		// Printing the list of available Endpoints
+		list := resp.(*utils.EndpointList)
+		printEndpointsist(*list)
+	} else {
+		utils.Logln(utils.LogPrefixError+"Getting List of Endpoints", err)
+	}
 }
 
 func printEndpointsist(endpointList utils.EndpointList) {
 
-    if endpointList.Count > 0 {
-        table := tablewriter.NewWriter(os.Stdout)
-        table.SetAlignment(tablewriter.ALIGN_LEFT)
+	if endpointList.Count > 0 {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-        data := []string{"NAME", "TYPE", "METHOD", "URL"}
-        table.Append(data)
+		data := []string{"NAME", "TYPE", "METHOD", "URL"}
+		table.Append(data)
 
-        for _, endpoint := range endpointList.Endpoints {
-            data = []string{endpoint.Name, endpoint.Type, endpoint.Method, endpoint.Url}
-            table.Append(data)
-        }
-        table.SetBorder(false)
-        table.SetColumnSeparator("  ")
-        table.Render()
-    } else {
-        fmt.Println("No Endpoints found")
-    }    
+		for _, endpoint := range endpointList.Endpoints {
+			data = []string{endpoint.Name, endpoint.Type, endpoint.Method, endpoint.Url}
+			table.Append(data)
+		}
+		table.SetBorder(false)
+		table.SetColumnSeparator("  ")
+		table.Render()
+	} else {
+		fmt.Println("No Endpoints found")
+	}
 }

--- a/cmd/cmd/endpointList.go
+++ b/cmd/cmd/endpointList.go
@@ -19,8 +19,8 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 // List Endpoints command related usage info
@@ -28,17 +28,17 @@ const listEndpointsCmdLiteral = "endpoints"
 
 // endpointsListCmd represents the list endpoints command
 var endpointsListCmd = &cobra.Command{
-    Use:   listEndpointsCmdLiteral,
-    Short: showEndpointCmdShortDesc,
-    Long:  showEndpointCmdLongDesc + showEndpointCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        // defined in endpointInfo.go
-        handleEndpointCmdArguments(args)
-    },
+	Use:   listEndpointsCmdLiteral,
+	Short: showEndpointCmdShortDesc,
+	Long:  showEndpointCmdLongDesc + showEndpointCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		// defined in endpointInfo.go
+		handleEndpointCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(endpointsListCmd)
-    endpointsListCmd.SetHelpTemplate(showEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showEndpointCmdLiteral, "[endpointname]") + showEndpointCmdExamples + utils.GetCmdFlags("endpoint(s)"))
+	showCmd.AddCommand(endpointsListCmd)
+	endpointsListCmd.SetHelpTemplate(showEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showEndpointCmdLiteral, "[endpointname]") + showEndpointCmdExamples + utils.GetCmdFlags("endpoint(s)"))
 }

--- a/cmd/cmd/inboundEndpointInfo.go
+++ b/cmd/cmd/inboundEndpointInfo.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "fmt"
-    "github.com/olekukonko/tablewriter"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
-    "os"
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
 )
 
 var inboundEndpointName string
@@ -34,64 +34,63 @@ const showInboundEndpointCmdShortDesc = "Get information about inbound endpoints
 
 var showInboundEndpointCmdLongDesc = "Get information about the InboundEndpoint specified by command line argument [inbound-name] If not specified, list all the Inbound Endpoints\n"
 
-var showInboundEndpointCmdExamples = 
-"Example:\n" +
-"To get details about a specific inbound endpoint\n" +
-"  " + utils.ProjectName + " " + showCmdLiteral + " " + showInboundEndpointCmdLiteral + " TestInboundEndpoint\n\n" +
-"To list all the inbound endpoints\n" +
-"  " + utils.ProjectName + " " + showCmdLiteral + " " + showInboundEndpointCmdLiteral + "\n\n"
+var showInboundEndpointCmdExamples = "Example:\n" +
+	"To get details about a specific inbound endpoint\n" +
+	"  " + utils.ProjectName + " " + showCmdLiteral + " " + showInboundEndpointCmdLiteral + " TestInboundEndpoint\n\n" +
+	"To list all the inbound endpoints\n" +
+	"  " + utils.ProjectName + " " + showCmdLiteral + " " + showInboundEndpointCmdLiteral + "\n\n"
 
 // InboundEndpointShowCmd represents the Show inboundEndpoint command
 var inboundEndpointShowCmd = &cobra.Command{
-    Use:   showInboundEndpointCmdLiteral,
-    Short: showInboundEndpointCmdShortDesc,
-    Long:  showInboundEndpointCmdLongDesc + showInboundEndpointCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        handleInboundCmdArguments(args)
-    },
+	Use:   showInboundEndpointCmdLiteral,
+	Short: showInboundEndpointCmdShortDesc,
+	Long:  showInboundEndpointCmdLongDesc + showInboundEndpointCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		handleInboundCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(inboundEndpointShowCmd)
-    inboundEndpointShowCmd.SetHelpTemplate(showInboundEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showInboundEndpointCmdLiteral, "[inbound-name]") + showInboundEndpointCmdExamples + utils.GetCmdFlags("inboundendpoint(s)"))
+	showCmd.AddCommand(inboundEndpointShowCmd)
+	inboundEndpointShowCmd.SetHelpTemplate(showInboundEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showInboundEndpointCmdLiteral, "[inbound-name]") + showInboundEndpointCmdExamples + utils.GetCmdFlags("inboundendpoint(s)"))
 }
 
 func handleInboundCmdArguments(args []string) {
-    utils.Logln(utils.LogPrefixInfo + "Show InboundEndpoint called")
-    if len(args) == 0 {
-        executeListInboundEndpointsCmd()
-    } else if len(args) == 1 {
-        if args[0] == "help" {
-            printInboundHelp()
-        } else {
-            inboundEndpointName = args[0]
-            executeGetInboundEndpointCmd(inboundEndpointName)
-        }
-    } else {
-        fmt.Println("Too many arguments. See usage below")
-        printInboundHelp()
-    }
+	utils.Logln(utils.LogPrefixInfo + "Show InboundEndpoint called")
+	if len(args) == 0 {
+		executeListInboundEndpointsCmd()
+	} else if len(args) == 1 {
+		if args[0] == "help" {
+			printInboundHelp()
+		} else {
+			inboundEndpointName = args[0]
+			executeGetInboundEndpointCmd(inboundEndpointName)
+		}
+	} else {
+		fmt.Println("Too many arguments. See usage below")
+		printInboundHelp()
+	}
 }
 
 func printInboundHelp() {
-    fmt.Print(showInboundEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showInboundEndpointCmdLiteral,
-        "[inbound-name]") + showInboundEndpointCmdExamples + utils.GetCmdFlags("inboundendpoint(s)"))
+	fmt.Print(showInboundEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showInboundEndpointCmdLiteral,
+		"[inbound-name]") + showInboundEndpointCmdExamples + utils.GetCmdFlags("inboundendpoint(s)"))
 }
 
 func executeGetInboundEndpointCmd(inboundEndpointname string) {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixInboundEndpoints + "?inboundEndpointName=" + inboundEndpointname
+	finalUrl := utils.RESTAPIBase + utils.PrefixInboundEndpoints + "?inboundEndpointName=" + inboundEndpointname
 
-    resp, err := utils.UnmarshalData(finalUrl, &utils.InboundEndpoint{})
+	resp, err := utils.UnmarshalData(finalUrl, &utils.InboundEndpoint{})
 
-    if err == nil {
-        // Printing the details of the InboundEndpoint
-        inboundEndpoint := resp.(*utils.InboundEndpoint)
-        printInboundEndpoint(*inboundEndpoint)
-    } else {
-        fmt.Println(utils.LogPrefixError+"Getting Information of InboundEndpoint", err)
-    }
+	if err == nil {
+		// Printing the details of the InboundEndpoint
+		inboundEndpoint := resp.(*utils.InboundEndpoint)
+		printInboundEndpoint(*inboundEndpoint)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Getting Information of InboundEndpoint", err)
+	}
 }
 
 // Print the details of an Inbound endpoint
@@ -99,59 +98,59 @@ func executeGetInboundEndpointCmd(inboundEndpointname string) {
 // @param InboundEndpoint : InboundEndpoint object
 func printInboundEndpoint(inbound utils.InboundEndpoint) {
 
-    fmt.Println("Name - " + inbound.Name)
-    fmt.Println("Type - " + inbound.Type)
-    fmt.Println("Stats - " + inbound.Stats)
-    fmt.Println("Tracing - " + inbound.Tracing)
-    fmt.Println("Parameters : ")
+	fmt.Println("Name - " + inbound.Name)
+	fmt.Println("Type - " + inbound.Type)
+	fmt.Println("Stats - " + inbound.Stats)
+	fmt.Println("Tracing - " + inbound.Tracing)
+	fmt.Println("Parameters : ")
 
-    table := tablewriter.NewWriter(os.Stdout)
-    table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-    data := []string{"NAME", "VALUE"}
-    table.Append(data)
+	data := []string{"NAME", "VALUE"}
+	table.Append(data)
 
-    for _, param := range inbound.Parameters {
-        data = []string{param.Name, param.Value}
-        table.Append(data)
-    }
-    table.SetBorder(false)
-    table.SetColumnSeparator(" ")
-    table.SetAutoMergeCells(true)
-    table.Render()
+	for _, param := range inbound.Parameters {
+		data = []string{param.Name, param.Value}
+		table.Append(data)
+	}
+	table.SetBorder(false)
+	table.SetColumnSeparator(" ")
+	table.SetAutoMergeCells(true)
+	table.Render()
 }
 
-func executeListInboundEndpointsCmd(){
-    finalUrl := utils.RESTAPIBase + utils.PrefixInboundEndpoints
+func executeListInboundEndpointsCmd() {
+	finalUrl := utils.RESTAPIBase + utils.PrefixInboundEndpoints
 
-    resp, err := utils.GetArtifactList(finalUrl, &utils.InboundEndpointList{})
+	resp, err := utils.GetArtifactList(finalUrl, &utils.InboundEndpointList{})
 
-    if err == nil {
-        // Printing the list of available Inbound endpoints
-        list := resp.(*utils.InboundEndpointList)
-        printInboundList(*list)        
-    } else {
-        utils.Logln(utils.LogPrefixError+"Getting List of Inbound Endpoints", err)
-    }
+	if err == nil {
+		// Printing the list of available Inbound endpoints
+		list := resp.(*utils.InboundEndpointList)
+		printInboundList(*list)
+	} else {
+		utils.Logln(utils.LogPrefixError+"Getting List of Inbound Endpoints", err)
+	}
 }
 
 func printInboundList(inboundList utils.InboundEndpointList) {
 
-    if inboundList.Count > 0 {
-        table := tablewriter.NewWriter(os.Stdout)
-        table.SetAlignment(tablewriter.ALIGN_LEFT)
+	if inboundList.Count > 0 {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-        data := []string{"NAME", "TYPE"}
-        table.Append(data)
+		data := []string{"NAME", "TYPE"}
+		table.Append(data)
 
-        for _, api := range inboundList.InboundEndpoints {
-            data = []string{api.Name, api.Type}
-            table.Append(data)
-        }
-        table.SetBorder(false)
-        table.SetColumnSeparator("  ")
-        table.Render()
-    } else {
-        fmt.Println("No Inbound Endpoints found")
-    }
+		for _, api := range inboundList.InboundEndpoints {
+			data = []string{api.Name, api.Type}
+			table.Append(data)
+		}
+		table.SetBorder(false)
+		table.SetColumnSeparator("  ")
+		table.Render()
+	} else {
+		fmt.Println("No Inbound Endpoints found")
+	}
 }

--- a/cmd/cmd/inboundEndpointList.go
+++ b/cmd/cmd/inboundEndpointList.go
@@ -19,8 +19,8 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 // List Inbound Endpoints command related usage info
@@ -28,17 +28,17 @@ const listInboundEndpointsCmdLiteral = "inboundendpoints"
 
 // inboundEndpointsListCmd represents the list inboundEndpoints command
 var inboundEndpointsListCmd = &cobra.Command{
-    Use:   listInboundEndpointsCmdLiteral,
-    Short: showInboundEndpointCmdShortDesc,
-    Long:  showInboundEndpointCmdLongDesc + showInboundEndpointCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        // defined in inboundEndpointInfo.go
-        handleInboundCmdArguments(args)
-    },
+	Use:   listInboundEndpointsCmdLiteral,
+	Short: showInboundEndpointCmdShortDesc,
+	Long:  showInboundEndpointCmdLongDesc + showInboundEndpointCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		// defined in inboundEndpointInfo.go
+		handleInboundCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(inboundEndpointsListCmd)
-    inboundEndpointsListCmd.SetHelpTemplate(showInboundEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showInboundEndpointCmdLiteral, "[inboundname]") + showInboundEndpointCmdExamples + utils.GetCmdFlags("inboundendpoint(s)"))
+	showCmd.AddCommand(inboundEndpointsListCmd)
+	inboundEndpointsListCmd.SetHelpTemplate(showInboundEndpointCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showInboundEndpointCmdLiteral, "[inboundname]") + showInboundEndpointCmdExamples + utils.GetCmdFlags("inboundendpoint(s)"))
 }

--- a/cmd/cmd/init.go
+++ b/cmd/cmd/init.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "os"
-    "fmt"
-    "strconv"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
+	"strconv"
 )
 
 // Init command related usage info
@@ -32,75 +32,73 @@ const initCmdShortDesc = "Set Management API configuration"
 
 var initCmdLongDesc = "Set the Hostname and the Port of the Management API\n"
 
-var initCmdUsage = 
-"Usage:\n" +
-"  " + programName + " " + initCmdLiteral + "\n"
+var initCmdUsage = "Usage:\n" +
+	"  " + programName + " " + initCmdLiteral + "\n"
 
-var initCmdExample = 
-"Examples:\n" +
-"  " + programName + " " + initCmdLiteral + "\n" +
-"  " + "Enter following parameters to configure the cli\n" +
-"  " + "Host name(default localhost): abc.com\n" +
-"  " + "Port number(default " + utils.DefaultPort + "): 9595\n" +
-"  " + "CLI configuration is successful\n"
+var initCmdExample = "Examples:\n" +
+	"  " + programName + " " + initCmdLiteral + "\n" +
+	"  " + "Enter following parameters to configure the cli\n" +
+	"  " + "Host name(default localhost): abc.com\n" +
+	"  " + "Port number(default " + utils.DefaultPort + "): 9595\n" +
+	"  " + "CLI configuration is successful\n"
 
 // initCmd represents the init command
 var initCmd = &cobra.Command{
-    Use:   initCmdLiteral,
-    Short: initCmdShortDesc,
-    Long:  initCmdLongDesc,
-    Run: func(cmd *cobra.Command, args []string) {
-        utils.Logln(utils.LogPrefixInfo + "Init called")
-        if len(args) > 0 {
-            printInitHelp()
-        } else {
-            promptUserForConfig()
-        }
-    },
+	Use:   initCmdLiteral,
+	Short: initCmdShortDesc,
+	Long:  initCmdLongDesc,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + "Init called")
+		if len(args) > 0 {
+			printInitHelp()
+		} else {
+			promptUserForConfig()
+		}
+	},
 }
 
 func init() {
-    rootCmd.AddCommand(initCmd)
-    initCmd.SetHelpTemplate(initCmdLongDesc + initCmdUsage + initCmdExample + utils.GetCmdFlags("init"))
+	rootCmd.AddCommand(initCmd)
+	initCmd.SetHelpTemplate(initCmdLongDesc + initCmdUsage + initCmdExample + utils.GetCmdFlags("init"))
 }
 
 func printInitHelp() {
-    fmt.Print(initCmdLongDesc + initCmdUsage + initCmdExample + utils.GetCmdFlags("init"))
+	fmt.Print(initCmdLongDesc + initCmdUsage + initCmdExample + utils.GetCmdFlags("init"))
 }
 
 func promptUserForConfig() {
-    fmt.Println("Enter following parameters to configure the cli")
-    fmt.Print("Host name(default localhost): ")
-    var host string
-    fmt.Scanln(&host)
-    if len(host) == 0 {
-        fmt.Println("Host name is not specified, default value localhost is used")
-        host = utils.DefaultHost
-    }
-    fmt.Printf("Port number(default %s): ", utils.DefaultPort)
-    var strPort string
-    fmt.Scanln(&strPort)
-    if len(strPort) == 0 {
-        fmt.Printf("Port number is not specified, default value %s is used\n", utils.DefaultPort)
-        strPort = utils.DefaultPort
-    } else {
-        port, err := strconv.Atoi(strPort)
-        if err == nil {
-            if (port < 1000) || (port > 10000) {
-                fmt.Println("Port number is out of range. Please specify a port number between 1000 and 10000")
-                os.Exit(1)
-            }
-            strPort = strconv.Itoa(int(port))
-        } else {
-            fmt.Println("Port number is invalid. Please specify a port number between 1000 and 10000")
-            os.Exit(1)
-        }
-    }
-    writeConfig(utils.HTTPSProtocol + host, strPort)
+	fmt.Println("Enter following parameters to configure the cli")
+	fmt.Print("Host name(default localhost): ")
+	var host string
+	fmt.Scanln(&host)
+	if len(host) == 0 {
+		fmt.Println("Host name is not specified, default value localhost is used")
+		host = utils.DefaultHost
+	}
+	fmt.Printf("Port number(default %s): ", utils.DefaultPort)
+	var strPort string
+	fmt.Scanln(&strPort)
+	if len(strPort) == 0 {
+		fmt.Printf("Port number is not specified, default value %s is used\n", utils.DefaultPort)
+		strPort = utils.DefaultPort
+	} else {
+		port, err := strconv.Atoi(strPort)
+		if err == nil {
+			if (port < 1000) || (port > 10000) {
+				fmt.Println("Port number is out of range. Please specify a port number between 1000 and 10000")
+				os.Exit(1)
+			}
+			strPort = strconv.Itoa(int(port))
+		} else {
+			fmt.Println("Port number is invalid. Please specify a port number between 1000 and 10000")
+			os.Exit(1)
+		}
+	}
+	writeConfig(utils.HTTPSProtocol+host, strPort)
 }
 
-func writeConfig(url, port string){
-    serverConfig := utils.ServerConfig{Url:url, Port:port}
-    utils.WriteServerConfigFile(serverConfig, utils.ServerConfigFilePath)
-    fmt.Println("CLI configuration is successful")
+func writeConfig(url, port string) {
+	serverConfig := utils.ServerConfig{Url: url, Port: port}
+	utils.WriteServerConfigFile(serverConfig, utils.ServerConfigFilePath)
+	fmt.Println("CLI configuration is successful")
 }

--- a/cmd/cmd/proxyServiceInfo.go
+++ b/cmd/cmd/proxyServiceInfo.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "fmt"
-    "github.com/olekukonko/tablewriter"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
-    "os"
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
 )
 
 var proxyServiceName string
@@ -34,64 +34,63 @@ const showProxyServiceCmdShortDesc = "Get information about proxy services"
 
 var showProxyServiceCmdLongDesc = "Get information about the Proxy Service specified by command line argument [proxy-name] If not specified, list all the proxy services\n"
 
-var showProxyServiceCmdExamples = 
-"Example:\n" +
-"To get details about a specific prxoy\n" +
-"  " + programName + " " + showCmdLiteral + " " + showProxyServiceCmdLiteral + " SampleProxy\n\n" +
-"To list all the proxies\n" +
-"  " + programName + " " + showCmdLiteral + " " + showProxyServiceCmdLiteral + "\n\n"
+var showProxyServiceCmdExamples = "Example:\n" +
+	"To get details about a specific prxoy\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showProxyServiceCmdLiteral + " SampleProxy\n\n" +
+	"To list all the proxies\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showProxyServiceCmdLiteral + "\n\n"
 
 // proxyServiceShowCmd represents the proxyService command
 var proxyServiceShowCmd = &cobra.Command{
-    Use:   showProxyServiceCmdLiteral,
-    Short: showProxyServiceCmdShortDesc,
-    Long:  showProxyServiceCmdLongDesc + showProxyServiceCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        handleProxyServiceCmdArguments(args)
-    },
+	Use:   showProxyServiceCmdLiteral,
+	Short: showProxyServiceCmdShortDesc,
+	Long:  showProxyServiceCmdLongDesc + showProxyServiceCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		handleProxyServiceCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(proxyServiceShowCmd)
-    proxyServiceShowCmd.SetHelpTemplate(showProxyServiceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showProxyServiceCmdLiteral, "[proxy-name]") + showProxyServiceCmdExamples + utils.GetCmdFlags("proxyservice(s)"))
+	showCmd.AddCommand(proxyServiceShowCmd)
+	proxyServiceShowCmd.SetHelpTemplate(showProxyServiceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showProxyServiceCmdLiteral, "[proxy-name]") + showProxyServiceCmdExamples + utils.GetCmdFlags("proxyservice(s)"))
 }
 
 func handleProxyServiceCmdArguments(args []string) {
-    utils.Logln(utils.LogPrefixInfo + "Show ProxyService called")
-    if len(args) == 0 {
-        executeListProxyServicesCmd()
-    } else if len(args) == 1 {
-        if args[0] == "help" {
-            printProxyServiceHelp()
-        } else {
-            proxyServiceName = args[0]
-            executeGetProxyServiceCmd(proxyServiceName)
-        }
-    } else {
-        fmt.Println("Too many arguments. See the usage below")
-        printProxyServiceHelp()
-    }
+	utils.Logln(utils.LogPrefixInfo + "Show ProxyService called")
+	if len(args) == 0 {
+		executeListProxyServicesCmd()
+	} else if len(args) == 1 {
+		if args[0] == "help" {
+			printProxyServiceHelp()
+		} else {
+			proxyServiceName = args[0]
+			executeGetProxyServiceCmd(proxyServiceName)
+		}
+	} else {
+		fmt.Println("Too many arguments. See the usage below")
+		printProxyServiceHelp()
+	}
 }
 
 func printProxyServiceHelp() {
-    fmt.Print(showProxyServiceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showProxyServiceCmdLiteral, 
-        "[proxy-name]") + showProxyServiceCmdExamples + utils.GetCmdFlags("proxyservice(s)"))
+	fmt.Print(showProxyServiceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showProxyServiceCmdLiteral,
+		"[proxy-name]") + showProxyServiceCmdExamples + utils.GetCmdFlags("proxyservice(s)"))
 }
 
 func executeGetProxyServiceCmd(proxyServiceName string) {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixProxyServices + "?proxyServiceName=" + proxyServiceName
+	finalUrl := utils.RESTAPIBase + utils.PrefixProxyServices + "?proxyServiceName=" + proxyServiceName
 
-    resp, err := utils.UnmarshalData(finalUrl, &utils.Proxy{})
+	resp, err := utils.UnmarshalData(finalUrl, &utils.Proxy{})
 
-    if err == nil {
-        // Printing the details of the Proxy Service
-        proxyService := resp.(*utils.Proxy)
-        printProxyServiceInfo(*proxyService)
-    } else {
-        fmt.Println(utils.LogPrefixError+"Getting Information of ProxyService", err)
-    }
+	if err == nil {
+		// Printing the details of the Proxy Service
+		proxyService := resp.(*utils.Proxy)
+		printProxyServiceInfo(*proxyService)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Getting Information of ProxyService", err)
+	}
 }
 
 // Print the details of a Proxy service
@@ -99,45 +98,45 @@ func executeGetProxyServiceCmd(proxyServiceName string) {
 // @param ProxyService : ProxyService object
 func printProxyServiceInfo(proxyService utils.Proxy) {
 
-    fmt.Println("Name - " + proxyService.Name)
-    fmt.Println("WSDL 1.1 - " + proxyService.WSDL1_1)
-    fmt.Println("WSDL 2.0 - " + proxyService.WSDL2_0)
-    fmt.Println("Stats - " + proxyService.Stats)
-    fmt.Println("Tracing - " + proxyService.Tracing)
+	fmt.Println("Name - " + proxyService.Name)
+	fmt.Println("WSDL 1.1 - " + proxyService.WSDL1_1)
+	fmt.Println("WSDL 2.0 - " + proxyService.WSDL2_0)
+	fmt.Println("Stats - " + proxyService.Stats)
+	fmt.Println("Tracing - " + proxyService.Tracing)
 }
 
 func executeListProxyServicesCmd() {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixProxyServices
+	finalUrl := utils.RESTAPIBase + utils.PrefixProxyServices
 
-    resp, err := utils.GetArtifactList(finalUrl, &utils.ProxyServiceList{})
+	resp, err := utils.GetArtifactList(finalUrl, &utils.ProxyServiceList{})
 
-    if err == nil {
-        // Printing the list of available Endpoints
-        list := resp.(*utils.ProxyServiceList)
-        printProxyList(*list)        
-    } else {
-        utils.Logln(utils.LogPrefixError+"Getting List of Proxies", err)
-    }
+	if err == nil {
+		// Printing the list of available Endpoints
+		list := resp.(*utils.ProxyServiceList)
+		printProxyList(*list)
+	} else {
+		utils.Logln(utils.LogPrefixError+"Getting List of Proxies", err)
+	}
 }
 
 func printProxyList(proxyList utils.ProxyServiceList) {
 
-    if proxyList.Count > 0 {
-        table := tablewriter.NewWriter(os.Stdout)
-        table.SetAlignment(tablewriter.ALIGN_LEFT)
+	if proxyList.Count > 0 {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-        data := []string{"NAME", "WSDL 1.1", "WSDL 2.0"}
-        table.Append(data)
+		data := []string{"NAME", "WSDL 1.1", "WSDL 2.0"}
+		table.Append(data)
 
-        for _, proxy := range proxyList.Proxies {
-            data = []string{proxy.Name, proxy.WSDL1_1, proxy.WSDL2_0}
-            table.Append(data)
-        }
-        table.SetBorder(false)
-        table.SetColumnSeparator("  ")
-        table.Render()
-    } else {
-        fmt.Println("No proxies found")
-    }
+		for _, proxy := range proxyList.Proxies {
+			data = []string{proxy.Name, proxy.WSDL1_1, proxy.WSDL2_0}
+			table.Append(data)
+		}
+		table.SetBorder(false)
+		table.SetColumnSeparator("  ")
+		table.Render()
+	} else {
+		fmt.Println("No proxies found")
+	}
 }

--- a/cmd/cmd/proxyServiceList.go
+++ b/cmd/cmd/proxyServiceList.go
@@ -19,8 +19,8 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 // List Proxy Services command related usage info
@@ -28,17 +28,17 @@ const listProxyServicesCmdLiteral = "proxyservices"
 
 // proxyServicesListCmd represents the proxyServices command
 var proxyServicesListCmd = &cobra.Command{
-    Use:   listProxyServicesCmdLiteral,
-    Short: showProxyServiceCmdShortDesc,
-    Long:  showProxyServiceCmdLongDesc + showProxyServiceCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        // defined in proxyServiceInfo.go
-        handleProxyServiceCmdArguments(args)
-    },
+	Use:   listProxyServicesCmdLiteral,
+	Short: showProxyServiceCmdShortDesc,
+	Long:  showProxyServiceCmdLongDesc + showProxyServiceCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		// defined in proxyServiceInfo.go
+		handleProxyServiceCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(proxyServicesListCmd)
-    proxyServicesListCmd.SetHelpTemplate(showProxyServiceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showProxyServiceCmdLiteral, "[proxy-name]") + showProxyServiceCmdExamples + utils.GetCmdFlags("proxyservice(s)"))
+	showCmd.AddCommand(proxyServicesListCmd)
+	proxyServicesListCmd.SetHelpTemplate(showProxyServiceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showProxyServiceCmdLiteral, "[proxy-name]") + showProxyServiceCmdExamples + utils.GetCmdFlags("proxyservice(s)"))
 }

--- a/cmd/cmd/root.go
+++ b/cmd/cmd/root.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "github.com/lithammer/dedent"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
-    "os"
-    "time"
+	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
+	"time"
 )
 
 var cfgFile string
@@ -41,41 +41,41 @@ var rootCmdValidArgs = []string{"init", "show", "version", "help"}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-    Use:   utils.ProjectName,
-    Short: rootCmdShortDesc,
-    Long:  rootCmdLongDesc,
-    ValidArgs: rootCmdValidArgs,
+	Use:       utils.ProjectName,
+	Short:     rootCmdShortDesc,
+	Long:      rootCmdLongDesc,
+	ValidArgs: rootCmdValidArgs,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-    if err := rootCmd.Execute(); err != nil {
-        os.Exit(1)
-    }
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 func init() {
-    cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(initConfig)
 
-    rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose mode")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose mode")
 
-    // Init ServerConfigVars
-    err := utils.SetConfigVars(utils.ServerConfigFilePath)
-    if err != nil {
-        utils.HandleErrorAndExit("Error reading "+utils.ServerConfigFileName+".", err)
-    }
+	// Init ServerConfigVars
+	err := utils.SetConfigVars(utils.ServerConfigFilePath)
+	if err != nil {
+		utils.HandleErrorAndExit("Error reading "+utils.ServerConfigFileName+".", err)
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 
-    if verbose {
-        utils.IsVerbose = true
-        utils.EnableVerboseMode()
-        t := time.Now()
-        utils.Logf(utils.LogPrefixInfo+"Executed ManagementCLI (%s) on %v\n", utils.ProjectName, t.Format(time.RFC1123))
-    } else {
-        utils.IsVerbose = false
-    }
+	if verbose {
+		utils.IsVerbose = true
+		utils.EnableVerboseMode()
+		t := time.Now()
+		utils.Logf(utils.LogPrefixInfo+"Executed ManagementCLI (%s) on %v\n", utils.ProjectName, t.Format(time.RFC1123))
+	} else {
+		utils.IsVerbose = false
+	}
 }

--- a/cmd/cmd/sequenceInfo.go
+++ b/cmd/cmd/sequenceInfo.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "fmt"
-    "github.com/olekukonko/tablewriter"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
-    "os"
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
 )
 
 var sequenceName string
@@ -34,64 +34,63 @@ const showSequenceCmdShortDesc = "Get information about sequences"
 
 var showSequenceCmdLongDesc = "Get information about the Sequence specified by command line argument [sequence-name] If not specified, list all the sequences\n"
 
-var showSequenceCmdExamples = 
-"Example:\n" +
-"To get details about a specific sequence\n" +
-"  " + programName + " " + showCmdLiteral + " " + showSequenceCmdLiteral + " SampleSequence\n\n" +
-"To list all the sequences\n" +
-"  " + programName + " " + showCmdLiteral + " " + showSequenceCmdLiteral + "\n\n"
+var showSequenceCmdExamples = "Example:\n" +
+	"To get details about a specific sequence\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showSequenceCmdLiteral + " SampleSequence\n\n" +
+	"To list all the sequences\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showSequenceCmdLiteral + "\n\n"
 
 // sequenceShowCmd represents the show sequence command
 var sequenceShowCmd = &cobra.Command{
-    Use:   showSequenceCmdLiteral,
-    Short: showSequenceCmdShortDesc,
-    Long:  showSequenceCmdLongDesc + showSequenceCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        handleSequenceCmdArguments(args)
-    },
+	Use:   showSequenceCmdLiteral,
+	Short: showSequenceCmdShortDesc,
+	Long:  showSequenceCmdLongDesc + showSequenceCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		handleSequenceCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(sequenceShowCmd)
-    sequenceShowCmd.SetHelpTemplate(showSequenceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showSequenceCmdLiteral, "[sequence-name]") + showSequenceCmdExamples + utils.GetCmdFlags("sequence(s)"))
+	showCmd.AddCommand(sequenceShowCmd)
+	sequenceShowCmd.SetHelpTemplate(showSequenceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showSequenceCmdLiteral, "[sequence-name]") + showSequenceCmdExamples + utils.GetCmdFlags("sequence(s)"))
 }
 
 func handleSequenceCmdArguments(args []string) {
-    utils.Logln(utils.LogPrefixInfo + "Show sequence called")
-    if len(args) == 0 {
-        executeListSequencesCmd()
-    } else if len(args) == 1 {
-        if args[0] == "help" {
-            printSequenceHelp()
-        } else {
-            sequenceName = args[0]
-            executeGetSequenceCmd(sequenceName)
-        }
-    } else {
-        fmt.Println("Too many arguments. See the usage below")
-        printSequenceHelp()
-    }
+	utils.Logln(utils.LogPrefixInfo + "Show sequence called")
+	if len(args) == 0 {
+		executeListSequencesCmd()
+	} else if len(args) == 1 {
+		if args[0] == "help" {
+			printSequenceHelp()
+		} else {
+			sequenceName = args[0]
+			executeGetSequenceCmd(sequenceName)
+		}
+	} else {
+		fmt.Println("Too many arguments. See the usage below")
+		printSequenceHelp()
+	}
 }
 
 func printSequenceHelp() {
-    fmt.Print(showSequenceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showSequenceCmdLiteral, 
-        "[sequence-name]") + showSequenceCmdExamples + utils.GetCmdFlags("sequence(s)"))
+	fmt.Print(showSequenceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showSequenceCmdLiteral,
+		"[sequence-name]") + showSequenceCmdExamples + utils.GetCmdFlags("sequence(s)"))
 }
 
 func executeGetSequenceCmd(sequencename string) {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixSequences + "?inboundEndpointName=" + sequencename
+	finalUrl := utils.RESTAPIBase + utils.PrefixSequences + "?inboundEndpointName=" + sequencename
 
-    resp, err := utils.UnmarshalData(finalUrl, &utils.Sequence{})
+	resp, err := utils.UnmarshalData(finalUrl, &utils.Sequence{})
 
-    if err == nil {
-        // Printing the details of the Sequence
-        sequence := resp.(*utils.Sequence)
-        printSequenceInfo(*sequence)
-    } else {
-        fmt.Println(utils.LogPrefixError+"Getting Information of the Sequence", err)
-    }
+	if err == nil {
+		// Printing the details of the Sequence
+		sequence := resp.(*utils.Sequence)
+		printSequenceInfo(*sequence)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Getting Information of the Sequence", err)
+	}
 }
 
 // Print the details of a Sequence
@@ -99,55 +98,55 @@ func executeGetSequenceCmd(sequencename string) {
 // @param task : Sequence object
 func printSequenceInfo(sequence utils.Sequence) {
 
-    fmt.Println("Name - " + sequence.Name)
-    fmt.Println("Container - " + sequence.Container)
-    fmt.Println("Stats - " + sequence.Stats)
-    fmt.Println("Tracing - " + sequence.Tracing)
+	fmt.Println("Name - " + sequence.Name)
+	fmt.Println("Container - " + sequence.Container)
+	fmt.Println("Stats - " + sequence.Stats)
+	fmt.Println("Tracing - " + sequence.Tracing)
 
-    var mediatorSring string
+	var mediatorSring string
 
-    for i, mediator := range sequence.Mediators {
-        if i > 0 {
-            mediatorSring += " , "    
-        }
-        mediatorSring += mediator
-    }
-    if mediatorSring != "" {
-        fmt.Println("Mediators - " + mediatorSring)
-    }
+	for i, mediator := range sequence.Mediators {
+		if i > 0 {
+			mediatorSring += " , "
+		}
+		mediatorSring += mediator
+	}
+	if mediatorSring != "" {
+		fmt.Println("Mediators - " + mediatorSring)
+	}
 }
 
 func executeListSequencesCmd() {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixSequences
+	finalUrl := utils.RESTAPIBase + utils.PrefixSequences
 
-    resp, err := utils.GetArtifactList(finalUrl, &utils.SequenceList{})
+	resp, err := utils.GetArtifactList(finalUrl, &utils.SequenceList{})
 
-    if err == nil {
-        // Printing the list of available Sequences
-        list := resp.(*utils.SequenceList)
-        printSequenceList(*list)
-    } else {
-        utils.Logln(utils.LogPrefixError+"Getting List of Sequences", err)
-    }
+	if err == nil {
+		// Printing the list of available Sequences
+		list := resp.(*utils.SequenceList)
+		printSequenceList(*list)
+	} else {
+		utils.Logln(utils.LogPrefixError+"Getting List of Sequences", err)
+	}
 }
 
-func printSequenceList(sequenceList utils.SequenceList){
-    if sequenceList.Count > 0 {
-        table := tablewriter.NewWriter(os.Stdout)
-        table.SetAlignment(tablewriter.ALIGN_LEFT)
+func printSequenceList(sequenceList utils.SequenceList) {
+	if sequenceList.Count > 0 {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-        data := []string{"NAME", "STATS", "TRACING"}
-        table.Append(data)
+		data := []string{"NAME", "STATS", "TRACING"}
+		table.Append(data)
 
-        for _, sequence := range sequenceList.Sequences {
-            data = []string{sequence.Name, sequence.Stats, sequence.Tracing}
-            table.Append(data)
-        }
-        table.SetBorder(false)
-        table.SetColumnSeparator("  ")
-        table.Render()
-    } else {
-        fmt.Println("No Sequences found")
-    }
+		for _, sequence := range sequenceList.Sequences {
+			data = []string{sequence.Name, sequence.Stats, sequence.Tracing}
+			table.Append(data)
+		}
+		table.SetBorder(false)
+		table.SetColumnSeparator("  ")
+		table.Render()
+	} else {
+		fmt.Println("No Sequences found")
+	}
 }

--- a/cmd/cmd/sequenceList.go
+++ b/cmd/cmd/sequenceList.go
@@ -19,8 +19,8 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 // List Seqeunces command related usage info
@@ -28,17 +28,17 @@ const listSequenceCmdLiteral = "sequences"
 
 // sequencesListCmd represents the list sequences command
 var sequencesListCmd = &cobra.Command{
-    Use:   listSequenceCmdLiteral,
-    Short: showSequenceCmdShortDesc,
-    Long:  showSequenceCmdLongDesc + showSequenceCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        // defined in seqeunceInfo.go
-        handleSequenceCmdArguments(args)
-    },
+	Use:   listSequenceCmdLiteral,
+	Short: showSequenceCmdShortDesc,
+	Long:  showSequenceCmdLongDesc + showSequenceCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		// defined in seqeunceInfo.go
+		handleSequenceCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(sequencesListCmd)
-    sequencesListCmd.SetHelpTemplate(showSequenceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showSequenceCmdLiteral, "[sequence-name]") + showSequenceCmdExamples + utils.GetCmdFlags("sequence(s)"))
+	showCmd.AddCommand(sequencesListCmd)
+	sequencesListCmd.SetHelpTemplate(showSequenceCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showSequenceCmdLiteral, "[sequence-name]") + showSequenceCmdExamples + utils.GetCmdFlags("sequence(s)"))
 }

--- a/cmd/cmd/show.go
+++ b/cmd/cmd/show.go
@@ -19,10 +19,10 @@
 package cmd
 
 import (
-  "fmt"
-  "github.com/lithammer/dedent"
-  "github.com/spf13/cobra"
-  "github.com/wso2/micro-integrator/cmd/utils"
+	"fmt"
+	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 var showCmdLiteral = "show"
@@ -59,16 +59,16 @@ var showCmdValidArgs = []string{"api", "carbonapp", "endpoint", "inboundendpoint
 
 // showCmd represents the show command
 var showCmd = &cobra.Command{
-  Use:   "show [command]",
-  Short: showCmdShortDesc,
-  Long:  showCmdLongDesc,
-  Run: func(cmd *cobra.Command, args []string) {
-    fmt.Print(showCmdLongDesc + showUsageError + utils.GetCmdFlags("show") + showCmdExamples + showCmdHelp)
-  },
-  ValidArgs: showCmdValidArgs,
+	Use:   "show [command]",
+	Short: showCmdShortDesc,
+	Long:  showCmdLongDesc,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Print(showCmdLongDesc + showUsageError + utils.GetCmdFlags("show") + showCmdExamples + showCmdHelp)
+	},
+	ValidArgs: showCmdValidArgs,
 }
 
 func init() {
-  rootCmd.AddCommand(showCmd)
-  showCmd.SetHelpTemplate(showCmdLongDesc + showUsageError + utils.GetCmdFlags("show") + showCmdExamples + showCmdHelp)
+	rootCmd.AddCommand(showCmd)
+	showCmd.SetHelpTemplate(showCmdLongDesc + showUsageError + utils.GetCmdFlags("show") + showCmdExamples + showCmdHelp)
 }

--- a/cmd/cmd/taskInfo.go
+++ b/cmd/cmd/taskInfo.go
@@ -19,11 +19,11 @@
 package cmd
 
 import (
-    "fmt"
-    "github.com/olekukonko/tablewriter"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
-    "os"
+	"fmt"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"os"
 )
 
 var taskName string
@@ -34,112 +34,111 @@ const showTaskCmdShortDesc = "Get information about tasks"
 
 var showTaskCmdLongDesc = "Get information about the Task specified by command line argument [task-name] If not specified, list all the tasks\n"
 
-var showTaskCmdExamples = 
-"Example:\n" +
-"To get details about a specific task\n" +
-"  " + programName + " " + showCmdLiteral + " " + showTaskCmdLiteral + " SampleTask\n\n" +
-"To list all the tasks\n" +
-"  " + programName + " " + showCmdLiteral + " " + showTaskCmdLiteral + "\n\n"
+var showTaskCmdExamples = "Example:\n" +
+	"To get details about a specific task\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showTaskCmdLiteral + " SampleTask\n\n" +
+	"To list all the tasks\n" +
+	"  " + programName + " " + showCmdLiteral + " " + showTaskCmdLiteral + "\n\n"
 
 // taskShowCmd represents the task command
 var taskShowCmd = &cobra.Command{
-    Use:   showTaskCmdLiteral,
-    Short: showTaskCmdShortDesc,
-    Long:  showTaskCmdLongDesc + showTaskCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        handleTaskCmdArguments(args)
-    },
+	Use:   showTaskCmdLiteral,
+	Short: showTaskCmdShortDesc,
+	Long:  showTaskCmdLongDesc + showTaskCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		handleTaskCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(taskShowCmd)
-    taskShowCmd.SetHelpTemplate(showTaskCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showTaskCmdLiteral, "[task-name]") + showTaskCmdExamples + utils.GetCmdFlags("task(s)"))
+	showCmd.AddCommand(taskShowCmd)
+	taskShowCmd.SetHelpTemplate(showTaskCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showTaskCmdLiteral, "[task-name]") + showTaskCmdExamples + utils.GetCmdFlags("task(s)"))
 }
 
 func handleTaskCmdArguments(args []string) {
-    utils.Logln(utils.LogPrefixInfo + "Show task called")
-    if len(args) == 0 {
-        executeListTasksCmd()
-    } else if len(args) == 1 {
-        if args[0] == "help" {
-            printTaskHelp()
-        } else {
-            taskName = args[0]
-            executeGetTaskCmd(taskName)
-        }
-    } else {
-        fmt.Println("Too many arguments. See the usage below")
-        printTaskHelp()
-    }
+	utils.Logln(utils.LogPrefixInfo + "Show task called")
+	if len(args) == 0 {
+		executeListTasksCmd()
+	} else if len(args) == 1 {
+		if args[0] == "help" {
+			printTaskHelp()
+		} else {
+			taskName = args[0]
+			executeGetTaskCmd(taskName)
+		}
+	} else {
+		fmt.Println("Too many arguments. See the usage below")
+		printTaskHelp()
+	}
 }
 
 func printTaskHelp() {
-    fmt.Print(showTaskCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showTaskCmdLiteral,
-        "[task-name]") + showTaskCmdExamples + utils.GetCmdFlags("task(s)"))
+	fmt.Print(showTaskCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, showTaskCmdLiteral,
+		"[task-name]") + showTaskCmdExamples + utils.GetCmdFlags("task(s)"))
 }
 
 func executeGetTaskCmd(taskname string) {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixTasks + "?taskName=" + taskname
+	finalUrl := utils.RESTAPIBase + utils.PrefixTasks + "?taskName=" + taskname
 
-    resp, err := utils.UnmarshalData(finalUrl, &utils.Task{})
+	resp, err := utils.UnmarshalData(finalUrl, &utils.Task{})
 
-    if err == nil {
-        // Printing the details of the Task
-        task := resp.(*utils.Task)
-        printTask(*task)
-    } else {
-        fmt.Println(utils.LogPrefixError+"Getting Information of the Task", err)
-    }
+	if err == nil {
+		// Printing the details of the Task
+		task := resp.(*utils.Task)
+		printTask(*task)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Getting Information of the Task", err)
+	}
 }
 
 // Print the details of a Task
 // Name, Class, Group, Type and Trigger details
 // @param task : Task object
 func printTask(task utils.Task) {
-    fmt.Println("Name - " + task.Name)
-    fmt.Println("Trigger Type - " + task.Type)
-    if task.Type == "cron" {
-        fmt.Println("Cron Expression - " + task.TriggerCron)
-    } else {
-        fmt.Println("Trigger Count - " + task.TriggerCount)
-        fmt.Println("Trigger Interval - " + task.TriggerInterval)
-    }    
+	fmt.Println("Name - " + task.Name)
+	fmt.Println("Trigger Type - " + task.Type)
+	if task.Type == "cron" {
+		fmt.Println("Cron Expression - " + task.TriggerCron)
+	} else {
+		fmt.Println("Trigger Count - " + task.TriggerCount)
+		fmt.Println("Trigger Interval - " + task.TriggerInterval)
+	}
 }
 
 func executeListTasksCmd() {
 
-    finalUrl := utils.RESTAPIBase + utils.PrefixTasks
+	finalUrl := utils.RESTAPIBase + utils.PrefixTasks
 
-    resp, err := utils.GetArtifactList(finalUrl, &utils.TaskList{})
+	resp, err := utils.GetArtifactList(finalUrl, &utils.TaskList{})
 
-    if err == nil {
-        // Printing the list of available Tasks
-        list := resp.(*utils.TaskList)
-        printTaskList(*list)
-    } else {
-        utils.Logln(utils.LogPrefixError+"Getting List of Tasks", err)
-    }
+	if err == nil {
+		// Printing the list of available Tasks
+		list := resp.(*utils.TaskList)
+		printTaskList(*list)
+	} else {
+		utils.Logln(utils.LogPrefixError+"Getting List of Tasks", err)
+	}
 }
 
 func printTaskList(taskList utils.TaskList) {
 
-    if taskList.Count > 0 {
-        table := tablewriter.NewWriter(os.Stdout)
-        table.SetAlignment(tablewriter.ALIGN_LEFT)
+	if taskList.Count > 0 {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetAlignment(tablewriter.ALIGN_LEFT)
 
-        data := []string{"NAME", "TRIGGER TYPE", "COUNT", "INTERVAL", "CRON EXPRESSION"}
-        table.Append(data)
+		data := []string{"NAME", "TRIGGER TYPE", "COUNT", "INTERVAL", "CRON EXPRESSION"}
+		table.Append(data)
 
-        for _, task := range taskList.Tasks {
-            data = []string{task.Name, task.Type, task.TriggerCount, task.TriggerInterval, task.TriggerCron}
-            table.Append(data)
-        }
-        table.SetBorder(false)
-        table.SetColumnSeparator("  ")
-        table.Render()
-    } else {
-        fmt.Println("No Tasks found")
-    }    
+		for _, task := range taskList.Tasks {
+			data = []string{task.Name, task.Type, task.TriggerCount, task.TriggerInterval, task.TriggerCron}
+			table.Append(data)
+		}
+		table.SetBorder(false)
+		table.SetColumnSeparator("  ")
+		table.Render()
+	} else {
+		fmt.Println("No Tasks found")
+	}
 }

--- a/cmd/cmd/taskList.go
+++ b/cmd/cmd/taskList.go
@@ -19,8 +19,8 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 // List Tasks command related usage info
@@ -28,17 +28,17 @@ const listTaskCmdLiteral = "tasks"
 
 // taskListCmd represents the list tasks command
 var taskListCmd = &cobra.Command{
-    Use:   listTaskCmdLiteral,
-    Short: showTaskCmdShortDesc,
-    Long:  showTaskCmdLongDesc + showTaskCmdExamples,
-    Run: func(cmd *cobra.Command, args []string) {
-        // defined in taskInfo.go
-        handleTaskCmdArguments(args)
-    },
+	Use:   listTaskCmdLiteral,
+	Short: showTaskCmdShortDesc,
+	Long:  showTaskCmdLongDesc + showTaskCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		// defined in taskInfo.go
+		handleTaskCmdArguments(args)
+	},
 }
 
 func init() {
-    showCmd.AddCommand(taskListCmd)
-    taskListCmd.SetHelpTemplate(showTaskCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral, 
-        showTaskCmdLiteral, "[task-name]") + showTaskCmdExamples + utils.GetCmdFlags("task(s)"))
+	showCmd.AddCommand(taskListCmd)
+	taskListCmd.SetHelpTemplate(showTaskCmdLongDesc + utils.GetCmdUsage(programName, showCmdLiteral,
+		showTaskCmdLiteral, "[task-name]") + showTaskCmdExamples + utils.GetCmdFlags("task(s)"))
 }

--- a/cmd/cmd/version.go
+++ b/cmd/cmd/version.go
@@ -19,23 +19,23 @@
 package cmd
 
 import (
-    "fmt"
-    "github.com/spf13/cobra"
-    "github.com/wso2/micro-integrator/cmd/utils"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
 )
 
 var version string
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
-    Use:   "version",
-    Short: "Version of the CLI",
-    Long:  `Display the version of the Command line tool`,
-    Run: func(cmd *cobra.Command, args []string) {
-        fmt.Println(utils.ProjectName + " version: " + version)
-    },
+	Use:   "version",
+	Short: "Version of the CLI",
+	Long:  `Display the version of the Command line tool`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(utils.ProjectName + " version: " + version)
+	},
 }
 
 func init() {
-    rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/mi.go
+++ b/cmd/mi.go
@@ -16,11 +16,10 @@
 * under the License.
  */
 
- package main
+package main
 
- import "github.com/wso2/micro-integrator/cmd/cmd"
- 
- func main() {
-     cmd.Execute()
- }
- 
+import "github.com/wso2/micro-integrator/cmd/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cmd/utils/constants.go
+++ b/cmd/utils/constants.go
@@ -19,8 +19,8 @@
 package utils
 
 import (
-    "os"
-    "path/filepath"
+	"os"
+	"path/filepath"
 )
 
 const ProjectName = "mi"
@@ -91,8 +91,8 @@ const DefaultRESTAPIBase = HTTPSProtocol + DefaultHost + ":" + DefaultPort + "/"
 const PrefixCarbonApps = "applications"
 const PrefixAPIs = "apis"
 const PrefixServices = "services"
-const PrefixProxyServices ="proxy-services"
-const PrefixInboundEndpoints ="inbound-endpoints"
+const PrefixProxyServices = "proxy-services"
+const PrefixInboundEndpoints = "inbound-endpoints"
 const PrefixEndpoints = "endpoints"
 const PrefixSequences = "sequences"
 const PrefixTasks = "tasks"

--- a/cmd/utils/errorHandling.go
+++ b/cmd/utils/errorHandling.go
@@ -19,25 +19,25 @@
 package utils
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 )
 
 var IsVerbose bool
 
-func HandleErrorAndExit(msg string, err error) {    
-    if err == nil {
-        fmt.Fprintf(os.Stderr, "%s: %v\n", ProjectName, msg)
-    } else {
-        fmt.Fprintf(os.Stderr, "%s: %v Reason: %v\n", ProjectName, msg, err.Error())
-    }
-    defer printAndExit()
+func HandleErrorAndExit(msg string, err error) {
+	if err == nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", ProjectName, msg)
+	} else {
+		fmt.Fprintf(os.Stderr, "%s: %v Reason: %v\n", ProjectName, msg, err.Error())
+	}
+	defer printAndExit()
 }
 
 func printAndExit() {
 
-    if !IsVerbose {
-        fmt.Println("Execute with --verbose to see detailed info.")
-    }
-    os.Exit(1)
+	if !IsVerbose {
+		fmt.Println("Execute with --verbose to see detailed info.")
+	}
+	os.Exit(1)
 }

--- a/cmd/utils/fileIOUtils.go
+++ b/cmd/utils/fileIOUtils.go
@@ -19,68 +19,68 @@
 package utils
 
 import (
-    "errors"
-    "gopkg.in/yaml.v2"
-    "io/ioutil"
-    "os"
+	"errors"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
 )
 
 // Write Server configuration to the yaml file
 // @param c : data
 // @param serverConfigFilePath : Path to file where env endpoints are stored
 func WriteServerConfigFile(c interface{}, envConfigFilePath string) {
-    data, err := yaml.Marshal(&c)
-    if err != nil {
-        HandleErrorAndExit("Unable to write configuration to file.", err)
-    }
+	data, err := yaml.Marshal(&c)
+	if err != nil {
+		HandleErrorAndExit("Unable to write configuration to file.", err)
+	}
 
-    err = ioutil.WriteFile(envConfigFilePath, data, 0644)
-    if err != nil {
-        HandleErrorAndExit("Unable to write configuration to file.", err)
-    }
+	err = ioutil.WriteFile(envConfigFilePath, data, 0644)
+	if err != nil {
+		HandleErrorAndExit("Unable to write configuration to file.", err)
+	}
 }
 
 // Read and return Server Configuration from the yaml file
 func GetServerConfigFromFile(filePath string) *ServerConfig {
-    data, err := ioutil.ReadFile(filePath)
-    if err != nil {
-        HandleErrorAndExit("ServerConfig: File Not Found: "+filePath, err)
-    }
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		HandleErrorAndExit("ServerConfig: File Not Found: "+filePath, err)
+	}
 
-    var serverConfig ServerConfig
-    if err := serverConfig.ParseServerConfigFromFile(data); err != nil {
-        HandleErrorAndExit("ServerConfig: Error parsing "+filePath, err)
-    }
+	var serverConfig ServerConfig
+	if err := serverConfig.ParseServerConfigFromFile(data); err != nil {
+		HandleErrorAndExit("ServerConfig: Error parsing "+filePath, err)
+	}
 
-    return &serverConfig
+	return &serverConfig
 }
 
 // Read and validate contents of server_config.yaml
 // will throw errors if the any of the lines is blank
 func (serverConfig *ServerConfig) ParseServerConfigFromFile(data []byte) error {
 
-    if err := yaml.Unmarshal(data, serverConfig); err != nil {
-        return err
-    }
+	if err := yaml.Unmarshal(data, serverConfig); err != nil {
+		return err
+	}
 
-    if serverConfig.Url == "" {
-        return errors.New("Blank Host")
-    }
-    if serverConfig.Port == "" {
-        return errors.New("Blank Port")
-    }
+	if serverConfig.Url == "" {
+		return errors.New("Blank Host")
+	}
+	if serverConfig.Port == "" {
+		return errors.New("Blank Port")
+	}
 
-    return nil
+	return nil
 }
 
 // Check whether the file exists.
 func IsFileExist(path string) (isFileExist bool) {
-    if _, err := os.Stat(path); err != nil {
-        if os.IsNotExist(err) {
-            return false
-        } else {
-            HandleErrorAndExit("Unable to find file "+path, err)
-        }
-    }
-    return true
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		} else {
+			HandleErrorAndExit("Unable to find file "+path, err)
+		}
+	}
+	return true
 }

--- a/cmd/utils/logUtils.go
+++ b/cmd/utils/logUtils.go
@@ -19,8 +19,8 @@
 package utils
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 )
 
 var loglnFunc = doNothinglnFunc
@@ -28,28 +28,28 @@ var loglnFunc = doNothinglnFunc
 var logfFunc = doNothingfFunc
 
 func verbosePrintlnFunc(a ...interface{}) {
-    fmt.Fprintln(os.Stderr, a...)
+	fmt.Fprintln(os.Stderr, a...)
 }
 
 func doNothinglnFunc(v ...interface{}) {
 }
 
 func verbosePrintfFunc(format string, a ...interface{}) {
-    fmt.Fprintf(os.Stderr, format, a...)
+	fmt.Fprintf(os.Stderr, format, a...)
 }
 
 func doNothingfFunc(format string, a ...interface{}) {
 }
 
 func Logln(a ...interface{}) {
-    loglnFunc(a...)
+	loglnFunc(a...)
 }
 
 func Logf(format string, a ...interface{}) {
-    logfFunc(format, a...)
+	logfFunc(format, a...)
 }
 
 func EnableVerboseMode() {
-    loglnFunc = verbosePrintlnFunc
-    logfFunc = verbosePrintfFunc
+	loglnFunc = verbosePrintlnFunc
+	logfFunc = verbosePrintfFunc
 }

--- a/cmd/utils/serverConfigVars.go
+++ b/cmd/utils/serverConfigVars.go
@@ -27,12 +27,12 @@ var RESTAPIBase = DefaultRESTAPIBase
 // @return error
 func SetConfigVars(serverConfigFilePath string) error {
 
-    if IsFileExist(serverConfigFilePath) {
-        mainConfig := GetServerConfigFromFile(serverConfigFilePath)
-        Logln(LogPrefixInfo + " reading '" + serverConfigFilePath + "'")
+	if IsFileExist(serverConfigFilePath) {
+		mainConfig := GetServerConfigFromFile(serverConfigFilePath)
+		Logln(LogPrefixInfo + " reading '" + serverConfigFilePath + "'")
 
-        RESTAPIBase = mainConfig.Url + ":" + mainConfig.Port + "/" + Context + "/"
-        Logln(LogPrefixInfo + "Setting REST API URL to " + RESTAPIBase)
-    }
-    return nil
+		RESTAPIBase = mainConfig.Url + ":" + mainConfig.Port + "/" + Context + "/"
+		Logln(LogPrefixInfo + "Setting REST API URL to " + RESTAPIBase)
+	}
+	return nil
 }

--- a/cmd/utils/structs.go
+++ b/cmd/utils/structs.go
@@ -19,181 +19,181 @@
 package utils
 
 type ServerConfig struct {
-    Url string `yaml:"server_address"`
-    Port string `yaml:"server_port"`
+	Url  string `yaml:"server_address"`
+	Port string `yaml:"server_port"`
 }
 
 type CarbonAppList struct {
-    Count       int32                   `xml:"Count"`
-    CarbonApps  []CarbonAppSummary      `xml:"List>Application"`
+	Count      int32              `xml:"Count"`
+	CarbonApps []CarbonAppSummary `xml:"List>Application"`
 }
 
 type CarbonAppSummary struct {
-    Name      string     `xml:"Name"`
-    Version   string     `xml:"Version"`
+	Name    string `xml:"Name"`
+	Version string `xml:"Version"`
 }
 
 type CarbonApp struct {
-    Name      string     `xml:"Name"`
-    Version   string     `xml:"Version"`
-    Artifacts []Artifact `xml:"Artifacts>Artifact"`
+	Name      string     `xml:"Name"`
+	Version   string     `xml:"Version"`
+	Artifacts []Artifact `xml:"Artifacts>Artifact"`
 }
 
 type Artifact struct {
-    Name string `xml:"Name"`
-    Type string `xml:"Type"`
+	Name string `xml:"Name"`
+	Type string `xml:"Type"`
 }
 
 type EndpointList struct {
-    Count       int32               `xml:"Count"`
-    Endpoints  []EndpointSummary    `xml:"List>Endpoint"`
+	Count     int32             `xml:"Count"`
+	Endpoints []EndpointSummary `xml:"List>Endpoint"`
 }
 
 type EndpointSummary struct {
-    Name      string     `xml:"Name"`
-    Type      string     `xml:"Type"`
-    Method    string     `xml:"Method"`
-    Url       string     `xml:"Url"`
+	Name   string `xml:"Name"`
+	Type   string `xml:"Type"`
+	Method string `xml:"Method"`
+	Url    string `xml:"Url"`
 }
 
 type Endpoint struct {
-    Name      string     `xml:"Name"`
-    Type      string     `xml:"Type"`
-    Method    string     `xml:"Method"`
-    Url       string     `xml:"Url"`
-    Stats     string     `xml:"Stats"`
+	Name   string `xml:"Name"`
+	Type   string `xml:"Type"`
+	Method string `xml:"Method"`
+	Url    string `xml:"Url"`
+	Stats  string `xml:"Stats"`
 }
 
 type InboundEndpointList struct {
-    Count               int32                       `xml:"Count"`
-    InboundEndpoints    []InboundEndpointSummary    `xml:"List>InboundEndpoint"`
+	Count            int32                    `xml:"Count"`
+	InboundEndpoints []InboundEndpointSummary `xml:"List>InboundEndpoint"`
 }
 
 type InboundEndpointSummary struct {
-    Name      string     `xml:"Name"`
-    Type      string     `xml:"Protocol"`
+	Name string `xml:"Name"`
+	Type string `xml:"Protocol"`
 }
 
 type InboundEndpoint struct {
-    Name          string      `xml:"Name"`
-    Type          string      `xml:"Protocol"`
-    Stats         string      `xml:"Stats"`
-    Tracing       string      `xml:"Tracing"`
-    Parameters    []Parameter `xml:"Parameters>Parameter"`
+	Name       string      `xml:"Name"`
+	Type       string      `xml:"Protocol"`
+	Stats      string      `xml:"Stats"`
+	Tracing    string      `xml:"Tracing"`
+	Parameters []Parameter `xml:"Parameters>Parameter"`
 }
 
 type Parameter struct {
-    Name  string `xml:"Name"`
-    Value string `xml:"Value"`
+	Name  string `xml:"Name"`
+	Value string `xml:"Value"`
 }
 
 type API struct {
-    Name      string     `xml:"Name"`
-    Context   string     `xml:"Context"`
-    // Host      string     `xml:"Host"`
-    // Port      string     `xml:"Port"`
-    Version   string     `xml:"Version"`
-    Stats     string     `xml:"Stats"`
-    Tracing   string     `xml:"Tracing"`
-    Resources []Resource `xml:"Resources>Resource"`
+	Name    string `xml:"Name"`
+	Context string `xml:"Context"`
+	// Host      string     `xml:"Host"`
+	// Port      string     `xml:"Port"`
+	Version   string     `xml:"Version"`
+	Stats     string     `xml:"Stats"`
+	Tracing   string     `xml:"Tracing"`
+	Resources []Resource `xml:"Resources>Resource"`
 }
 
 type APIList struct {
-    Count     int32         `xml:"Count"`
-    Apis      []APISummary  `xml:"List>API"`
+	Count int32        `xml:"Count"`
+	Apis  []APISummary `xml:"List>API"`
 }
 
 type APISummary struct {
-    Name      string     `xml:"Name"`
-    Context   string     `xml:"Context"`
+	Name    string `xml:"Name"`
+	Context string `xml:"Context"`
 }
 
 type Resource struct {
-    Methods       []string  `xml:"Methods>Item"`
-    Url             string  `xml:"Url"`
+	Methods []string `xml:"Methods>Item"`
+	Url     string   `xml:"Url"`
 }
 
 type ProxyServiceList struct {
-    Count           int32             `xml:"Count"`
-    Proxies         []ProxySummary    `xml:"List>ProxyService"`
+	Count   int32          `xml:"Count"`
+	Proxies []ProxySummary `xml:"List>ProxyService"`
 }
 
 type ProxySummary struct {
-    Name      string     `xml:"Name"`
-    WSDL1_1   string     `xml:"WSDL1_1"`
-    WSDL2_0   string     `xml:"WSDL2_0"`
+	Name    string `xml:"Name"`
+	WSDL1_1 string `xml:"WSDL1_1"`
+	WSDL2_0 string `xml:"WSDL2_0"`
 }
 
 type Proxy struct {
-    Name      string     `xml:"Name"`
-    WSDL1_1   string     `xml:"WSDL1_1"`
-    WSDL2_0   string     `xml:"WSDL2_0"`
-    Stats     string     `xml:"Stats"`
-    Tracing   string     `xml:"Tracing"`
+	Name    string `xml:"Name"`
+	WSDL1_1 string `xml:"WSDL1_1"`
+	WSDL2_0 string `xml:"WSDL2_0"`
+	Stats   string `xml:"Stats"`
+	Tracing string `xml:"Tracing"`
 }
 
 type Service struct {
-    Name        string `xml:"Name"`
-    Description string `xml:"Description"`
-    Type        string `xml:"Type"`
-    Status      string `xml:"Status"`
-    TryItURL    string `xml:"TryItUrl"`
+	Name        string `xml:"Name"`
+	Description string `xml:"Description"`
+	Type        string `xml:"Type"`
+	Status      string `xml:"Status"`
+	TryItURL    string `xml:"TryItUrl"`
 }
 
 type SequenceList struct {
-    Count       int32               `xml:"Count"`
-    Sequences  []SequenceSummary    `xml:"List>Sequence"`
+	Count     int32             `xml:"Count"`
+	Sequences []SequenceSummary `xml:"List>Sequence"`
 }
 
 type SequenceSummary struct {
-    Name        string      `xml:"Name"`
-    Container   string      `xml:"Container"`
-    Stats       string      `xml:"Stats"`
-    Tracing     string      `xml:"Tracing"`
+	Name      string `xml:"Name"`
+	Container string `xml:"Container"`
+	Stats     string `xml:"Stats"`
+	Tracing   string `xml:"Tracing"`
 }
 
 type Sequence struct {
-    Name      string   `xml:"Name"`
-    Container string   `xml:"Container"`
-    Stats     string   `xml:"Stats"`
-    Tracing   string   `xml:"Tracing"`
-    Mediators []string `xml:"Mediators>Mediator"`
+	Name      string   `xml:"Name"`
+	Container string   `xml:"Container"`
+	Stats     string   `xml:"Stats"`
+	Tracing   string   `xml:"Tracing"`
+	Mediators []string `xml:"Mediators>Mediator"`
 }
 
 type TaskList struct {
-    Count       int32     `xml:"Count"`
-    Tasks       []Task    `xml:"List>Task"`
+	Count int32  `xml:"Count"`
+	Tasks []Task `xml:"List>Task"`
 }
 
 type Task struct {
-    Name            string `xml:"Name"`
-    Type            string `xml:"TriggerType"`
-    TriggerCount    string `xml:"TriggerCount"`
-    TriggerInterval string `xml:"TriggerInterval"`
-    TriggerCron     string `xml:"TriggerCron"`
+	Name            string `xml:"Name"`
+	Type            string `xml:"TriggerType"`
+	TriggerCount    string `xml:"TriggerCount"`
+	TriggerInterval string `xml:"TriggerInterval"`
+	TriggerCron     string `xml:"TriggerCron"`
 }
 
 type ServerSummary struct {
-    Name     string `xml:"Name"`
-    Version  string `xml:"Version"`
-    Location string `xml:"Location"`
+	Name     string `xml:"Name"`
+	Version  string `xml:"Version"`
+	Location string `xml:"Location"`
 }
 
 type ListResponse struct {
-    Count int32    `xml:"Count"`
-    List  []string `xml:"List>Item"`
+	Count int32    `xml:"Count"`
+	List  []string `xml:"List>Item"`
 }
 
 type RegistrationResponse struct {
-    ClientSecretExpiresAt string `xml:"client_secret_expires_at"`
-    ClientID              string `xml:"client_id"`
-    ClientSecret          string `xml:"client_secret"`
-    ClientName            string `xml:"client_name"`
+	ClientSecretExpiresAt string `xml:"client_secret_expires_at"`
+	ClientID              string `xml:"client_id"`
+	ClientSecret          string `xml:"client_secret"`
+	ClientName            string `xml:"client_name"`
 }
 
 type TokenResponse struct {
-    AccessToken  string `xml:"access_token"`
-    RefreshToken string `xml:"refresh_token"`
-    TokenType    string `xml:"token_type"`
-    ExpiresIn    int32  `xml:"expires_in"`
+	AccessToken  string `xml:"access_token"`
+	RefreshToken string `xml:"refresh_token"`
+	TokenType    string `xml:"token_type"`
+	ExpiresIn    int32  `xml:"expires_in"`
 }

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -19,101 +19,101 @@
 package utils
 
 import (
-    "bufio"
-    "crypto/tls"
-    "encoding/xml"
-    "errors"
-    "fmt"
-    "golang.org/x/crypto/ssh/terminal"
-    "gopkg.in/resty.v1"
-    "net/http"
-    "os"
-    "runtime"
-    "strings"
+	"bufio"
+	"crypto/tls"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"golang.org/x/crypto/ssh/terminal"
+	"gopkg.in/resty.v1"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
 )
 
 // Invoke http-post request using go-resty
 func InvokePOSTRequest(url string, headers map[string]string, body string) (*resty.Response, error) {
 
-    AllowInsecureSSLConnection()
-    resp, err := resty.R().SetHeaders(headers).SetBody(body).Post(url)
+	AllowInsecureSSLConnection()
+	resp, err := resty.R().SetHeaders(headers).SetBody(body).Post(url)
 
-    return resp, err
+	return resp, err
 }
 
 // Invoke http-get request using go-resty
 func InvokeGETRequest(url string, headers map[string]string) (*resty.Response, error) {
 
-    AllowInsecureSSLConnection()
-    resp, err := resty.R().SetHeaders(headers).Get(url)
+	AllowInsecureSSLConnection()
+	resp, err := resty.R().SetHeaders(headers).Get(url)
 
-    return resp, err
+	return resp, err
 }
 
 // Invoke http-put request using go-resty
 func InvokeUPDATERequest(url string, headers map[string]string, body string) (*resty.Response, error) {
 
-    resp, err := resty.R().SetHeaders(headers).SetBody(body).Put(url)
+	resp, err := resty.R().SetHeaders(headers).SetBody(body).Put(url)
 
-    return resp, err
+	return resp, err
 }
 
 // Invoke http-delete request using go-resty
 func InvokeDELETERequest(url string, headers map[string]string) (*resty.Response, error) {
 
-    resp, err := resty.R().SetHeaders(headers).Delete(url)
+	resp, err := resty.R().SetHeaders(headers).Delete(url)
 
-    return resp, err
+	return resp, err
 }
 
 func PromptForUsername() string {
-    reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(os.Stdin)
 
-    fmt.Print("Enter Username: ")
-    username, _ := reader.ReadString('\n')
+	fmt.Print("Enter Username: ")
+	username, _ := reader.ReadString('\n')
 
-    return username
+	return username
 }
 
 func PromptForPassword() string {
-    fmt.Print("Enter Password: ")
-    bytePassword, _ := terminal.ReadPassword(0)
-    password := string(bytePassword)
-    fmt.Println()
-    return password
+	fmt.Print("Enter Password: ")
+	bytePassword, _ := terminal.ReadPassword(0)
+	password := string(bytePassword)
+	fmt.Println()
+	return password
 }
 
 // return a string containing the file name, function name
 // and the line number of a specified entry on the call stack
 func WhereAmI(depthList ...int) string {
-    var depth int
-    if depthList == nil {
-        depth = 1
-    } else {
-        depth = depthList[0]
-    }
-    function, file, line, _ := runtime.Caller(depth)
-    return fmt.Sprintf("File: %s Line: %d Function: %s ", chopPath(file), line, runtime.FuncForPC(function).Name())
+	var depth int
+	if depthList == nil {
+		depth = 1
+	} else {
+		depth = depthList[0]
+	}
+	function, file, line, _ := runtime.Caller(depth)
+	return fmt.Sprintf("File: %s Line: %d Function: %s ", chopPath(file), line, runtime.FuncForPC(function).Name())
 }
 
 // return the source filename after the last slash
 func chopPath(original string) string {
-    i := strings.LastIndex(original, "/")
-    if i == -1 {
-        return original
-    } else {
-        return original[i+1:]
-    }
+	i := strings.LastIndex(original, "/")
+	if i == -1 {
+		return original
+	} else {
+		return original[i+1:]
+	}
 }
 
 func PrintList(list []string) {
-    for _, item := range list {
-        fmt.Println(item)
-    }
+	for _, item := range list {
+		fmt.Println(item)
+	}
 }
 
 func AllowInsecureSSLConnection() {
-    resty.SetTLSClientConfig(&tls.Config{ InsecureSkipVerify: true })
+	resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 }
 
 // Get Artifact List depending on the @param url and unmarshal it
@@ -122,29 +122,29 @@ func AllowInsecureSSLConnection() {
 // @return struct object
 // @return error
 func GetArtifactList(url string, model interface{}) (interface{}, error) {
-    Logln(LogPrefixInfo+"URL:", url)
+	Logln(LogPrefixInfo+"URL:", url)
 
-    headers := make(map[string]string)
+	headers := make(map[string]string)
 
-    resp, err := InvokeGETRequest(url, headers)
+	resp, err := InvokeGETRequest(url, headers)
 
-    if err != nil {
-        HandleErrorAndExit("Unable to connect to host", nil)
-    }
+	if err != nil {
+		HandleErrorAndExit("Unable to connect to host", nil)
+	}
 
-    Logln(LogPrefixInfo+"Response:", resp.Status())
+	Logln(LogPrefixInfo+"Response:", resp.Status())
 
-    if resp.StatusCode() == http.StatusOK {
-        response := model
-        unmarshalError := xml.Unmarshal([]byte(resp.Body()), &response)
+	if resp.StatusCode() == http.StatusOK {
+		response := model
+		unmarshalError := xml.Unmarshal([]byte(resp.Body()), &response)
 
-        if unmarshalError != nil {
-            HandleErrorAndExit(LogPrefixError+"invalid XML response", unmarshalError)
-        }
-        return response, nil
-    } else {
-        return nil, errors.New(resp.Status())
-    }
+		if unmarshalError != nil {
+			HandleErrorAndExit(LogPrefixError+"invalid XML response", unmarshalError)
+		}
+		return response, nil
+	} else {
+		return nil, errors.New(resp.Status())
+	}
 }
 
 // Unmarshal Data from the response to the respective struct
@@ -154,44 +154,42 @@ func GetArtifactList(url string, model interface{}) (interface{}, error) {
 // @return error
 func UnmarshalData(url string, model interface{}) (interface{}, error) {
 
-    Logln(LogPrefixInfo+"URL:", url)
+	Logln(LogPrefixInfo+"URL:", url)
 
-    headers := make(map[string]string)
+	headers := make(map[string]string)
 
-    resp, err := InvokeGETRequest(url, headers)
+	resp, err := InvokeGETRequest(url, headers)
 
-    if err != nil {
-        HandleErrorAndExit("Unable to connect to host", nil)
-    }
+	if err != nil {
+		HandleErrorAndExit("Unable to connect to host", nil)
+	}
 
-    Logln(LogPrefixInfo+"Response:", resp.Status())
+	Logln(LogPrefixInfo+"Response:", resp.Status())
 
-    if resp.StatusCode() == http.StatusOK {
-        response := model
-        unmarshalError := xml.Unmarshal([]byte(resp.Body()), &response)
+	if resp.StatusCode() == http.StatusOK {
+		response := model
+		unmarshalError := xml.Unmarshal([]byte(resp.Body()), &response)
 
-        if unmarshalError != nil {
-            HandleErrorAndExit(LogPrefixError+"invalid XML response", unmarshalError)
-        }
-        return response, nil
-    } else {
-        return nil, errors.New(resp.Status())
-    }
+		if unmarshalError != nil {
+			HandleErrorAndExit(LogPrefixError+"invalid XML response", unmarshalError)
+		}
+		return response, nil
+	} else {
+		return nil, errors.New(resp.Status())
+	}
 }
 
 func GetCmdFlags(cmd string) string {
-    var showCmdFlags = 
-    "Flags:\n" + 
-    "  -h, --help\t\thelp for " + cmd + "\n" +
-    "Global Flags:\n" +
-    "  -v, --verbose\t\tEnable verbose mode\n"
-    return showCmdFlags
+	var showCmdFlags = "Flags:\n" +
+		"  -h, --help\t\thelp for " + cmd + "\n" +
+		"Global Flags:\n" +
+		"  -v, --verbose\t\tEnable verbose mode\n"
+	return showCmdFlags
 }
 
 func GetCmdUsage(program, cmd, subcmd, arg string) string {
-    var showCmdUsage = 
-    "Usage:\n" + 
-    "  " + program + " " + cmd + " " + subcmd + "(s)\n" +
-    "  " + program + " " + cmd + " " + subcmd + "(s) " + arg + "\n\n"
-    return showCmdUsage
+	var showCmdUsage = "Usage:\n" +
+		"  " + program + " " + cmd + " " + subcmd + "(s)\n" +
+		"  " + program + " " + cmd + " " + subcmd + "(s) " + arg + "\n\n"
+	return showCmdUsage
 }


### PR DESCRIPTION
## Purpose
`go fmt` the entire CLI code. From the [Go official site](https://blog.golang.org/go-fmt-your-code), the advantages of using `go fmt` are as follows.

- easier to write: never worry about minor formatting concerns while hacking away,
easier to read: when all code looks the same you need not mentally convert others' formatting style into something you can understand.
- easier to maintain: mechanical changes to the source don't cause unrelated changes to the file's formatting; diffs show only the real changes.
- uncontroversial: never have a debate about spacing or brace position ever again!