### PR TITLE
[Test Hackathon] Fix Intermittent Test failures

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/HTTPHeaderCaseSensitivityTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/HTTPHeaderCaseSensitivityTestCase.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.AxisFault;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -35,7 +34,6 @@ public class HTTPHeaderCaseSensitivityTestCase extends ESBIntegrationTest {
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("httpHeaderTestProxy");
     }
 
     /*Add a http header with name "TEST_HEADER" where all the letters are in uppercase.*/
@@ -89,10 +87,5 @@ public class HTTPHeaderCaseSensitivityTestCase extends ESBIntegrationTest {
                 .getFirstChildWithName(new QName("http://services.samples/xsd", "symbol"));
 
         assertEquals(symbolElement.getText(), "mixed", "Fault, invalid response");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/NullValueTransportHeaderTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/NullValueTransportHeaderTestCase.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axis2.AxisFault;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.exceptions.AutomationFrameworkException;
@@ -53,10 +52,5 @@ public class NullValueTransportHeaderTestCase extends ESBIntegrationTest {
                         "{\"test\" : \"nullHeaderVal\"}", requestHeader);
         Assert.assertTrue(response.getData().contains("{\"company\" : \"wso2\"}"),
                 "Expected response was not" + "received. Got " + response.getData());
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationAxis2ClientScopeTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationAxis2ClientScopeTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -82,10 +81,5 @@ public class PropertyIntegrationAxis2ClientScopeTestCase extends ESBIntegrationT
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyShortAxis2ClientTestProxy"), null,
                         "Random Symbol");
         assertTrue(response.toString().contains("12"), "Short Property Not Set in the Axis2-client scope!");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationAxis2ScopeTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationAxis2ScopeTestCase.java
@@ -99,9 +99,4 @@ public class PropertyIntegrationAxis2ScopeTestCase extends ESBIntegrationTest {
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyOMAxis2TestProxy"), null, "Random Symbol");
         assertTrue(response.toString().contains("OMMMMM"), "OM Property Not Set in the Axis2 scope!");
     }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        cleanup();
-    }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationDISABLE_CHUNKING_PropertyTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationDISABLE_CHUNKING_PropertyTest.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.esb.mediator.test.property;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -38,7 +37,6 @@ public class PropertyIntegrationDISABLE_CHUNKING_PropertyTest extends ESBIntegra
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/DISABLE_CHUNKING.xml");
         wireServer = new WireMonitorServer(8993);
     }
 
@@ -56,10 +54,5 @@ public class PropertyIntegrationDISABLE_CHUNKING_PropertyTest extends ESBIntegra
         String response = wireServer.getCapturedMessage();
         assertTrue(response.contains("Content-Length"), "Content-Length not found in out going message");
 
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationDefaultScopeTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationDefaultScopeTestCase.java
@@ -19,7 +19,6 @@ package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -97,10 +96,5 @@ public class PropertyIntegrationDefaultScopeTestCase extends ESBIntegrationTest 
                 response.getFirstElement().getFirstChildWithName(new QName("http://services.samples/xsd", "name"))
                         .toString().contains("12 Company"), "Short Property not set in the Default scope!");
 
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationDisableAddressingForOutMessagesTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationDisableAddressingForOutMessagesTestCase.java
@@ -43,7 +43,6 @@ public class PropertyIntegrationDisableAddressingForOutMessagesTestCase extends 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("disableAddressingTestProxy");
         axisOperationClient = new AxisOperationClient();
 
     }
@@ -77,7 +76,6 @@ public class PropertyIntegrationDisableAddressingForOutMessagesTestCase extends 
 
     @AfterClass(alwaysRun = true)
     public void stop() throws Exception {
-        cleanup();
         axisOperationClient.destroy();
         axisOperationClient = null;
     }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationFORCE_HTTP_10TestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationFORCE_HTTP_10TestCase.java
