### PR TITLE
Exclude template test package

### DIFF
--- a/integration/mediation-tests/tests-other/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/testng.xml
@@ -91,14 +91,6 @@
         </packages>
     </test>
 
-    <test name="Template-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.template"/>
-            <!--todo Uncomment below package after synapse 2.1.7-wso2v35 or higher upgrade-->
-            <package name="org.wso2.carbon.esb.template.endpointTemplate"/>
-        </packages>
-    </test>
-
     <test name="Stats-Test" preserve-order="true" verbose="2">
         <packages>
             <package name="org.wso2.carbon.esb.statistics"/>


### PR DESCRIPTION
## Purpose
Exclude template test package from the testng file. All these tests verify whether the resources are deploying correctly. There are admin APIs already implemented to check is those artifacts are exist and those are verifying under test services. 