### PR TITLE
cli: match version from build environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,32 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
+# do not indent (Makefile syntax, not bash)
+ifdef MVN_RELEASE_VERSION
+# maven release
+$(info MVN_RELEASE_VERSION is $(MVN_RELEASE_VERSION))
+VERSION=$(MVN_RELEASE_VERSION)
+else
+# not a maven release
+ifdef POM_VERSION
+VERSION=$(POM_VERSION)
+$(info POM_VERSION is $(POM_VERSION))
+endif
+endif
+# one of these will be set to VERSION in Jenkins Production Environment
+
+
 .PHONY: install
 install:
 	mvn clean install
-	cd cmd && ./build.sh -t mi.go -v 1.0.0 -f;
+	cd cmd && ./build.sh -t mi.go -v ${VERSION} -f
 
 .PHONY: install-cli
 install-cli:
-	cd cmd && ./build.sh -t mi.go -v 1.0.0 -f
+	cd cmd && ./build.sh -t mi.go -v ${VERSION} -f
+
+.PHONY: install-cli-local
+install-cli-local:
+	$(eval VERSION := $(shell mvn -q -Dexec.executable=echo -Dexec.args='$${project.version}' --non-recursive exec:exec))
+	cd cmd && ./build.sh -t mi.go -v ${VERSION} -f
+


### PR DESCRIPTION
## Purpose
> Replace the hardcoded version of MI CLI with the version of the Micro-Integrator itself. Closes #121