### PR TITLE
Fix Circular dependency error

### DIFF
--- a/integration/mediation-tests/tests-sample/src/test/java/org/wso2/carbon/esb/samples/test/miscellaneous/Sample650TestCase.java
+++ b/integration/mediation-tests/tests-sample/src/test/java/org/wso2/carbon/esb/samples/test/miscellaneous/Sample650TestCase.java
@@ -121,7 +121,7 @@ public class Sample650TestCase extends ESBSampleIntegrationTest {
     }
 
     @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
-    @Test(groups = "wso2.esb", description = "Test local entries")
+    @Test(groups = "wso2.esb", description = "Test local entries", enabled = false)
     public void testLocalEntries() throws Exception {
         assertTrue(localEntriesAdminClient.getEntryDataCount() > 1, "local entries not added");
     }
@@ -133,7 +133,7 @@ public class Sample650TestCase extends ESBSampleIntegrationTest {
     }
 
     @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
-    @Test(groups = "wso2.esb", description = "Test tasks")
+    @Test(groups = "wso2.esb", description = "Test tasks", enabled = false)
     public void testTasks() throws Exception {
         assertTrue(getNoOfArtifacts("tasks") == 1, "tasks not added");
     }

--- a/integration/mediation-tests/tests-sample/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-sample/src/test/resources/testng.xml
@@ -9,51 +9,51 @@
         <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestTransformerListener"/>
     </listeners>
 
-    <!--<test name="ESB-Sample-Endpoint-Test" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.samples.test.endpoint.*"/>-->
-        <!--</packages>-->
-    <!--</test>-->
+    <test name="ESB-Sample-Endpoint-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.samples.test.endpoint.*"/>
+        </packages>
+    </test>
 
-    <!--<test name="ESB-Sample-Messaging-Test-1" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.samples.test.messaging.*"/>-->
-        <!--</packages>-->
-        <!--<classes>-->
-            <!--<class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample701TestCase">-->
-                <!--<methods>-->
-                    <!--<exclude name=".*"/>-->
-                <!--</methods>-->
-            <!--</class>-->
-            <!--<class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample702TestCase">-->
-                <!--<methods>-->
-                    <!--<exclude name=".*"/>-->
-                <!--</methods>-->
-            <!--</class>-->
-            <!--<class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample704TestCase">-->
-                <!--<methods>-->
-                    <!--<exclude name=".*"/>-->
-                <!--</methods>-->
-            <!--</class>-->
-            <!--<class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample700TestCase">-->
-                <!--<methods>-->
-                    <!--<exclude name=".*"/>-->
-                <!--</methods>-->
-            <!--</class>-->
-        <!--</classes>-->
-    <!--</test>-->
-    <!--<test name="ESB-Sample-Mediation-Test" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.samples.test.mediation.*"/>-->
-        <!--</packages>-->
-        <!--<classes>-->
-            <!--<class name="org.wso2.carbon.esb.samples.test.mediation.jason.Sample441TestCase">-->
-                <!--<methods>-->
-                    <!--<exclude name=".*"/>-->
-                <!--</methods>-->
-            <!--</class>-->
-        <!--</classes>-->
-    <!--</test>-->
+    <test name="ESB-Sample-Messaging-Test-1" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.samples.test.messaging.*"/>
+        </packages>
+        <classes>
+            <class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample701TestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+            <class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample702TestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+            <class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample704TestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+            <class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample700TestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+    <test name="ESB-Sample-Mediation-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.samples.test.mediation.*"/>
+        </packages>
+        <classes>
+            <class name="org.wso2.carbon.esb.samples.test.mediation.jason.Sample441TestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
     <test name="ESB-Sample-Miscellaneous-Test" preserve-order="true" verbose="2">
         <packages>
             <package name="org.wso2.carbon.esb.samples.test.miscellaneous.*"/>
@@ -71,42 +71,42 @@
             </class>
         </classes>
     </test>
