### PR TITLE
test: exclude MediationStatEnableTestCase

### DIFF
--- a/integration/mediation-tests/tests-other/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/testng.xml
@@ -99,6 +99,13 @@
         <packages>
             <package name="org.wso2.carbon.esb.mediationstats.*"/>
         </packages>
+        <classes>
+            <class name="org.wso2.carbon.esb.mediationstats.test.MediationStatEnableTestCase">
+                <methods>
+                    <exclude name="*"/>
+                </methods>
+            </class>
+        </classes>
     </test>
     
     <test name="Stats-Test" preserve-order="true" verbose="2">


### PR DESCRIPTION
## Purpose
> Exclude MediationStatEnableTestCase as it contains a call to deploy a service through an admin service, which is not available in the Micro Integrator.