### PR TITLE
fix test: ProxyStatisticsTest

### DIFF
--- a/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/SplitAggregateProxy.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/SplitAggregateProxy.xml
@@ -1,27 +1,56 @@
-<proxy xmlns="http://ws.apache.org/ns/synapse" name="SplitAggregateProxy" transports="https, http" startOnLoad="true" statistics="enable" trace="enable">
-        <target>
-            <inSequence>
-                <iterate xmlns:m0="http://services.samples" attachPath="//m0:getQuote" expression="//m0:getQuote/m0:request" preservePayload="true">
-                    <target>
-                        <sequence>
-                            <send>
-                                <endpoint>
-                                    <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
-                                </endpoint>
-                            </send>
-                        </sequence>
-                    </target>
-                </iterate>
-            </inSequence>
-            <outSequence>
-                <aggregate>
-                    <completeCondition>
-                        <messageCount/>
-                    </completeCondition>
-                    <onComplete xmlns:m0="http://services.samples" expression="//m0:getQuoteResponse">
-                        <send/>
-                    </onComplete>
-                </aggregate>
-            </outSequence>
-        </target>
-    </proxy>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="SplitAggregateProxy" transports="https, http" startOnLoad="true"
+       statistics="enable" trace="enable">
+    <target>
+        <inSequence>
+            <iterate xmlns:m0="http://services.samples" attachPath="//m0:getQuote" expression="//m0:getQuote/m0:request"
+                     preservePayload="true">
+                <target>
+                    <sequence>
+                        <send>
+                            <endpoint>
+                                <address uri="http://localhost:9000/services/SimpleStockQuoteService" />
+                            </endpoint>
+                        </send>
+                    </sequence>
+                </target>
+            </iterate>
+        </inSequence>
+        <outSequence>
+            <aggregate>
+                <completeCondition>
+                    <messageCount />
+                </completeCondition>
+                <onComplete xmlns:m0="http://services.samples" expression="//m0:getQuoteResponse">
+                    <send />
+                </onComplete>
+            </aggregate>
+        </outSequence>
+        <faultSequence>
+            <log level="full">
+                <property name="MESSAGE" value="Executing default &quot;fault&quot; sequence" />
+                <property expression="get-property('ERROR_CODE')" name="ERROR_CODE" />
+                <property expression="get-property('ERROR_MESSAGE')" name="ERROR_MESSAGE" />
+            </log>
+            <drop />
+        </faultSequence>
+    </target>
+</proxy>

--- a/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/StockQuoteProxy.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/StockQuoteProxy.xml
@@ -1,10 +1,38 @@
-<proxy xmlns="http://ws.apache.org/ns/synapse" name="StockQuoteProxy" startOnLoad="true" transports="https, http" statistics="enable" trace="enable">
-        <target>
-            <endpoint>
-                <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
-            </endpoint>
-            <outSequence>
-                <send/>
-            </outSequence>
-        </target>
-    </proxy>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="StockQuoteProxy" startOnLoad="true" transports="https, http"
+       statistics="enable" trace="enable">
+    <target>
+        <endpoint>
+            <address uri="http://localhost:9000/services/SimpleStockQuoteService" />
+        </endpoint>
+        <outSequence>
+            <send />
+        </outSequence>
+        <faultSequence>
+            <log level="full">
+                <property name="MESSAGE" value="Executing default &quot;fault&quot; sequence" />
+                <property expression="get-property('ERROR_CODE')" name="ERROR_CODE" />
+                <property expression="get-property('ERROR_MESSAGE')" name="ERROR_MESSAGE" />
+            </log>
+            <drop />
+        </faultSequence>
+    </target>
+</proxy>

--- a/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/servers/ThriftServer.java
+++ b/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/servers/ThriftServer.java
@@ -18,6 +18,16 @@
 
 package org.wso2.esb.integration.common.utils.servers;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.automation.engine.frameworkutils.FrameworkPathUtil;
@@ -36,16 +46,6 @@ import org.wso2.carbon.databridge.core.exception.StreamDefinitionStoreException;
 import org.wso2.carbon.databridge.core.internal.authentication.AuthenticationHandler;
 import org.wso2.carbon.databridge.receiver.thrift.ThriftDataReceiver;
 import org.wso2.carbon.user.api.UserStoreException;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Matcher;
 
 public class ThriftServer implements Runnable {
     private static Log log = LogFactory.getLog(ThriftServer.class);
@@ -170,7 +170,9 @@ public class ThriftServer implements Runnable {
     }
 
     public void resetPreservedEventList() {
-        preservedEventList.clear();
+        if (preservedEventList != null) {
+            preservedEventList.clear();
+        }
     }
 
     public List<StreamDefinition> loadStreamDefinitions() {
@@ -241,6 +243,14 @@ public class ThriftServer implements Runnable {
             } catch (InterruptedException e) {
                 //ignored
             }
+        }
+    }
+
+    public void waitToReceiveEvents(int maxWaitTime) {
+        try {
+            Thread.sleep(maxWaitTime);
+        } catch (InterruptedException e) {
+            //ignored
         }
     }
 


### PR DESCRIPTION
## Purpose
Fix ProxyStatisticsTest failure as part of the testing hackathon. 

## Approach
"waitToReceiveEvents" method in the ThriftServer.java class in the test-common package has overloaded a method called to sleep the thread for a given period of time to wait until the ESB sends artifact config data to the thrift server. 