-    <!--<test name="ESB-Sample-Proxy-Test" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.samples.test.proxy.*"/>-->
-        <!--</packages>-->
-        <!--<classes>-->
-            <!--<class name="org.wso2.carbon.esb.samples.test.proxy.Sample153TestCase">-->
-                <!--<methods>-->
-                    <!--<exclude name=".*"/>-->
-                <!--</methods>-->
-            <!--</class>-->
-        <!--</classes>-->
-    <!--</test>-->
-    <!--<test name="ESB-Sample-Transport-Test" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.samples.test.transport.*"/>-->
-        <!--</packages>-->
+    <test name="ESB-Sample-Proxy-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.samples.test.proxy.*"/>
+        </packages>
+        <classes>
+            <class name="org.wso2.carbon.esb.samples.test.proxy.Sample153TestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+    <test name="ESB-Sample-Transport-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.samples.test.transport.*"/>
+        </packages>
 
-        <!--<classes>-->
-            <!--&lt;!&ndash;excluded due to wso2/product-ei/#1234&ndash;&gt;-->
-            <!--<class name="org.wso2.carbon.esb.samples.test.transport.Sample254TestCase">-->
-                <!--<methods>-->
-                    <!--<exclude name=".*"/>-->
-                <!--</methods>-->
-            <!--</class>-->
-        <!--</classes>-->
+        <classes>
+            <!--excluded due to wso2/product-ei/#1234-->
+            <class name="org.wso2.carbon.esb.samples.test.transport.Sample254TestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+        </classes>
 
-    <!--</test>-->
-    <!--<test name="ESB-Sample-StreamingXpath-Test" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.samples.test.streamingxpath.*"/>-->
-        <!--</packages>-->
-    <!--</test>-->
-    <!--<test name="ESB-Sample-PriorityExecutor" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.samples.test.mediation.priorityexecutor.*"/>-->
-        <!--</packages>-->
-    <!--</test>-->
+    </test>
+    <test name="ESB-Sample-StreamingXpath-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.samples.test.streamingxpath.*"/>
+        </packages>
+    </test>
+    <test name="ESB-Sample-PriorityExecutor" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.samples.test.mediation.priorityexecutor.*"/>
+        </packages>
+    </test>
 </suite>
 

--- a/integration/mediation-tests/tests-sample/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-sample/src/test/resources/testng.xml
@@ -9,51 +9,51 @@
         <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestTransformerListener"/>
     </listeners>
 
-    <test name="ESB-Sample-Endpoint-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.samples.test.endpoint.*"/>
-        </packages>
-    </test>
+    <!--<test name="ESB-Sample-Endpoint-Test" preserve-order="true" verbose="2">-->
+        <!--<packages>-->
+            <!--<package name="org.wso2.carbon.esb.samples.test.endpoint.*"/>-->
+        <!--</packages>-->
+    <!--</test>-->
 
-    <test name="ESB-Sample-Messaging-Test-1" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.samples.test.messaging.*"/>
-        </packages>
-        <classes>
-            <class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample701TestCase">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-            <class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample702TestCase">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-            <class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample704TestCase">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-            <class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample700TestCase">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-    <test name="ESB-Sample-Mediation-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.samples.test.mediation.*"/>
-        </packages>
-        <classes>
-            <class name="org.wso2.carbon.esb.samples.test.mediation.jason.Sample441TestCase">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
+    <!--<test name="ESB-Sample-Messaging-Test-1" preserve-order="true" verbose="2">-->
+        <!--<packages>-->
+            <!--<package name="org.wso2.carbon.esb.samples.test.messaging.*"/>-->
+        <!--</packages>-->
+        <!--<classes>-->
+            <!--<class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample701TestCase">-->
+                <!--<methods>-->
+                    <!--<exclude name=".*"/>-->
+                <!--</methods>-->
+            <!--</class>-->
+            <!--<class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample702TestCase">-->
+                <!--<methods>-->
+                    <!--<exclude name=".*"/>-->
+                <!--</methods>-->
+            <!--</class>-->
+            <!--<class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample704TestCase">-->
+                <!--<methods>-->
+                    <!--<exclude name=".*"/>-->
+                <!--</methods>-->
+            <!--</class>-->
+            <!--<class name="org.wso2.carbon.esb.samples.test.messaging.store.Sample700TestCase">-->
+                <!--<methods>-->
+                    <!--<exclude name=".*"/>-->
+                <!--</methods>-->
+            <!--</class>-->
+        <!--</classes>-->
+    <!--</test>-->
+    <!--<test name="ESB-Sample-Mediation-Test" preserve-order="true" verbose="2">-->
+        <!--<packages>-->
+            <!--<package name="org.wso2.carbon.esb.samples.test.mediation.*"/>-->
+        <!--</packages>-->
+        <!--<classes>-->
+            <!--<class name="org.wso2.carbon.esb.samples.test.mediation.jason.Sample441TestCase">-->
+                <!--<methods>-->
+                    <!--<exclude name=".*"/>-->
+                <!--</methods>-->
+            <!--</class>-->
+        <!--</classes>-->
+    <!--</test>-->
     <test name="ESB-Sample-Miscellaneous-Test" preserve-order="true" verbose="2">
         <packages>
             <package name="org.wso2.carbon.esb.samples.test.miscellaneous.*"/>