@@ -46,14 +46,10 @@ public class PropertyIntegrationFORCE_HTTP_10TestCase extends ESBIntegrationTest
     @AfterClass(alwaysRun = true)
     public void stop() throws Exception {
         tcpMonListener.stop();
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Test-with FORCE_HTTP_1.0 Property enabled false " + "scenario")
     public void testWithForceHTTP10EnabledFalseTest() throws Exception {
-
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/FORCE_HTTP_1.0_DISABLED.xml");
-
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("FORCE_HTTP_1_0_FalseTestProxy"), null, "WSO2");
 
@@ -67,9 +63,6 @@ public class PropertyIntegrationFORCE_HTTP_10TestCase extends ESBIntegrationTest
 
     @Test(groups = "wso2.esb", description = "Test-with FORCE_HTTP_1.0 Property enabled true scenario", dependsOnMethods = "testWithForceHTTP10EnabledFalseTest")
     public void testWithForceHTTP10EnabledTrueTest() throws Exception {
-
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/FORCE_HTTP_1.0_ENABLED.xml");
-
         tcpMonListener.clear();
 
         Thread.sleep(3000);

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationForceErrorOnSOAPFaultPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationForceErrorOnSOAPFaultPropertyTestCase.java
@@ -36,17 +36,10 @@ public class PropertyIntegrationForceErrorOnSOAPFaultPropertyTestCase extends ES
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/FORCE_ERROR_ON_SOAP_FAULT.xml");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Test-Without No_ENTITY_BODY Property", enabled = false)
     public void testWithoutOutOnlyPropertyTest() throws Exception {
-
         SimpleHttpClient httpClient = new SimpleHttpClient();
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Content-Type", "text/xml");

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationForceHttpContentLengthPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationForceHttpContentLengthPropertyTestCase.java
@@ -22,7 +22,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -46,16 +45,8 @@ public class PropertyIntegrationForceHttpContentLengthPropertyTestCase extends E
         wireServer = new WireMonitorServer(8994);
     }
 
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
-    }
-
     @Test(groups = "wso2.esb", description = "Tests when both properties are enabled")
     public void testWithEnableFORCE_HTTP_CONTENT_LENGTHAndCOPY_CONTENT_LENGTH_FROM_INCOMINGTest() throws Exception {
-
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/EnableFORCE_HTTP_CONTENT_LENGTH.xml");
-
         wireServer.start();
 
         HttpClient httpclient = new DefaultHttpClient();
@@ -82,10 +73,6 @@ public class PropertyIntegrationForceHttpContentLengthPropertyTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Tests when both properties are disabled", dependsOnMethods = "testWithEnableFORCE_HTTP_CONTENT_LENGTHAndCOPY_CONTENT_LENGTH_FROM_INCOMINGTest")
     public void testWithDisableFORCE_HTTP_CONTENT_LENGTHAndCOPY_CONTENT_LENGTH_FROM_INCOMINGTest() throws Exception {
-
-        loadESBConfigurationFromClasspath(
-                "/artifacts/ESB/mediatorconfig/property/DisableFORCE_HTTP_CONTENT_LENGTH.xml");
-
         wireServer.start();
 
         HttpClient httpclient = new DefaultHttpClient();

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationForceSCAcceptedPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationForceSCAcceptedPropertyTestCase.java
@@ -22,7 +22,6 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.FileRequestEntity;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.RequestEntity;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.frameworkutils.FrameworkPathUtil;
@@ -42,15 +41,8 @@ public class PropertyIntegrationForceSCAcceptedPropertyTestCase extends ESBInteg
         super.init();
     }
 
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
-    }
-
     @Test(groups = "wso2.esb", description = "Testing functionality of FORCE_SC_ACCEPTED " + "- Enabled False")
     public void testFORCE_SC_ACCEPTEDPropertyEnabledFalseScenario() throws Exception {
-        verifyProxyServiceExistence("FORCE_SC_ACCEPTED_FalseTestProxy");
-
         int responseStatus = 0;
 
         String strXMLFilename =
@@ -78,8 +70,6 @@ public class PropertyIntegrationForceSCAcceptedPropertyTestCase extends ESBInteg
     @Test(groups = "wso2.esb", description = "Testing functionality of FORCE_SC_ACCEPTED " + "Enabled True  - "
             + "Client should receive 202 message", dependsOnMethods = "testFORCE_SC_ACCEPTEDPropertyEnabledFalseScenario")
     public void testWithFORCE_SC_ACCEPTEDPropertyEnabledTrueScenario() throws Exception {
-        verifyProxyServiceExistence("FORCE_SC_ACCEPTED_TrueTestProxy");
-
         int responseStatus = 0;
 
         String strXMLFilename =

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationHTTP_SCTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationHTTP_SCTestCase.java
@@ -22,7 +22,6 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.FileRequestEntity;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.RequestEntity;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.frameworkutils.FrameworkPathUtil;
@@ -40,13 +39,6 @@ public class PropertyIntegrationHTTP_SCTestCase extends ESBIntegrationTest {
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("HTTP_SCTestProxy");
-
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Getting HTTP status code number ")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationMessageFormatPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationMessageFormatPropertyTestCase.java
@@ -21,7 +21,6 @@ import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.OMNamespace;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.test.utils.http.client.HttpClientUtil;
@@ -42,13 +41,7 @@ public class PropertyIntegrationMessageFormatPropertyTestCase extends ESBIntegra
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("MESSAGE_FORMAT_TestProxy");
         clientUtil = new HttpClientUtil();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Testing with POX message format")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationNO_ENTITY_BODY_PropertyTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationNO_ENTITY_BODY_PropertyTest.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.esb.mediator.test.property;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMException;
 import org.apache.axiom.om.util.AXIOMUtil;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -66,10 +65,5 @@ public class PropertyIntegrationNO_ENTITY_BODY_PropertyTest extends ESBIntegrati
     public void testWithNoEntityBodyPropertTest() throws Exception {
         client.getWithContentType(getProxyServiceURLHttp("Axis2ProxyService2") + "/echoString", "in=IBM",
                 MediaType.APPLICATION_FORM_URLENCODED);
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationNO_KEEPALIVE_PropertyTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationNO_KEEPALIVE_PropertyTest.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.esb.mediator.test.property;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -55,10 +54,5 @@ public class PropertyIntegrationNO_KEEPALIVE_PropertyTest extends ESBIntegration
         String response = wireServer.getCapturedMessage();
         assertTrue(response.contains("Connection: Close"), "Property Not Set");
 
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationOUT_ONLYPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationOUT_ONLYPropertyTestCase.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.AxisFault;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -37,15 +36,8 @@ public class PropertyIntegrationOUT_ONLYPropertyTestCase extends ESBIntegrationT
         super.init();
     }
 
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
-    }
-
     @Test(groups = "wso2.esb", description = "Tests when Out_Only property is disabled")
     public void testOutOnlyPropertyEnabledFalse() throws Exception {
-        verifyProxyServiceExistence("OUT_ONLY_FalseTestProxy");
-
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("OUT_ONLY_FalseTestProxy"), null, "WSO2");
 
@@ -55,8 +47,6 @@ public class PropertyIntegrationOUT_ONLYPropertyTestCase extends ESBIntegrationT
 
     @Test(groups = "wso2.esb", description = "Tests when Out_Only property is enabled", dependsOnMethods = "testOutOnlyPropertyEnabledFalse", expectedExceptions = AxisFault.class)
     public void testOutOnlyPropertyEnabledTrue() throws Exception {
-        verifyProxyServiceExistence("OUT_ONLY_TrueTestProxy");
-
         axis2Client.sendSimpleStockQuoteRequest(getProxyServiceURLHttp("OUT_ONLY_TrueTestProxy"), null, "WSO2");
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationOperationNamePropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationOperationNamePropertyTestCase.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.test.utils.http.client.HttpClientUtil;
@@ -37,13 +36,7 @@ public class PropertyIntegrationOperationNamePropertyTestCase extends ESBIntegra
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("propertyOperationNameTestProxy");
         clientUtil = new HttpClientUtil();
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Testing functionality of OperationName Property")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationOperationScopeRemovePropertiesTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationOperationScopeRemovePropertiesTestCase.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.CarbonLogReader;
@@ -38,11 +39,12 @@ public class PropertyIntegrationOperationScopeRemovePropertiesTestCase extends E
     public void setEnvironment() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type Integer (operation scope)")
     public void testIntVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyIntOperationRemoveTestProxy"), null,
                         "Random Symbol");
@@ -52,7 +54,7 @@ public class PropertyIntegrationOperationScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type String (operation scope)")
     public void testStringVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyStringOperationRemoveTestProxy"), null,
                         "Random Symbol");
@@ -63,7 +65,7 @@ public class PropertyIntegrationOperationScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type Float (operation scope)")
     public void testFloatVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyFloatOperationRemoveTestProxy"), null,
                         "Random Symbol");
