### PR TITLE
Exclude ESBJAVA4821WSDLProxyServiceDeploymentTestCase

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/testng.xml
@@ -29,6 +29,11 @@
                     <exclude name=".*"/>
                 </methods>
             </class>
+            <class name="org.wso2.carbon.esb.proxyservice.test.wsdlBasedProxy.ESBJAVA4821WSDLProxyServiceDeploymentTestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
             <class name="org.wso2.carbon.esb.proxyservice.test.loggingProxy.PickEndPointFromRegistryTestCase"/>
             <class name="org.wso2.carbon.esb.proxyservice.test.loggingProxy.ProxyServiceEnablingHTTPTestCase"/>
             <class name="org.wso2.carbon.esb.proxyservice.test.loggingProxy.ProxyServiceEndPointThroughURLTestCase"/>


### PR DESCRIPTION
## Purpose
> This test case cannot be executed as hot deployment does not exist in MI. Hence excluding the test case.