@@ -69,50 +69,44 @@
                     <exclude name=".*"/>
                 </methods>
             </class>
-            <class name="org.wso2.carbon.esb.samples.test.miscellaneous.Sample650TestCase">
-                <methods>
-                    <exclude name="testLocalEntries"/>
-                    <exclude name="testTasks"/>
-                </methods>
-            </class>
         </classes>
     </test>
-    <test name="ESB-Sample-Proxy-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.samples.test.proxy.*"/>
-        </packages>
-        <classes>
-            <class name="org.wso2.carbon.esb.samples.test.proxy.Sample153TestCase">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-        </classes>
-    </test>
-    <test name="ESB-Sample-Transport-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.samples.test.transport.*"/>
-        </packages>
+    <!--<test name="ESB-Sample-Proxy-Test" preserve-order="true" verbose="2">-->
+        <!--<packages>-->
+            <!--<package name="org.wso2.carbon.esb.samples.test.proxy.*"/>-->
+        <!--</packages>-->
+        <!--<classes>-->
+            <!--<class name="org.wso2.carbon.esb.samples.test.proxy.Sample153TestCase">-->
+                <!--<methods>-->
+                    <!--<exclude name=".*"/>-->
+                <!--</methods>-->
+            <!--</class>-->
+        <!--</classes>-->
+    <!--</test>-->
+    <!--<test name="ESB-Sample-Transport-Test" preserve-order="true" verbose="2">-->
+        <!--<packages>-->
+            <!--<package name="org.wso2.carbon.esb.samples.test.transport.*"/>-->
+        <!--</packages>-->
 
-        <classes>
-            <!--excluded due to wso2/product-ei/#1234-->
-            <class name="org.wso2.carbon.esb.samples.test.transport.Sample254TestCase">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-        </classes>
+        <!--<classes>-->
+            <!--&lt;!&ndash;excluded due to wso2/product-ei/#1234&ndash;&gt;-->
+            <!--<class name="org.wso2.carbon.esb.samples.test.transport.Sample254TestCase">-->
+                <!--<methods>-->
+                    <!--<exclude name=".*"/>-->
+                <!--</methods>-->
+            <!--</class>-->
+        <!--</classes>-->
 
-    </test>
-    <test name="ESB-Sample-StreamingXpath-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.samples.test.streamingxpath.*"/>
-        </packages>
-    </test>
-    <test name="ESB-Sample-PriorityExecutor" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.samples.test.mediation.priorityexecutor.*"/>
-        </packages>
-    </test>
+    <!--</test>-->
+    <!--<test name="ESB-Sample-StreamingXpath-Test" preserve-order="true" verbose="2">-->
+        <!--<packages>-->
+            <!--<package name="org.wso2.carbon.esb.samples.test.streamingxpath.*"/>-->
+        <!--</packages>-->
+    <!--</test>-->
+    <!--<test name="ESB-Sample-PriorityExecutor" preserve-order="true" verbose="2">-->
+        <!--<packages>-->
+            <!--<package name="org.wso2.carbon.esb.samples.test.mediation.priorityexecutor.*"/>-->
+        <!--</packages>-->
+    <!--</test>-->
 </suite>
 


### PR DESCRIPTION


## Purpose
This PR is to fix java.lang.IllegalStateException: Circular dependency: Sample650TestCase.testEndPoints()[pri:0, instance:org.wso2.carbon.esb.samples.test.miscellaneous.Sample650TestCase