@@ -73,7 +75,7 @@ public class PropertyIntegrationOperationScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type Long (operation scope)")
     public void testLongVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyLongOperationRemoveTestProxy"), null,
                         "Random Symbol");
@@ -83,7 +85,7 @@ public class PropertyIntegrationOperationScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type Short (operation scope)")
     public void testShortVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyShortOperationRemoveTestProxy"), null,
                         "Random Symbol");
@@ -93,12 +95,17 @@ public class PropertyIntegrationOperationScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type OM (operation scope)")
     public void testOMVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyOMOperationRemoveTestProxy"), null,
                         "Random Symbol");
         assertTrue(response.toString().contains("Property Set and Removed"), "Proxy Invocation Failed!");
         assertTrue(isMatchFound("symbol = OMMMMM"), "OM Property Not Either Set or Removed in the Axis2 scope!!");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        carbonLogReader.stop();
     }
 
     /**
@@ -108,7 +115,6 @@ public class PropertyIntegrationOperationScopeRemovePropertiesTestCase extends E
     private boolean isMatchFound(String matchStr) throws InterruptedException {
         boolean isSet = carbonLogReader.checkForLog(matchStr, DEFAULT_TIMEOUT) &&
                 carbonLogReader.checkForLog("symbol = null", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
         return isSet;
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationOperationScopeTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationOperationScopeTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -82,10 +81,5 @@ public class PropertyIntegrationOperationScopeTestCase extends ESBIntegrationTes
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyShortOperationTestProxy"), null,
                         "Random Symbol");
         assertTrue(response.toString().contains("12"), "Short Property Not Set in the Operation scope!");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationPOST_TO_URI_PropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationPOST_TO_URI_PropertyTestCase.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.esb.mediator.test.property;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -55,10 +54,4 @@ public class PropertyIntegrationPOST_TO_URI_PropertyTestCase extends ESBIntegrat
         String response = wireServer.getCapturedMessage();
         assertTrue(response.contains("POST http://localhost:8992"), "Faulty Response");
     }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        cleanup();
-    }
-
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationPropertyInTransportScopeTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationPropertyInTransportScopeTest.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.esb.mediator.test.property;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -54,10 +53,5 @@ public class PropertyIntegrationPropertyInTransportScopeTest extends ESBIntegrat
         }
         String response = wireServer.getCapturedMessage();
         assertTrue(response.contains("TransportProperty: testProperty"), "Property not set");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationRESTURLPostFixTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationRESTURLPostFixTestCase.java
@@ -19,7 +19,6 @@ package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -63,10 +62,5 @@ public class PropertyIntegrationRESTURLPostFixTestCase extends ESBIntegrationTes
         assertEquals(response.getFirstElement().getText(), "charitha", "Text does not match");
         //TODO: Checking the following log message in ESB log."rest-url-value = /echoString?s=wso2"
 
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationResponseTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationResponseTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -36,13 +35,6 @@ public class PropertyIntegrationResponseTestCase extends ESBIntegrationTest {
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("RESPONSE_PropertyTestProxy");
-
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = { "wso2.esb" }, description = "RESPONSETEnabledTrue scenario")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationSystemDatePropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationSystemDatePropertyTestCase.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -39,13 +38,6 @@ public class PropertyIntegrationSystemDatePropertyTestCase extends ESBIntegratio
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("SYSTEM_DATE_TestProxy");
-
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Test return of the current date")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationSystemTimePropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationSystemTimePropertyTestCase.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -41,13 +40,6 @@ public class PropertyIntegrationSystemTimePropertyTestCase extends ESBIntegratio
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("SYSTEM_TIME_TestProxy");
-
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Test return of the current time in milliseconds")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTRANSPORT_HEADERSPropertyTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTRANSPORT_HEADERSPropertyTest.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.esb.mediator.test.property;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -38,7 +37,6 @@ public class PropertyIntegrationTRANSPORT_HEADERSPropertyTest extends ESBIntegra
     public void setEnvironment() throws Exception {
         init();
         wireServer = new WireMonitorServer(8996);
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/TRANSPORT_HEADERS.xml");
     }
 
     @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
@@ -55,10 +53,5 @@ public class PropertyIntegrationTRANSPORT_HEADERSPropertyTest extends ESBIntegra
         }
         String response = wireServer.getCapturedMessage();
         assertFalse(response.contains("Test-TRANSPORT_HEADERS: test"), "Property not set");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTestCase.java
@@ -19,12 +19,10 @@ package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
-import java.io.File;
 import javax.xml.namespace.QName;
 
 public class PropertyIntegrationTestCase extends ESBIntegrationTest {
@@ -32,14 +30,6 @@ public class PropertyIntegrationTestCase extends ESBIntegrationTest {
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        loadESBConfigurationFromClasspath(
-                File.separator + "artifacts" + File.separator + "ESB" + File.separator + "synapseconfig"
-                        + File.separator + "propertyMediatorConfig" + File.separator + "synapse.xml");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Set a new property value (static text value) and retrieve it using get-property(property-name) Xpath function  (in default scope)")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTransportInNameTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTransportInNameTestCase.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -34,13 +33,6 @@ public class PropertyIntegrationTransportInNameTestCase extends ESBIntegrationTe
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        verifyProxyServiceExistence("TRANSPORT_IN_NAME_TestProxy");
-
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Test Property -  read incoming transport name")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTransportScopeRemovePropertiesTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTransportScopeRemovePropertiesTestCase.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.CarbonLogReader;
@@ -37,11 +38,12 @@ public class PropertyIntegrationTransportScopeRemovePropertiesTestCase extends E
     public void setEnvironment() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type Integer (transport scope)")
     public void testIntVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyIntTransportRemoveTestProxy"), null,
                         "Random Symbol");
@@ -51,7 +53,7 @@ public class PropertyIntegrationTransportScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type String (transport scope)")
     public void testStringVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyStringTransportRemoveTestProxy"), null,
                         "Random Symbol");
@@ -62,7 +64,7 @@ public class PropertyIntegrationTransportScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type Float (transport scope)")
     public void testFloatVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyFloatTransportRemoveTestProxy"), null,
                         "Random Symbol");
@@ -72,7 +74,7 @@ public class PropertyIntegrationTransportScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type Long (transport scope)")
     public void testLongVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyLongTransportRemoveTestProxy"), null,
                         "Random Symbol");
@@ -82,7 +84,7 @@ public class PropertyIntegrationTransportScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type Short (transport scope)")
     public void testShortVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyShortTransportRemoveTestProxy"), null,
                         "Random Symbol");
@@ -92,12 +94,17 @@ public class PropertyIntegrationTransportScopeRemovePropertiesTestCase extends E
 
     @Test(groups = "wso2.esb", description = "Remove action as \"value\" and type OM (transport scope)")
     public void testOMVal() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyOMTransportRemoveTestProxy"), null,
                         "Random Symbol");
         assertTrue(response.toString().contains("Property Set and Removed"), "Proxy Invocation Failed!");
         assertTrue(isMatchFound("symbol = OMMMMM"), "OM Property Not Either Set or Removed in the Axis2 scope!!");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        carbonLogReader.stop();
     }
 
     /**
@@ -107,7 +114,6 @@ public class PropertyIntegrationTransportScopeRemovePropertiesTestCase extends E
     private boolean isMatchFound(String matchStr) throws InterruptedException {
         boolean isSet = carbonLogReader.checkForLog(matchStr, DEFAULT_TIMEOUT) &&
                 carbonLogReader.checkForLog("symbol = null", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
         return isSet;
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTransportScopeTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTransportScopeTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -83,10 +82,5 @@ public class PropertyIntegrationTransportScopeTestCase extends ESBIntegrationTes
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("propertyShortTransportTestProxy"), null,
                         "Random Symbol");
         assertTrue(response.toString().contains("12"), "Short Property Not Set in the Transport scope!");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXPathBodyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXPathBodyTestCase.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
@@ -36,14 +35,8 @@ public class PropertyIntegrationXPathBodyTestCase extends ESBIntegrationTest {
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/Synapse_XPath_ Variables_Body.xml");
         logViewer = new LogViewerClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
 
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = "wso2.esb", description = "Tests when connections exist")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXPathExtensionTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXPathExtensionTestCase.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
@@ -38,13 +37,7 @@ public class PropertyIntegrationXPathExtensionTestCase extends ESBIntegrationTes
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/XPATHEXTENSION.xml");
         logViewer = new LogViewerClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = { "wso2.esb" }, description = "RESPONSETEnabledTrue scenario")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXPathTrpPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXPathTrpPropertyTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
@@ -38,14 +37,8 @@ public class PropertyIntegrationXPathTrpPropertyTestCase extends ESBIntegrationT
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/XPATHTRP.xml");
         logViewer = new LogViewerClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
 
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Get transport header named " + "Content-Type of the current message")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXpathAxis2PropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXpathAxis2PropertyTestCase.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.esb.mediator.test.property;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
@@ -40,14 +39,7 @@ public class PropertyIntegrationXpathAxis2PropertyTestCase extends ESBIntegratio
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         init();
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/XPATHAXIS2.xml");
         logViewer = new LogViewerClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
-
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test getting the property value at the axis2 scope")

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXpathCtxPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXpathCtxPropertyTestCase.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
@@ -41,14 +40,7 @@ public class PropertyIntegrationXpathCtxPropertyTestCase extends ESBIntegrationT
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        loadESBConfigurationFromClasspath("/artifacts/ESB/mediatorconfig/property/XPATHCTX.xml");
         logViewer = new LogViewerClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
-
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Endpoint is a non-existent endpoint reference key , "

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXpathURLPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationXpathURLPropertyTestCase.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.esb.mediator.test.property;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
@@ -39,13 +40,12 @@ public class PropertyIntegrationXpathURLPropertyTestCase extends ESBIntegrationT
     public void setEnvironment() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
-
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test getting the  URI element of a request URL")
     public void testXpathURLProperty() throws Exception {
         boolean isUri = false;
-        carbonLogReader.start();
         HttpRequestUtil.sendGetRequest(getApiInvocationURL("XpathURLPropertyApi") + "/edit?a=wso2&b=2.4", null);
 
         try {
@@ -57,7 +57,11 @@ public class PropertyIntegrationXpathURLPropertyTestCase extends ESBIntegrationT
         String msg = "SYMBOL = wso2, VALUE = 2.4";
         // after sending the message reading the log file
         isUri = carbonLogReader.checkForLog(msg, DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
         assertTrue(isUri, "Message expected (SYMBOL = wso2, VALUE = 2.4) Not found");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/propertyIntegrationAxis2ClientRemovePropertiesTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/propertyIntegrationAxis2ClientRemovePropertiesTestCase.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.CarbonLogReader;
@@ -49,10 +50,14 @@ public class propertyIntegrationAxis2ClientRemovePropertiesTestCase extends ESBI
         assertTrue(response.toString().contains("Property Set and Removed"), "Proxy Invocation Failed!");
         assertTrue(isMatchFound("symbol = TestValue") && isMatchFound("symbol = null"),
                 "Integer Property Not Either Set or Removed in the Axis2 Client scope!!");
-        carbonLogReader.stop();
     }
 
     private boolean isMatchFound(String matchStr) throws InterruptedException {
         return carbonLogReader.checkForLog(matchStr, DEFAULT_TIMEOUT);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/SetRemovePropertiesWithNashornJsTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/SetRemovePropertiesWithNashornJsTestCase.java
@@ -38,19 +38,19 @@ public class SetRemovePropertiesWithNashornJsTestCase extends ESBIntegrationTest
     public void setEnvironment() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
-        super.cleanup();
+        carbonLogReader.stop();
     }
 
     @Test(groups = "wso2.esb", description = "Set a property with axis2 scope in script mediator")
     public void testSetPropertyWithAxis2ScopeInScript() throws Exception {
-
+        carbonLogReader.clearLogs();
         boolean propertySet;
         boolean propertyRemoved;
-        carbonLogReader.start();
         OMElement response = axis2Client
                 .sendCustomQuoteRequest(getProxyServiceURLHttp("setRemovePropertiesWithNashornJsTestProxy"), null,
                         "inlineTest");
@@ -63,10 +63,9 @@ public class SetRemovePropertiesWithNashornJsTestCase extends ESBIntegrationTest
 
     @Test(groups = "wso2.esb", description = "Set a property with transport scope in script mediator")
     public void testSetPropertyWithTransportScopeInScript() throws Exception {
-
+        carbonLogReader.clearLogs();
         boolean propertySet;
         boolean propertyRemoved;
-        carbonLogReader.start();
         OMElement response = axis2Client
                 .sendCustomQuoteRequest(getProxyServiceURLHttp("setRemovePropertiesWithNashornJsTestProxy"), null,
                         "inlineTest");
@@ -79,10 +78,9 @@ public class SetRemovePropertiesWithNashornJsTestCase extends ESBIntegrationTest
 
     @Test(groups = "wso2.esb", description = "Set a property with operation scope in script mediator")
     public void testSetPropertyWithOperationScopeInScript() throws Exception {
-
+        carbonLogReader.clearLogs();
         boolean propertySet;
         boolean propertyRemoved;
-        carbonLogReader.start();
         OMElement response = axis2Client
                 .sendCustomQuoteRequest(getProxyServiceURLHttp("setRemovePropertiesWithNashornJsTestProxy"), null,
                         "inlineTest");
@@ -105,7 +103,6 @@ public class SetRemovePropertiesWithNashornJsTestCase extends ESBIntegrationTest
         if (carbonLogReader.checkForLog(property, DEFAULT_TIMEOUT)) {
             containsProperty = true;
         }
-        carbonLogReader.stop();
         return containsProperty;
     }
 }


### PR DESCRIPTION
## Purpose
 Fix Intermittent Test failures as part of Test Hackathon
-Remove obosolete methods
-Start the logReader thread @BeforeClass and stop @Afterclass (Reduce thread creation overhead)