### PR TITLE
Fix test-other module build failure

### DIFF
--- a/integration/mediation-tests/tests-other/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/testng.xml
@@ -102,7 +102,7 @@
         <classes>
             <class name="org.wso2.carbon.esb.mediationstats.test.MediationStatEnableTestCase">
                 <methods>
-                    <exclude name="*"/>
+                    <exclude name=".*"/>
                 </methods>
             </class>
         </classes>


### PR DESCRIPTION


## Purpose
This is to fix java.util.regex.PatternSyntaxException: Dangling meta character '*' near index 0
* error