### PR TITLE
Correct TCP server port

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/conf/axis2/axis2.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/conf/axis2/axis2.xml
@@ -251,7 +251,7 @@
     <transportReceiver name="vfs" class="org.apache.synapse.transport.vfs.VFSTransportListener"/>
 
     <transportReceiver name="tcp" class="org.apache.axis2.transport.tcp.TCPTransportListener">
-        <parameter name="transport.tcp.port">8480</parameter>
+        <parameter name="transport.tcp.port">8290</parameter>
         <parameter name="transport.tcp.contentType">application/soap+xml</parameter>
         <!--parameter name="transport.tcp.contentType">text/xml</parameter-->
     </transportReceiver>


### PR DESCRIPTION
## Description
Set TCP server port as 8290 to fix transport test module's test failures.