### PR TITLE
Exclude test method in testcase : CarbonApplicationDeploymentTestCase

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/testng.xml
@@ -86,7 +86,7 @@
         <classes>
             <class name="org.wso2.carbon.esb.car.deployment.test.CAppDeploymentOrderTest">
                 <methods>
-                    <exclude name=".*"/>
+                    <exclude name="localEntryDeploymentTest"/>
                 </methods>
             </class>
         </classes>


### PR DESCRIPTION
## Purpose
localEntryDeploymentTest method is excluded from the CarbonApplicationDeploymentTestCase. MI rest API is not yet implemented for local entries. 

Please refer: https://github.com/wso2/micro-integrator/issues/366
