### PR TITLE
Exclude spring mediator tests

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/testng.xml
@@ -82,12 +82,6 @@
         </packages>
     </test>
 
-    <test name="Spring-mediator-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.mediator.test.spring"/>
-        </packages>
-    </test>
-
     <test name="Smook-mediator-Test" preserve-order="true" verbose="2">
         <packages>
             <package name="org.wso2.carbon.esb.mediator.test.smooks"/>


### PR DESCRIPTION
## Purpose
> Exclude tests related to spring mediator since the feature is deprecated.