### PR TITLE
Disable invalid test: IterateSequentialPropertySavingTestCase

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/testng.xml
@@ -148,6 +148,11 @@
                     <exclude name=".*" />
                 </methods>
             </class>
+            <class name="org.wso2.carbon.esb.mediator.test.iterate.IterateSequentialPropertySavingTestCase">
+                <methods>
+                    <exclude name=".*" />
+                </methods>
+            </class>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
Disable test runs for IterateSequentialPropertySavingTestCase since it checks the update scenario of a deployed proxy which is not valid in MI.