### PR TITLE
[Test Hackathon] Fix Intermittent Test failures

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/aggregate/AggregateEmptyJsonPayloadTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/aggregate/AggregateEmptyJsonPayloadTestCase.java
@@ -35,11 +35,13 @@ import static org.wso2.esb.integration.common.utils.Utils.assertIfSystemLogConta
  */
 public class AggregateEmptyJsonPayloadTestCase extends ESBIntegrationTest {
 
+    CarbonLogReader logReader = new CarbonLogReader();
     private static final String PROXY_NAME = "aggregateEmptyJsonPayloadTestProxy";
 
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
         super.init();
+        logReader.start();
     }
 
     /**
@@ -64,11 +66,10 @@ public class AggregateEmptyJsonPayloadTestCase extends ESBIntegrationTest {
         requestHeader.put("Content-type", "text/xml");
         requestHeader.put("SOAPAction", "urn:mediate");
         requestHeader.put("Accept", "application/json");
-        CarbonLogReader logReader = new CarbonLogReader();
-        logReader.start();
         HttpRequestUtil.doPost(new URL(getProxyServiceURLHttp(PROXY_NAME)), inputPayload, requestHeader);
 
         Assert.assertTrue(assertIfSystemLogContains(logReader, expectedOutput),
                 "No content 204 responses are not properly aggregated at the aggregate mediator.");
+        logReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/callOut/CalloutJMSHeadersTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/callOut/CalloutJMSHeadersTestCase.java
@@ -30,29 +30,29 @@ import org.wso2.esb.integration.common.utils.clients.axis2client.AxisServiceClie
 import static org.testng.Assert.assertTrue;
 
 public class CalloutJMSHeadersTestCase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
         super.init();
         esbUtils.isProxyServiceExist(contextUrls.getBackEndUrl(), sessionCookie, "JMCalloutClientProxy");
         esbUtils.isProxyServiceExist(contextUrls.getBackEndUrl(), sessionCookie, "JMSCalloutBEProxy");
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Callout JMS headers test case")
     public void testCalloutJMSHeaders() throws Exception {
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
         AxisServiceClient client = new AxisServiceClient();
         String payload = "<payload/>";
         AXIOMUtil.stringToOM(payload);
-        carbonLogReader.start();
+
         client.sendRobust(AXIOMUtil.stringToOM(payload), getProxyServiceURLHttp("JMCalloutClientProxy"), "urn:mediate");
         boolean logFound = Utils.assertIfSystemLogContains(carbonLogReader, "RequestHeaderVal");
         assertTrue(logFound, "Required log entry not found");
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
-        super.cleanup();
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/callTemplate/CallTemplateIntegrationParamsWithValuesTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/callTemplate/CallTemplateIntegrationParamsWithValuesTestCase.java
@@ -32,13 +32,13 @@ public class CallTemplateIntegrationParamsWithValuesTestCase extends ESBIntegrat
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
+        carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Call Template Mediator Sample Parameters with"
             + " values assigned test")
     public void testTemplatesParameter() throws Exception {
-        carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp(proxyServiceName), null, "IBM");
         boolean requestLog = false;

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationAxis2ScopeTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationAxis2ScopeTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.property;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/AddHeadersUsingNashornJsTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/AddHeadersUsingNashornJsTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
@@ -81,10 +80,5 @@ public class AddHeadersUsingNashornJsTestCase extends ESBIntegrationTest {
         Assert.assertTrue((response.getData().contains("OM")),
                 "Response does not contain the keyword \"OM\". " + "Response: " + response.getData());
 
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/CustomIntegrationWithJSStoredInRegistryTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/CustomIntegrationWithJSStoredInRegistryTestCase.java
@@ -58,11 +58,6 @@ public class CustomIntegrationWithJSStoredInRegistryTestCase extends ESBIntegrat
 
     }
 
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
-
     private void enableDebugLogging() throws Exception {
         LoggingAdminClient logAdminClient = new LoggingAdminClient(contextUrls.getBackEndUrl(), getSessionCookie());
         logAdminClient.updateLoggerData("org.apache.synapse", "DEBUG", true, false);

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/GroovyScriptSupportTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/GroovyScriptSupportTestCase.java
@@ -70,11 +70,4 @@ public class GroovyScriptSupportTestCase extends ESBIntegrationTest {
 
         assertEquals(actualResult, expectedResult, "Fault: value 'symbol' mismatched");
     }
-
-    @AfterClass(alwaysRun = true)
-    @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
-
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InlineNashornJsFunctionsForBothInAndOutTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InlineNashornJsFunctionsForBothInAndOutTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -52,10 +51,4 @@ public class InlineNashornJsFunctionsForBothInAndOutTestCase extends ESBIntegrat
         assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")),
                 "Fault response null localpart");
     }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
-
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InlinedFunctionTest.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InlinedFunctionTest.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -49,10 +48,5 @@ public class InlinedFunctionTest extends ESBIntegrationTest {
                 "Price", "Local Name does not match");
         assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")).getText(),
                 "Text does not exist");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InvalidFunctionTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InvalidFunctionTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axis2.AxisFault;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -36,10 +35,4 @@ public class InvalidFunctionTestCase extends ESBIntegrationTest {
         axis2Client.sendCustomQuoteRequest(
                 getProxyServiceURLHttp("scriptMediatorJSStoredInRegistryInvalidFunctionTestProxy"), null, "WSO2");
     }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
-
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InvokeScriptWithDynamicKeyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InvokeScriptWithDynamicKeyTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -52,10 +51,5 @@ public class InvokeScriptWithDynamicKeyTestCase extends ESBIntegrationTest {
 
         assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")),
                 "Fault response null localpart");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InvokingInvalidFunctionInNashornJsTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/InvokingInvalidFunctionInNashornJsTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axis2.AxisFault;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -39,10 +38,4 @@ public class InvokingInvalidFunctionInNashornJsTestCase extends ESBIntegrationTe
         axis2Client.sendCustomQuoteRequest(getProxyServiceURLHttp("nashornJsInvokeInvalidFunctionTestProxy"), null,
                 "Invalid");
     }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
-
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/JsonSupportByScriptMediatorTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/JsonSupportByScriptMediatorTestCase.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
@@ -42,7 +43,7 @@ public class JsonSupportByScriptMediatorTestCase extends ESBIntegrationTest {
     protected void init() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
-
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Sending a JSON message Via REST and manipulate with JS")
@@ -64,7 +65,7 @@ public class JsonSupportByScriptMediatorTestCase extends ESBIntegrationTest {
 
     @Test(groups = { "wso2.esb" }, description = "Serialize JSON payload with JS")
     public void testSerializingJson() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         Map<String, String> httpHeaders = new HashMap<>();
         httpHeaders.put("Content-Type", "application/json");
         String payload = "{\n" + "\"name\": \"John Doe\",\n" + "\"dob\": \"1990-03-19\",\n" + "\"ssn\": " + "\"234-23"
@@ -115,6 +116,11 @@ public class JsonSupportByScriptMediatorTestCase extends ESBIntegrationTest {
 
     }
 
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        carbonLogReader.stop();
+    }
+
     /**
      * This method check whether given property contains in the logs.
      *
@@ -123,7 +129,6 @@ public class JsonSupportByScriptMediatorTestCase extends ESBIntegrationTest {
      */
     private boolean isPropertyContainedInLog(String property) throws InterruptedException {
         boolean containsProperty = carbonLogReader.checkForLog(property, DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
         return containsProperty;
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/LocalEntryFunctionTestForNashornTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/LocalEntryFunctionTestForNashornTestCase.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -54,10 +53,5 @@ public class LocalEntryFunctionTestForNashornTestCase extends ESBIntegrationTest
                 "Price", "Local Name does not match");
         assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")).getText(),
                 "Text does not exist");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        super.cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/MediationWithNashornJsScriptStoredInRegistryTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/MediationWithNashornJsScriptStoredInRegistryTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -54,10 +53,4 @@ public class MediationWithNashornJsScriptStoredInRegistryTestCase extends ESBInt
         assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")),
                 "Fault " + "response null localpart");
     }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
-
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/NativeJsonSupportByNashornJsTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/NativeJsonSupportByNashornJsTestCase.java
@@ -43,6 +43,7 @@ public class NativeJsonSupportByNashornJsTestCase extends ESBIntegrationTest {
     protected void init() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Sending a JSON message Via REST and manipulate with NashornJS")
@@ -64,7 +65,7 @@ public class NativeJsonSupportByNashornJsTestCase extends ESBIntegrationTest {
 
     @Test(groups = { "wso2.esb" }, description = "Serialize JSON payload with NashornJS")
     public void testSerializingJson() throws Exception {
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         Map<String, String> httpHeaders = new HashMap<>();
         httpHeaders.put("Content-Type", "application/json");
         String payload = "{\n" + "\"name\": \"John Doe\",\n" + "\"dob\": \"1990-03-19\",\n" + "\"ssn\": " + "\"234-23"
@@ -125,12 +126,11 @@ public class NativeJsonSupportByNashornJsTestCase extends ESBIntegrationTest {
         if (carbonLogReader.checkForLog(property, DEFAULT_TIMEOUT)) {
             containsProperty = true;
         }
-        carbonLogReader.stop();
         return containsProperty;
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
-        super.cleanup();
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/RubyScriptSupportTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/RubyScriptSupportTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -76,12 +75,6 @@ public class RubyScriptSupportTestCase extends ESBIntegrationTest {
         assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")),
                 "Fault response null localpart");
     }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
-
 
     private void enableDebugLogging() throws Exception {
         LoggingAdminClient logAdminClient = new LoggingAdminClient(contextUrls.getBackEndUrl(), getSessionCookie());

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/ScriptIntegrationInvokeJsScriptFunction.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/ScriptIntegrationInvokeJsScriptFunction.java
@@ -57,10 +57,4 @@ public class ScriptIntegrationInvokeJsScriptFunction extends ESBIntegrationTest 
         assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")),
                 "Fault response null localpart");
     }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
-
-    }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/ScriptIntegrationRetrieveScriptFromConfig.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/ScriptIntegrationRetrieveScriptFromConfig.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -53,10 +52,5 @@ public class ScriptIntegrationRetrieveScriptFromConfig extends ESBIntegrationTes
 
         assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")),
                 "Fault response null localpart");
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void close() throws Exception {
-        super.cleanup();
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/ScriptIntegrationToGenerateFaultTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/ScriptIntegrationToGenerateFaultTestCase.java
@@ -98,7 +98,6 @@ public class ScriptIntegrationToGenerateFaultTestCase extends ESBIntegrationTest
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
-        super.cleanup();
         clearUploadedResource();
     }
 

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/ScriptWithIncludeOptionTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/ScriptWithIncludeOptionTestCase.java
@@ -55,9 +55,4 @@ public class ScriptWithIncludeOptionTestCase extends ESBIntegrationTest {
                 "Fault response null localpart");
 
     }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/SequenceWhichHasJsFunctionsForBothInOutTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/SequenceWhichHasJsFunctionsForBothInOutTestCase.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.esb.mediator.test.script;
 
 import org.apache.axiom.om.OMElement;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -53,10 +52,4 @@ public class SequenceWhichHasJsFunctionsForBothInOutTestCase extends ESBIntegrat
                 "Fault response null localpart");
 
     }
-
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanup();
-    }
-
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/SetPropertyWithScopeInScriptMediatorTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/SetPropertyWithScopeInScriptMediatorTestCase.java
@@ -17,47 +17,43 @@ public class SetPropertyWithScopeInScriptMediatorTestCase extends ESBIntegration
     public void setEnvironment() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
-        super.cleanup();
+        carbonLogReader.stop();
     }
 
     @Test(groups = "wso2.esb", description = "Set a property with axis2 scope in script mediator")
     public void testSetPropertyWithAxis2ScopeInScript() throws Exception {
-
+        carbonLogReader.clearLogs();
         StockQuoteClient axis2Client1 = new StockQuoteClient();
-        carbonLogReader.start();
         axis2Client1.sendSimpleStockQuoteRequest(getProxyServiceURLHttp("scriptMediatorSetPropertyWithScopeTestProxy"),
                 null, "WSO2");
 
         boolean setPropertyInLog = Utils.checkForLog(carbonLogReader, "Axis2_Property = AXIS2_PROPERTY", 10);
         Assert.assertTrue(setPropertyInLog, " The property with axis2 scope is not set ");
         boolean removePropertyInLog = Utils.checkForLog(carbonLogReader, "Axis2_Property_After_Remove = null", 10);
-        carbonLogReader.stop();
         Assert.assertTrue(removePropertyInLog, " The property with axis2 scope is not remove ");
     }
 
     @Test(groups = "wso2.esb", description = "Set a property with transport scope in script mediator")
     public void testSetPropertyWithTransportScopeInScript() throws Exception {
-
+        carbonLogReader.clearLogs();
         StockQuoteClient axis2Client1 = new StockQuoteClient();
-        carbonLogReader.start();
         axis2Client1.sendSimpleStockQuoteRequest(getProxyServiceURLHttp("scriptMediatorSetPropertyWithScopeTestProxy"),
                 null, "WSO2");
         boolean setPropertyInLog = Utils.checkForLog(carbonLogReader, "Transport_Property = TRANSPORT_PROPERTY", 10);
         Assert.assertTrue(setPropertyInLog, " The property with transport scope is not set ");
         boolean removePropertyInLog = Utils.checkForLog(carbonLogReader, "Transport_Property_After_Remove = null", 10);
-        carbonLogReader.stop();
         Assert.assertTrue(removePropertyInLog, " The property with axis2 transport is not remove ");
     }
 
     @Test(groups = "wso2.esb", description = "Set a property with operation scope in script mediator")
     public void testSetPropertyWithOperationScopeInScript() throws Exception {
-
+        carbonLogReader.clearLogs();
         StockQuoteClient axis2Client1 = new StockQuoteClient();
-        carbonLogReader.start();
         axis2Client1.sendSimpleStockQuoteRequest(getProxyServiceURLHttp("scriptMediatorSetPropertyWithScopeTestProxy"),
                 null, "WSO2");
 
@@ -65,7 +61,6 @@ public class SetPropertyWithScopeInScriptMediatorTestCase extends ESBIntegration
         Assert.assertTrue(setPropertyInLog, " The property with operation scope is not set ");
 
         boolean removePropertyInLog = Utils.checkForLog(carbonLogReader, "Operation_Property_After_Remove = null", 10);
-        carbonLogReader.stop();
         Assert.assertTrue(removePropertyInLog, " The property with operation scope is not remove ");
     }
 }

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/switchMediator/SwitchInsideSwitchTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/switchMediator/SwitchInsideSwitchTestCase.java
@@ -32,12 +32,11 @@ public class SwitchInsideSwitchTestCase extends ESBIntegrationTest {
     public void beforeClass() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Switch Mediator: Testing Switch inside Switch Scenario")
     public void testSample2() throws Exception {
-        carbonLogReader.start();
-
         axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("switchMediatorSwitchInsideSwitchTestProxy"),
                         getBackEndServiceUrl(ESBTestConstant.SIMPLE_STOCK_QUOTE_SERVICE), "IBM");
@@ -47,5 +46,6 @@ public class SwitchInsideSwitchTestCase extends ESBIntegrationTest {
                 "Test Property not set");
         Assert.assertTrue(carbonLogReader.checkForLog("Great stock - IBM", DEFAULT_TIMEOUT),
                 "Symbol property not set");
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/api/test/ESBJAVA3751UriTemplateReservedCharacterEncodingTest.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/api/test/ESBJAVA3751UriTemplateReservedCharacterEncodingTest.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.esb.api.test;
  */
 
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
@@ -32,20 +33,18 @@ public class ESBJAVA3751UriTemplateReservedCharacterEncodingTest extends ESBInte
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
         super.init();
-        verifyAPIExistence("ClientApi");
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Sending http request with a query param consist of"
             + " reserved character : ")
     public void testURITemplateExpandWithPercentEncoding() throws Exception {
+        carbonLogReader.clearLogs();
         boolean isPercentEncoded = false;
-        carbonLogReader.start();
         HttpResponse response = HttpRequestUtil
                 .sendGetRequest(getApiInvocationURL("services/client/urlEncoded?queryParam=ESB:WSO2"), null);
         isPercentEncoded = carbonLogReader.checkForLog("ESB%3AWSO2", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         Assert.assertTrue(isPercentEncoded,
                 "Reserved character should be percent encoded while uri-template expansion");
 
@@ -55,12 +54,10 @@ public class ESBJAVA3751UriTemplateReservedCharacterEncodingTest extends ESBInte
             + "character : with percent encoding escaped at uri-template expansion")
     public void testURITemplateExpandWithEscapedPercentEncoding() throws Exception {
         boolean isPercentEncoded = false;
-        carbonLogReader.start();
+        carbonLogReader.clearLogs();
         HttpResponse response = HttpRequestUtil
                 .sendGetRequest(getApiInvocationURL("services/client/escapeUrlEncoded?queryParam=ESB:WSO2"), null);
         isPercentEncoded = carbonLogReader.checkForLog("ESB%3AWSO2", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         Assert.assertFalse(isPercentEncoded,
                 "Reserved character should not be percent encoded while uri-template expansion as escape enabled");
 
@@ -69,13 +66,11 @@ public class ESBJAVA3751UriTemplateReservedCharacterEncodingTest extends ESBInte
     @Test(groups = { "wso2.esb" }, description = "Sending http request with a path param consist of"
             + " reserved character : ")
     public void testURITemplateExpandWithPercentEncodingPathParamCase() throws Exception {
+        carbonLogReader.clearLogs();
         boolean isPercentEncoded = false;
-        carbonLogReader.start();
         HttpResponse response = HttpRequestUtil
                 .sendGetRequest(getApiInvocationURL("services/client/urlEncoded/ESB:WSO2"), null);
         isPercentEncoded = carbonLogReader.checkForLog("To: /services/test_2/ESB%3AWSO2", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         Assert.assertTrue(isPercentEncoded,
                 "Reserved character should be percent encoded while uri-template expansion");
 
@@ -84,13 +79,11 @@ public class ESBJAVA3751UriTemplateReservedCharacterEncodingTest extends ESBInte
     @Test(groups = { "wso2.esb" }, description = "Sending http request with a path param consist of reserved "
             + "character : with percent encoding escaped at uri-template expansion")
     public void testURITemplateExpandWithEscapedPercentEncodingPathParam() throws Exception {
+        carbonLogReader.clearLogs();
         boolean isPercentEncoded = false;
-        carbonLogReader.start();
         HttpResponse response = HttpRequestUtil
                 .sendGetRequest(getApiInvocationURL("services/client/escapeUrlEncoded/ESB:WSO2"), null);
         isPercentEncoded = carbonLogReader.checkForLog("To: /services/test_2/ESB%3AWSO2", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         Assert.assertFalse(isPercentEncoded,
                 "Reserved character should not be percent encoded while uri-template expansion as escape enabled");
 
@@ -99,17 +92,15 @@ public class ESBJAVA3751UriTemplateReservedCharacterEncodingTest extends ESBInte
     @Test(groups = { "wso2.esb" }, description = "Sending http request with a query param consist of"
             + " reserved space character ")
     public void testURITemplateParameterDecodingSpaceCharacterCase() throws Exception {
+        carbonLogReader.clearLogs();
         boolean isPercentEncoded = false;
         boolean isMessageContextPropertyPercentDecoded = false;
-        carbonLogReader.start();
         HttpResponse response = HttpRequestUtil
                 .sendGetRequest(getApiInvocationURL("services/client/urlEncoded?queryParam=ESB%20WSO2"), null);
         String decodedMessageContextProperty = "decodedQueryParamValue = ESB WSO2";
         isMessageContextPropertyPercentDecoded =
                 carbonLogReader.checkForLog(decodedMessageContextProperty, DEFAULT_TIMEOUT);
         isPercentEncoded = carbonLogReader.checkForLog("ESB%20WSO2", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         Assert.assertTrue(isMessageContextPropertyPercentDecoded,
                 "Uri-Template parameters should be percent decoded at message context property");
         Assert.assertTrue(isPercentEncoded,
@@ -119,17 +110,15 @@ public class ESBJAVA3751UriTemplateReservedCharacterEncodingTest extends ESBInte
     @Test(groups = { "wso2.esb" }, description = "Sending http request with a query param consist of"
             + " reserved + character ")
     public void testURITemplateParameterDecodingPlusCharacterCase() throws Exception {
+        carbonLogReader.clearLogs();
         boolean isPercentEncoded = false;
         boolean isMessageContextPropertyPercentDecoded = false;
-        carbonLogReader.start();
         HttpResponse response = HttpRequestUtil
                 .sendGetRequest(getApiInvocationURL("services/client/urlEncoded?queryParam=ESB+WSO2"), null);
         String decodedMessageContextProperty = "decodedQueryParamValue = ESB+WSO2";
         isMessageContextPropertyPercentDecoded =
                 carbonLogReader.checkForLog(decodedMessageContextProperty, DEFAULT_TIMEOUT);
         isPercentEncoded = carbonLogReader.checkForLog("ESB%2BWSO2", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         Assert.assertTrue(isMessageContextPropertyPercentDecoded,
                 "Uri-Template parameters should be percent decoded at message context property");
         Assert.assertTrue(isPercentEncoded,
@@ -139,16 +128,14 @@ public class ESBJAVA3751UriTemplateReservedCharacterEncodingTest extends ESBInte
     @Test(groups = { "wso2.esb" }, description = "Sending http request with a query param consist of"
             + " reserved + character ")
     public void testURITemplateParameterDecodingWithPercentEncodingEscapedAtExpansion() throws Exception {
+        carbonLogReader.clearLogs();
         boolean isPercentEncoded = false;
         boolean isMessageContextPropertyPercentDecoded = false;
-        carbonLogReader.start();
         HttpResponse response = HttpRequestUtil
                 .sendGetRequest(getApiInvocationURL("services/client/escapeUrlEncoded?queryParam=ESB+WSO2"), null);
         String decodedMessageContextProperty = "decodedQueryParamValue = ESB+WSO2";
         isMessageContextPropertyPercentDecoded = carbonLogReader.checkForLog(decodedMessageContextProperty, DEFAULT_TIMEOUT);
         isPercentEncoded = carbonLogReader.checkForLog("ESB%2BWSO2", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         Assert.assertTrue(isMessageContextPropertyPercentDecoded,
                 "Uri-Template parameters should be percent decoded at message context property");
         Assert.assertFalse(isPercentEncoded,
@@ -158,16 +145,18 @@ public class ESBJAVA3751UriTemplateReservedCharacterEncodingTest extends ESBInte
     @Test(groups = { "wso2.esb" }, description = "Sending http request with a path param consist of"
             + " whole URL including protocol , host , port etc. ")
     public void testURITemplateSpecialCaseVariableWithFullURL() throws Exception {
+        carbonLogReader.clearLogs();
         boolean isPercentEncoded = false;
-        carbonLogReader.start();
         HttpResponse response = HttpRequestUtil.sendGetRequest(
                 getApiInvocationURL("services/client/special_case/http://localhost:8480/services/test_2/special_case"),
                 null);
         isPercentEncoded = carbonLogReader.checkForLog("To: /services/test_2/special_case", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         Assert.assertTrue(isPercentEncoded,
                 "The Special case of of Full URL expansion should be identified and should not percent encode full URL");
+    }
 
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/endpoint/test/ESBJAVA3340QueryParamHttpEndpointTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/endpoint/test/ESBJAVA3340QueryParamHttpEndpointTestCase.java
@@ -26,10 +26,13 @@ import org.wso2.esb.integration.common.utils.CarbonLogReader;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 public class ESBJAVA3340QueryParamHttpEndpointTestCase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader;
 
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
         super.init();
+        carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = {
@@ -37,8 +40,6 @@ public class ESBJAVA3340QueryParamHttpEndpointTestCase extends ESBIntegrationTes
     public void testPassParamsToEndpoint() throws InterruptedException {
         String requestString = "/context?queryParam=some%20value";
         boolean isSpaceCharacterEscaped;
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         try {
             HttpRequestUtil.sendGetRequest(getApiInvocationURL("passParamsToEPTest") + requestString, null);
         } catch (Exception timeout) {

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/endpoint/test/FaultSequenceExecutionOrderTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/endpoint/test/FaultSequenceExecutionOrderTestCase.java
@@ -37,6 +37,7 @@ import java.util.Map;
 public class FaultSequenceExecutionOrderTestCase extends ESBIntegrationTest {
 
     private SampleAxis2Server axis2Server;
+    CarbonLogReader carbonLogReader;
 
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
@@ -44,13 +45,12 @@ public class FaultSequenceExecutionOrderTestCase extends ESBIntegrationTest {
         axis2Server = new SampleAxis2Server("test_axis2_server_9001.xml");
         axis2Server.deployService(ESBTestConstant.SIMPLE_STOCK_QUOTE_SERVICE + "_timeout");
         axis2Server.start();
+        carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = {"wso2.esb"}, description = "Correct Fault Sequence Invoke Test")
     public void testCorrectFaultSequenceExecution() throws Exception {
-
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         String contentType = "application/xml";
         SimpleHttpClient httpClient = new SimpleHttpClient();
         Map<String, String> headers = new HashMap<String, String>();
@@ -60,12 +60,12 @@ public class FaultSequenceExecutionOrderTestCase extends ESBIntegrationTest {
         boolean isSuperSequecefalutExecuted = carbonLogReader.checkForLog("aF = A Fault", DEFAULT_TIMEOUT);
         Assert.assertTrue(isImmediateOnly);
         Assert.assertFalse(isSuperSequecefalutExecuted);
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() {
         axis2Server.stop();
         axis2Server = null;
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/getprocessor/test/FaviconTest.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/getprocessor/test/FaviconTest.java
@@ -27,16 +27,16 @@ import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import java.io.IOException;
 
 public class FaviconTest extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = {"wso2.esb"}, description = "Test for ClosedChannel Exception")
     public void faviconTest() throws Exception {
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         HttpsResponse response = HttpsURLConnectionClient.
                 getRequest("https://localhost:8443/" + "favicon.ico", null);
         Assert.assertEquals(response.getResponseCode(), 301, "Response code mismatch");

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/EI1622JMSInboundMessagePollingConsumerTest.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/EI1622JMSInboundMessagePollingConsumerTest.java
@@ -40,6 +40,7 @@ public class EI1622JMSInboundMessagePollingConsumerTest extends ESBIntegrationTe
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Check whether polling is suspended.")
@@ -50,7 +51,6 @@ public class EI1622JMSInboundMessagePollingConsumerTest extends ESBIntegrationTe
         assertTrue(Utils.checkForLog(carbonLogReader, "Suspending polling as the pollingSuspensionLimit of 2 "
                         + "reached. Polling will be re-started after 3000 milliseconds", 10),
                 "JMS Polling suspension is not enabled.");
-        carbonLogReader.stop();
         Utils.undeploySynapseConfiguration(ENDPOINT_NAME, "inbound-endpoints", true);
     }
 
@@ -61,7 +61,6 @@ public class EI1622JMSInboundMessagePollingConsumerTest extends ESBIntegrationTe
 
         assertTrue(Utils.checkForLog(carbonLogReader, "Polling is suspended permanently", 10),
                 "JMS Polling is not permanently suspended though the suspension limit is 0.");
-        carbonLogReader.stop();
         Utils.undeploySynapseConfiguration(ENDPOINT_NAME, "inbound-endpoints", true);
     }
 
@@ -78,9 +77,8 @@ public class EI1622JMSInboundMessagePollingConsumerTest extends ESBIntegrationTe
 
         try {
             Utils.deploySynapseConfiguration(inBoundEndpoint, ENDPOINT_NAME, "inbound-endpoints", true);
-            sender.connect(queueName);
             carbonLogReader.clearLogs();
-            carbonLogReader.start();
+            sender.connect(queueName);
             sender.pushMessage("<?xml version='1.0' encoding='UTF-8'?>"
                     + "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\""
                     + " xmlns:ser=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">"
@@ -96,7 +94,7 @@ public class EI1622JMSInboundMessagePollingConsumerTest extends ESBIntegrationTe
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
-        super.cleanup();
+        carbonLogReader.stop();
     }
 
     /**

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA3282CalloutJMSHeadersTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA3282CalloutJMSHeadersTestCase.java
@@ -34,12 +34,11 @@ public class ESBJAVA3282CalloutJMSHeadersTestCase extends ESBIntegrationTest {
     protected void init() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = {"wso2.esb"}, description = "Callout JMS headers test case")
     public void testCalloutJMSHeaders() throws Exception {
-        carbonLogReader.start();
-
         AxisServiceClient client = new AxisServiceClient();
         String payload = "<payload/>";
         AXIOMUtil.stringToOM(payload);
@@ -47,11 +46,10 @@ public class ESBJAVA3282CalloutJMSHeadersTestCase extends ESBIntegrationTest {
                           "urn:mediate");
 
         assertTrue(carbonLogReader.checkForLog("RequestHeaderVal", DEFAULT_TIMEOUT));
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
-        super.cleanup();
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/cache/DistributedCachingHeaderSerializationTestcase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/cache/DistributedCachingHeaderSerializationTestcase.java
@@ -33,21 +33,20 @@ import java.util.Map;
  * This test can be used make sure cache mediator works with distributed caching is enabled.
  */
 public class DistributedCachingHeaderSerializationTestcase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "cache meditor test enabling axis2 clustering.")
     public void testDistributedCachingHeaderSerialization() throws Exception {
-
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
         String requestXml = "<a>ABC</a>";
 
         SimpleHttpClient httpClient = new SimpleHttpClient();
         Map<String, String> headers = new HashMap<String, String>();
-        carbonLogReader.start();
         headers.put("Content-Type", "application/xml;charset=UTF-8");
         HttpResponse response1 = httpClient.doPost(getApiInvocationURL("CachingTest") + "/test", headers, requestXml,
                 "application/xml;charset=UTF-8");

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/callout/ESBJAVA_4118_SOAPHeaderHandlingTest.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/callout/ESBJAVA_4118_SOAPHeaderHandlingTest.java
@@ -39,6 +39,7 @@ public class ESBJAVA_4118_SOAPHeaderHandlingTest extends ESBIntegrationTest {
         super.init();
         verifyProxyServiceExistence("TestCalloutSoapHeader");
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "Test whether the callout mediator successfully handle SOAP messages "
@@ -57,7 +58,6 @@ public class ESBJAVA_4118_SOAPHeaderHandlingTest extends ESBIntegrationTest {
         boolean errorLog = false;
 
         try {
-            carbonLogReader.start();
             int result = httpClient.executeMethod(post);
             String responseBody = post.getResponseBodyAsString();
             log.info("Response Status: " + result);

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/callout/ESBJAVA_4239_AccessHTTPSCAfterCallout.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/callout/ESBJAVA_4239_AccessHTTPSCAfterCallout.java
@@ -22,14 +22,14 @@ public class ESBJAVA_4239_AccessHTTPSCAfterCallout extends ESBIntegrationTest {
     @BeforeClass(alwaysRun = true)
     public void deployeService() throws Exception {
         super.init();
+        carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test whether an HTTP SC can be retrieved after the callout mediator.")
     public void testFetchHTTP_SC_After_Callout_Mediator() throws RemoteException, InterruptedException {
         final String proxyUrl = getProxyServiceURLHttp(PROXY_SERVICE_NAME);
         AxisServiceClient client = new AxisServiceClient();
-        carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         client.sendRobust(createPlaceOrderRequest(3.141593E0, 4, "IBM"), proxyUrl, "placeOrder");
 
         boolean isScFound = carbonLogReader.checkForLog(EXPECTED_LOG_MESSAGE, DEFAULT_TIMEOUT);

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/clone/ESBJAVA3412EmptyStackExceptionTest.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/clone/ESBJAVA3412EmptyStackExceptionTest.java
@@ -29,6 +29,7 @@ public class ESBJAVA3412EmptyStackExceptionTest extends ESBIntegrationTest {
         verifyProxyServiceExistence("CloneMediatorEmptyStackProxy");
 
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     /**
@@ -49,7 +50,6 @@ public class ESBJAVA3412EmptyStackExceptionTest extends ESBIntegrationTest {
 
         // invoking the service through the proxy service
         AxisServiceClient client = new AxisServiceClient();
-        carbonLogReader.start();
 
         final String proxyUrl = contextUrls.getServiceUrl() + "/CloneMediatorEmptyStackProxy";
 
@@ -61,7 +61,6 @@ public class ESBJAVA3412EmptyStackExceptionTest extends ESBIntegrationTest {
         isEmptyStackError = carbonLogReader.checkForLog(expectedErrorMsg, DEFAULT_TIMEOUT) && carbonLogReader.
                 checkForLog(expectedStackTrace, DEFAULT_TIMEOUT);
         carbonLogReader.stop();
-        carbonLogReader.clearLogs();
         /*
          * Asserting the results here. If there's an Empty stack error, then the
          * assertion should fail.

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ForceMessageValidationTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ForceMessageValidationTestCase.java
@@ -61,6 +61,7 @@ public class ForceMessageValidationTestCase extends ESBIntegrationTest {
         super.init();
 
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     //enable tests with the synapse fix
@@ -74,7 +75,6 @@ public class ForceMessageValidationTestCase extends ESBIntegrationTest {
             + "property.")
     public void testInvalidJSONMessage() throws Exception {
         carbonLogReader.clearLogs();
-        carbonLogReader.start();
 
         String inputPayload = "{\"abc\" :\"123\" } xyz";
         String expectedOutput = "Error while building the message." + "{\"abc\" :\"123\" } xyz";
@@ -86,7 +86,6 @@ public class ForceMessageValidationTestCase extends ESBIntegrationTest {
 
         Assert.assertTrue(carbonLogReader.checkForLog(expectedOutput, DEFAULT_TIMEOUT), "Test fails for forcing "
                 + "JSON validation with force.json.message.validation passthru-http property.");
-        carbonLogReader.stop();
     }
 
     /**
@@ -97,7 +96,6 @@ public class ForceMessageValidationTestCase extends ESBIntegrationTest {
     @Test(groups = "wso2.esb", description = "Test for invalid XML payload with force.xml.message.validation property.")
     public void testInvalidXMLMessage() throws Exception {
         carbonLogReader.clearLogs();
-        carbonLogReader.start();
 
         String inputPayload = "<foo>\n" + "  <bar>xyz</bar>\n" + "</foo>\n" + "</bar>";
         String expectedOutput =
@@ -109,11 +107,11 @@ public class ForceMessageValidationTestCase extends ESBIntegrationTest {
         HttpRequestUtil.doPost(new URL(getApiInvocationURL(API_NAME)), inputPayload, requestHeader);
         Assert.assertTrue(carbonLogReader.checkForLog(expectedOutput, DEFAULT_TIMEOUT),
                 "Test fails for forcing XML validation with force.xml.message.validation passthru-http property.");
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
         serverConfigurationManager.restoreToLastMIConfiguration();
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/registry/caching/CachableDurationTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/registry/caching/CachableDurationTestCase.java
@@ -41,6 +41,7 @@ public class CachableDurationTestCase extends ESBIntegrationTest {
         super.init();
         registryManager = new MicroRegistryManager();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
         String sourceFile = getESBResourceLocation() + File.separator + "synapseconfig" + File.separator + "registry"
                 + File.separator + "caching" + File.separator + "registry.xml";
         String registryConfig = FileUtils.readFileToString(new File(sourceFile));
@@ -53,26 +54,22 @@ public class CachableDurationTestCase extends ESBIntegrationTest {
     public void testCachableDuration() throws Exception {
 
         carbonLogReader.clearLogs();
-        carbonLogReader.start();
         //invoking the service
         SendRequest();
 
         //Check if the property we set is used
         boolean validLogMessage = validateLogMessage(OLD_VALUE);
         Assert.assertTrue(validLogMessage);
-        carbonLogReader.stop();
 
         //Update the registry value
         updateResourcesInConfigRegistry();
         Assert.assertTrue(registryManager.getProperty(PATH, RESOURCE_PATH, NAME).equals(NEW_VALUE));
         carbonLogReader.clearLogs();
-        carbonLogReader.start();
         SendRequest();
 
         //Check if the new value is being used
         boolean validChangedLogMessage = validateLogMessage(NEW_VALUE);
         Assert.assertTrue(validChangedLogMessage);
-        carbonLogReader.stop();
 
     }
 
@@ -121,7 +118,7 @@ public class CachableDurationTestCase extends ESBIntegrationTest {
         String registryConfig = FileUtils.readFileToString(new File(sourceFile));
         Utils.deploySynapseConfiguration(AXIOMUtil.stringToOM(registryConfig), "registry", "",
                 true);
-        super.cleanup();
+        carbonLogReader.stop();
     }
 
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/registry/task/ESBJAVA4565TestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/registry/task/ESBJAVA4565TestCase.java
@@ -33,6 +33,7 @@ import org.wso2.esb.integration.common.utils.Utils;
  */
 
 public class ESBJAVA4565TestCase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
@@ -51,15 +52,15 @@ public class ESBJAVA4565TestCase extends ESBIntegrationTest {
                         + "    <property name=\"injectTo\" value=\"sequence\" xmlns:task=\"http://www.wso2.org/products/wso2commons/tasks\"/>\n"
                         + "    <property name=\"message\" xmlns:task=\"http://www.wso2.org/products/wso2commons/tasks\"><empty/></property>\n" + "</task>");
         Utils.deploySynapseConfiguration(task, "TestTask", "tasks", true);
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "Analyze carbon logs to find NPE due to unresolved tenant domain.")
     public void checkErrorLog() throws Exception {
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         boolean hasErrorLog = carbonLogReader.checkForLog(
                 "java.lang.NullPointerException: Tenant domain has not been set in CarbonContext", DEFAULT_TIMEOUT);
         Assert.assertFalse(hasErrorLog,
                 "Tenant domain not resolved when registry resource is accessed inside " + "a scheduled task");
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-sample/src/test/java/org/wso2/carbon/esb/samples/test/mediation/Sample18TestCase.java
+++ b/integration/mediation-tests/tests-sample/src/test/java/org/wso2/carbon/esb/samples/test/mediation/Sample18TestCase.java
@@ -35,21 +35,18 @@ import static org.testng.Assert.fail;
  * Sample 18: Transforming a Message Using ForEachMediator
  */
 public class Sample18TestCase extends ESBSampleIntegrationTest {
-
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
     private String endpoint;
 
     @BeforeClass(alwaysRun = true)
     public void uploadSynapseConfig() throws Exception {
         super.init();
         endpoint = getProxyServiceURLHttp("Sample18TestCaseProxy");
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Transforming a Message Using ForEachMediator")
     public void testTransformWithForEachMediator() throws Exception {
-
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
-
         String request =
                 "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:m0=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">\n"
                         + "    <soap:Header/>\n" + "    <soap:Body>\n" + "        <m0:getQuote>\n"

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/proxyservice/test/loggingProxy/ProxyServiceEndPointThroughURLTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/proxyservice/test/loggingProxy/ProxyServiceEndPointThroughURLTestCase.java
@@ -28,16 +28,16 @@ import javax.xml.namespace.QName;
 import static org.testng.Assert.*;
 
 public class ProxyServiceEndPointThroughURLTestCase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "Proxy service with providing endpoint through url")
     public void testLoggingProxy() throws Exception {
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getProxyServiceURLHttp("StockQuoteLoggingProxy"), null, "WSO2");
 

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/APIHeadMethod.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/APIHeadMethod.java
@@ -30,10 +30,12 @@ import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import static org.testng.Assert.assertTrue;
 
 public class APIHeadMethod extends ESBIntegrationTest {
+    CarbonLogReader logReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
+        logReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "API HTTP HEAD Method")
@@ -41,8 +43,7 @@ public class APIHeadMethod extends ESBIntegrationTest {
         String restURL = "http://localhost:8480/headTest";
         DefaultHttpClient httpclient = new DefaultHttpClient();
 
-        CarbonLogReader logReader = new CarbonLogReader();
-        logReader.start();
+
 
         HttpHead httpHead = new HttpHead(restURL);
         HttpResponse response = httpclient.execute(httpHead);

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestPostFixUrlTest.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestPostFixUrlTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.esb.rest.test.api;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
@@ -38,6 +39,7 @@ public class RestPostFixUrlTest extends ESBIntegrationTest {
     public void init() throws Exception {
         super.init();
         logReader = new CarbonLogReader();
+        logReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Sending a Message Via REST with additional resource")
@@ -47,14 +49,13 @@ public class RestPostFixUrlTest extends ESBIntegrationTest {
          *  sending request from Client API with additional resource
          * "anotherParam" services/client/anotherParam
          */
-        logReader.start();
+        logReader.clearLogs();
 
         HttpRequestUtil.sendGetRequest(getApiInvocationURL("services/client/anotherParam"), null);
 
         Assert.assertFalse(logReader.checkForLog("anotherParam", DEFAULT_TIMEOUT),
                 " Target URL is wrong. It appends the context URL part also.");
 
-        logReader.stop();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Sending a Message Via REST with additional resource")
@@ -65,11 +66,15 @@ public class RestPostFixUrlTest extends ESBIntegrationTest {
          *  & prameter - "foo"
          *  services/client/anotherParam/foo
          */
-        logReader.start();
+        logReader.clearLogs();
 
         HttpRequestUtil.sendGetRequest(getApiInvocationURL("services/client/anotherParam/foo"), null);
         Assert.assertTrue(logReader.checkForLog("/services/testAPI/foo", DEFAULT_TIMEOUT),
                 " Target URL is wrong. expected /services/testAPI/foo ");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
         logReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/scheduledtask/test/InjectToSequenceTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/scheduledtask/test/InjectToSequenceTestCase.java
@@ -37,6 +37,7 @@ public class InjectToSequenceTestCase extends ESBIntegrationTest {
     public void setEnvironment() throws Exception {
         super.init();
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" })
@@ -57,17 +58,16 @@ public class InjectToSequenceTestCase extends ESBIntegrationTest {
                         + "    <property name=\"injectTo\" value=\"sequence\" \n"
                         + "xmlns:task=\"http://www.wso2.org/products/wso2commons/tasks\"/>\n" + "</task>");
 
-        carbonLogReader.start();
         Utils.deploySynapseConfiguration(task, "SampleInjectToSequenceTask", "tasks",  true);
         TimeUnit.SECONDS.sleep(5);
 
         boolean invokedLogFound = carbonLogReader.checkForLog("SEQUENCE INVOKED", DEFAULT_TIMEOUT);
-        carbonLogReader.stop();
         assertTrue(invokedLogFound);
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
+        carbonLogReader.stop();
         Utils.undeploySynapseConfiguration("SampleInjectToSequenceTask", "tasks");
     }
 }

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/scheduledtask/test/TaskWithLargeIntervalValueTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/scheduledtask/test/TaskWithLargeIntervalValueTestCase.java
@@ -33,10 +33,12 @@ import static org.testng.Assert.assertTrue;
  * Test whether the scheduled task is created successfully when large interval value(> Integer.MAX_VALUE) is defined.
  */
 public class TaskWithLargeIntervalValueTestCase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = {
@@ -61,8 +63,6 @@ public class TaskWithLargeIntervalValueTestCase extends ESBIntegrationTest {
                         + "xmlns:task=\"http://www.wso2.org/products/wso2commons/tasks\"/>\n" + "</task>");
 
         Utils.deploySynapseConfiguration(task, "ESBJAVA5234TestTask", "tasks", true);
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         boolean assertValue = Utils
                 .logExists(carbonLogReader, "injected value from ESBJAVA5234TestTask received",
                         5);
@@ -72,5 +72,6 @@ public class TaskWithLargeIntervalValueTestCase extends ESBIntegrationTest {
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
         Utils.undeploySynapseConfiguration("ESBJAVA5234TestTask", "tasks");
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA2464TestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA2464TestCase.java
@@ -9,12 +9,13 @@ import org.wso2.esb.integration.common.utils.CarbonLogReader;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 public class ESBJAVA2464TestCase extends ESBIntegrationTest {
-
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
     private static final String logLine0 = "org.wso2.carbon.proxyadmin.service.ProxyServiceAdmin is not an admin service. Service name ";
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = {
@@ -29,8 +30,6 @@ public class ESBJAVA2464TestCase extends ESBIntegrationTest {
                 + "  <soapenv:Header/>" + "  <soapenv:Body>" + "     <echo:echoInt>" + "        <!--Optional:-->"
                 + "       <in>1</in>" + "     </echo:echoInt>" + "  </soapenv:Body>" + "</soapenv:Envelope>";
 
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         try {
             sender.connect("ESBJAVA2464TestProxy");
             for (int i = 0; i < 3; i++) {

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA2907TestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA2907TestCase.java
@@ -12,19 +12,18 @@ import org.wso2.esb.integration.common.utils.clients.axis2client.AxisServiceClie
  * ESBJAVA-2907 OMElements are not added as properties when saving messages to the MessageStore
  */
 public class ESBJAVA2907TestCase extends ESBIntegrationTest {
-
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
     private static String GET_QUOTE_REQUEST_BODY = "OM_ELEMENT_PREFIX_ = <ns:getQuote xmlns:ns=\"http://services.samples\"><ns:request><ns:symbol>IBM</ns:symbol></ns:request></ns:getQuote>";
 
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "Test adding OMElements as properties when saving messages to the MessageStore")
     public void testAddingOMElementPropertyToMessageStore() throws Exception {
         AxisServiceClient client = new AxisServiceClient();
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         client.sendRobust(Utils.getStockQuoteRequest("IBM"), getProxyServiceURLHttp("testPS"), "getQuote");
         Assert.assertTrue(carbonLogReader.checkForLog(GET_QUOTE_REQUEST_BODY, DEFAULT_TIMEOUT), "OMElement is not saved to the message store");
         carbonLogReader.stop();

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/JMSOutOnlyTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/JMSOutOnlyTestCase.java
@@ -27,17 +27,17 @@ import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.clients.axis2client.AxisServiceClient;
 
 public class JMSOutOnlyTestCase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader;
 
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
         super.init();
+        carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test proxy service with out-only jms transport")
     public void testJMSProxy() throws Exception {
-
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
 
         AxisServiceClient client = new AxisServiceClient();
         String payload = "<?xml version='1.0' encoding='UTF-8'?>"

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/JMSSenderStaleConnectionsTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/JMSSenderStaleConnectionsTestCase.java
@@ -35,6 +35,7 @@ import org.wso2.esb.integration.common.utils.clients.axis2client.AxisServiceClie
  * message will be sent. If this message get into default fault sequence, the test will be failed.
  */
 public class JMSSenderStaleConnectionsTestCase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
     /* this will be printed on default fault sequence when the exception is thrown */
     private final String exceptedErrorLog = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/"
             + "envelope/\"><soapenv:Body><ns:getQuote xmlns:ns=\"http://services.samples\"><ns:request><ns:symbol>"
@@ -43,6 +44,7 @@ public class JMSSenderStaleConnectionsTestCase extends ESBIntegrationTest {
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test for JMS sender side stale connections handling")
@@ -63,9 +65,6 @@ public class JMSSenderStaleConnectionsTestCase extends ESBIntegrationTest {
         /* send another message after broker restart */
         client.sendRobust(Utils.getStockQuoteRequest("JMS"),
                 getProxyServiceURLHttp("JMSSenderStaleConnectionsTestProxy"), "getQuote");
-
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
 
         Assert.assertFalse(carbonLogReader.checkForLog(exceptedErrorLog, DEFAULT_TIMEOUT),
                 "Sender Side Stale connections handling test failed");

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/MSMPCronForwarderCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/MSMPCronForwarderCase.java
@@ -52,12 +52,11 @@ public class MSMPCronForwarderCase extends ESBIntegrationTest {
     protected void init() throws Exception {
         // START THE ESB
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test Cron Forwarding of message processor")
     public void testMessageProcessorCronForwader() throws Exception {
-
-        carbonLogReader.start();
 
         // SEND THE REQUEST
         String addUrl = getProxyServiceURLHttp("MSMPRetrytest");

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportActionAfterFailureDELETETestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportActionAfterFailureDELETETestCase.java
@@ -59,6 +59,7 @@ public class MailToTransportActionAfterFailureDELETETestCase extends ESBIntegrat
         carbonLogReader = new CarbonLogReader();
         greenMailUser = GreenMailServer.getPrimaryUser();
         greenMailClient = new GreenMailClient(greenMailUser);
+        carbonLogReader.start();
 
         // Since ESB reads all unread emails one by one,
         // we have to delete all unread emails before running the test
@@ -68,7 +69,6 @@ public class MailToTransportActionAfterFailureDELETETestCase extends ESBIntegrat
 
     @Test(groups = { "wso2.esb" }, description = "Test email transport received action after failure delete")
     public void testEmailTransportActionAfterFailureDELETE() throws Exception {
-        carbonLogReader.start();
         Date date = new Date();
         emailSubject = "Failure Delete : " + new Timestamp(date.getTime());
         greenMailClient.sendMail(emailSubject);
@@ -77,13 +77,13 @@ public class MailToTransportActionAfterFailureDELETETestCase extends ESBIntegrat
                 "Couldn't get the failure message!");
 
         assertTrue(GreenMailServer.checkEmailDeleted(emailSubject, "imap"), "Mail has not been deleted successfully");
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
         Utils.undeploySynapseConfiguration("MailToTransportActionAfterFailureDELETETestCase",
                 "proxy-services");
+        carbonLogReader.stop();
     }
 }
 

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportActionAfterFailureMOVETestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportActionAfterFailureMOVETestCase.java
@@ -57,6 +57,7 @@ public class MailToTransportActionAfterFailureMOVETestCase extends ESBIntegratio
                 "MailToTransportActionAfterFailureMoveTestCase","proxy-services",
                 true);
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
         greenMailUser = GreenMailServer.getPrimaryUser();
         greenMailClient = new GreenMailClient(greenMailUser);
 
@@ -67,7 +68,6 @@ public class MailToTransportActionAfterFailureMOVETestCase extends ESBIntegratio
 
     @Test(groups = { "wso2.esb" }, description = "Test email transport received action after failure move")
     public void testEmailTransportActionAfterFailureMOVE() throws Exception {
-        carbonLogReader.start();
         Date date = new Date();
         emailSubject = "Failure Move : " + new Timestamp(date.getTime());
         greenMailClient.sendMail(emailSubject);
@@ -77,11 +77,11 @@ public class MailToTransportActionAfterFailureMOVETestCase extends ESBIntegratio
 
         assertTrue(GreenMailServer.checkEmailMoved(emailSubject, "imap"),
                 "Mail has not been moved successfully");
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
+        carbonLogReader.stop();
         Utils.undeploySynapseConfiguration("MailToTransportActionAfterFailureMoveTestCase",
                 "proxy-services");
     }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportActionAfterProcessDeleteTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportActionAfterProcessDeleteTestCase.java
@@ -59,6 +59,7 @@ public class MailToTransportActionAfterProcessDeleteTestCase extends ESBIntegrat
         carbonLogReader = new CarbonLogReader();
         greenMailUser = GreenMailServer.getPrimaryUser();
         greenMailClient = new GreenMailClient(greenMailUser);
+        carbonLogReader.start();
 
         // Since ESB reads all unread emails one by one, we have to delete
         // the all unread emails before run the test
@@ -67,7 +68,6 @@ public class MailToTransportActionAfterProcessDeleteTestCase extends ESBIntegrat
 
     @Test(groups = { "wso2.esb" }, description = "Test email transport action after process delete")
     public void testEmailTransportActionAfterProcessDelete() throws Exception {
-        carbonLogReader.start();
         Date date = new Date();
         emailSubject = "Process Delete : " + new Timestamp(date.getTime());
         greenMailClient.sendMail(emailSubject);
@@ -75,11 +75,11 @@ public class MailToTransportActionAfterProcessDeleteTestCase extends ESBIntegrat
         assertTrue(carbonLogReader.checkForLog(emailSubject, DEFAULT_TIMEOUT), "Email not processed!");
 
         assertTrue(GreenMailServer.checkEmailDeleted(emailSubject, "imap"), "Mail has not been deleted successfully");
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
         Utils.undeploySynapseConfiguration("MailTransportProtocolDelete","proxy-services");
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportActionAfterProcessMoveTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportActionAfterProcessMoveTestCase.java
@@ -59,6 +59,7 @@ public class MailToTransportActionAfterProcessMoveTestCase extends ESBIntegratio
         carbonLogReader = new CarbonLogReader();
         greenMailUser = GreenMailServer.getPrimaryUser();
         greenMailClient = new GreenMailClient(greenMailUser);
+        carbonLogReader.start();
 
         // Since ESB reads all unread emails one by one, we have to delete
         // the all unread emails before run the test
@@ -67,7 +68,6 @@ public class MailToTransportActionAfterProcessMoveTestCase extends ESBIntegratio
 
     @Test(groups = { "wso2.esb" }, description = "Test email transport action after process move")
     public void testEmailTransportActionAfterProcessMove() throws Exception {
-        carbonLogReader.start();
         Date date = new Date();
         emailSubject = "Process Move : " + new Timestamp(date.getTime());
         greenMailClient.sendMail(emailSubject);
@@ -75,11 +75,11 @@ public class MailToTransportActionAfterProcessMoveTestCase extends ESBIntegratio
         assertTrue(carbonLogReader.checkForLog(emailSubject, DEFAULT_TIMEOUT), "Email not processed!");
 
         assertTrue(GreenMailServer.checkEmailMoved(emailSubject, "imap"), "Mail has not been moved successfully");
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
         Utils.undeploySynapseConfiguration("MailTransportMove","proxy-services");
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportFolderTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportFolderTestCase.java
@@ -55,6 +55,7 @@ public class MailToTransportFolderTestCase extends ESBIntegrationTest {
         carbonLogReader = new CarbonLogReader();
         greenMailUser = GreenMailServer.getPrimaryUser();
         greenMailClient = new GreenMailClient(greenMailUser);
+        carbonLogReader.start();
 
         // Since ESB reads all unread emails one by one, we have to delete
         // the all unread emails before run the test
@@ -63,7 +64,6 @@ public class MailToTransportFolderTestCase extends ESBIntegrationTest {
 
     @Test(groups = { "wso2.esb" }, description = "Test email transport folder parameter")
     public void testEmailTransportFolder() throws Exception {
-        carbonLogReader.start();
         Date date = new Date();
         emailSubject = "Folder Test : " + new Timestamp(date.getTime());
         greenMailClient.sendMail(emailSubject);
@@ -74,6 +74,7 @@ public class MailToTransportFolderTestCase extends ESBIntegrationTest {
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
         Utils.undeploySynapseConfiguration("MailTransportFolder","proxy-services");
+        carbonLogReader.stop();
     }
 
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportInvalidAddressTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportInvalidAddressTestCase.java
@@ -50,6 +50,7 @@ public class MailToTransportInvalidAddressTestCase extends ESBIntegrationTest {
                 "MailTransportInvalidAddress","proxy-services",
                 true);
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
 
         // Since ESB reads all unread emails one by one, we have to delete
         // the all unread emails before run the test
@@ -59,13 +60,13 @@ public class MailToTransportInvalidAddressTestCase extends ESBIntegrationTest {
     @Test(groups = {
             "wso2.esb" }, description = "Test email transport with invalid address parameter and pop3 protocol")
     public void testEmailTransportInvalidAddress() throws Exception {
-        carbonLogReader.start();
         assertTrue(carbonLogReader.checkForLog("Error connecting to mail server for address", DEFAULT_TIMEOUT),
                 "Couldn't find the error message in log");
     }
 
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
+        carbonLogReader.stop();
         Utils.undeploySynapseConfiguration("MailTransportInvalidAddress","proxy-services");
     }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportInvalidFolderTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportInvalidFolderTestCase.java
@@ -47,6 +47,7 @@ public class MailToTransportInvalidFolderTestCase extends ESBIntegrationTest {
                 "MailTransportInvalidFolder","proxy-services",
                 true);
         carbonLogReader = new CarbonLogReader();
+        carbonLogReader.start();
 
         // Since ESB reads all unread emails one by one, we have to delete
         // the all unread emails before run the test
@@ -55,7 +56,6 @@ public class MailToTransportInvalidFolderTestCase extends ESBIntegrationTest {
 
     @Test(groups = { "wso2.esb" }, description = "Test email transport with invalid folder")
     public void testEmailTransportInvalidFolder() throws Exception {
-        carbonLogReader.start();
         assertTrue(carbonLogReader.checkForLog("FolderABC not found", DEFAULT_TIMEOUT),
                 "Couldn't find the error message in log");
     }
@@ -63,6 +63,7 @@ public class MailToTransportInvalidFolderTestCase extends ESBIntegrationTest {
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
         Utils.undeploySynapseConfiguration("MailTransportInvalidFolder","proxy-services");
+        carbonLogReader.stop();
     }
 
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportPreserveHeadersTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportPreserveHeadersTestCase.java
@@ -60,6 +60,7 @@ public class MailToTransportPreserveHeadersTestCase extends ESBIntegrationTest {
         carbonLogReader = new CarbonLogReader();
         greenMailUser = GreenMailServer.getPrimaryUser();
         greenMailClient = new GreenMailClient(greenMailUser);
+        carbonLogReader.start();
 
         // Since ESB reads all unread emails one by one, we have to delete
         // the all unread emails before run the test
@@ -68,7 +69,6 @@ public class MailToTransportPreserveHeadersTestCase extends ESBIntegrationTest {
 
     @Test(groups = { "wso2.esb" }, description = "Test email transport preserve header parameter")
     public void testEmailPreserveHeaderTransport() throws Exception {
-        carbonLogReader.start();
         Date date = new Date();
         String emailSubject = "Preserve Headers Test : " + new Timestamp(date.getTime());
         Map<String, String> headers = new HashMap<>();
@@ -82,6 +82,7 @@ public class MailToTransportPreserveHeadersTestCase extends ESBIntegrationTest {
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
         Utils.undeploySynapseConfiguration("MailTransportPreserveHeader","proxy-services");
+        carbonLogReader.stop();
     }
 
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportRemoveHeaderTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mailto/transport/receiver/test/MailToTransportRemoveHeaderTestCase.java
@@ -58,6 +58,7 @@ public class MailToTransportRemoveHeaderTestCase extends ESBIntegrationTest {
         carbonLogReader = new CarbonLogReader();
         greenMailUser = GreenMailServer.getPrimaryUser();
         greenMailClient = new GreenMailClient(greenMailUser);
+        carbonLogReader.start();
 
         // Since ESB reads all unread emails one by one, we have to delete
         // the all unread emails before run the test
@@ -66,7 +67,6 @@ public class MailToTransportRemoveHeaderTestCase extends ESBIntegrationTest {
 
     @Test(groups = { "wso2.esb" }, description = "Test email transport remove header parameter")
     public void testEmailRemoveHeaderTransport() throws Exception {
-        carbonLogReader.start();
         Date date = new Date();
         String emailSubject = "Remove Headers Test : " + new Timestamp(date.getTime());
         greenMailClient.sendMail(emailSubject);
@@ -78,6 +78,7 @@ public class MailToTransportRemoveHeaderTestCase extends ESBIntegrationTest {
     @AfterClass(alwaysRun = true)
     public void deleteService() throws Exception {
         Utils.undeploySynapseConfiguration("MailTransportRemoveHeader","proxy-services");
+        carbonLogReader.stop();
     }
 
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mqtt/inbound/transport/test/MQTTInboundMessagePollingTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/mqtt/inbound/transport/test/MQTTInboundMessagePollingTestCase.java
@@ -29,7 +29,6 @@ import org.wso2.carbon.automation.extensions.servers.jmsserver.controller.config
 import org.wso2.carbon.esb.jms.utils.JMSBroker;
 import org.wso2.carbon.esb.mqtt.utils.MQTTTestClient;
 import org.wso2.carbon.esb.mqtt.utils.QualityOfService;
-import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
 import org.wso2.esb.integration.common.extensions.jmsserver.ActiveMQServerExtension;
 import org.wso2.esb.integration.common.utils.CarbonLogReader;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -45,7 +44,7 @@ import java.io.File;
  * 4. Inspect logs and check if message is consumed
  */
 public class MQTTInboundMessagePollingTestCase extends ESBIntegrationTest {
-
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
     private JMSBroker activeMQServer;
 
     @BeforeClass(alwaysRun = true)
@@ -59,12 +58,11 @@ public class MQTTInboundMessagePollingTestCase extends ESBIntegrationTest {
                 + "MQTT_Test_Inbound_EP.xml")));
         Utils.deploySynapseConfiguration(inboundOMElement, "MQTT_Test_Inbound_EP", "inbound-endpoints", true);
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Check if Inbound MQTT Transport receives messages without issue")
     public void testMQTTInboundEndpointMessagePolling() throws Exception {
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
         //connect to broker and publish a message
         String brokerURL = "tcp://localhost:1883";
         String userName = "admin";
@@ -88,7 +86,6 @@ public class MQTTInboundMessagePollingTestCase extends ESBIntegrationTest {
         //check EI log to see if message is consumed
         boolean result = carbonLogReader.checkForLog(messageToSend, DEFAULT_TIMEOUT);
         Assert.assertTrue(result, "Message is not found in log. Expected : " + messageToSend);
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
@@ -96,6 +93,7 @@ public class MQTTInboundMessagePollingTestCase extends ESBIntegrationTest {
         activeMQServer.stop();
         ActiveMQServerExtension.startMQServer();
         Utils.undeploySynapseConfiguration("MQTT_Test_Inbound_EP", "inbound-endpoints");
+        carbonLogReader.stop();
     }
 
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HeadMethodResponseTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HeadMethodResponseTestCase.java
@@ -28,17 +28,16 @@ import org.wso2.esb.integration.common.utils.clients.SimpleHttpClient;
 import static org.testng.Assert.assertFalse;
 
 public class HeadMethodResponseTestCase extends ESBIntegrationTest {
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = " Checking response for HEAD request contains a body")
     public void testResponseBodyOfHEADRequest() throws Exception {
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
-
         SimpleHttpClient httpClient = new SimpleHttpClient();
         httpClient.doGet(contextUrls.getServiceUrl() + "/HeadMethodResponseTestClientProxy", null);
 

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/PassthroughTransportHttpProxyTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/PassthroughTransportHttpProxyTestCase.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertTrue;
 
 public class PassthroughTransportHttpProxyTestCase extends ESBIntegrationTest {
     private ServerConfigurationManager serverConfigurationManager;
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
@@ -40,12 +41,11 @@ public class PassthroughTransportHttpProxyTestCase extends ESBIntegrationTest {
                 getESBResourceLocation() + File.separator + "passthru" + File.separator + "transport" + File.separator
                         + "httpproxy" + File.separator + "axis2.xml"));
         super.init();
+        carbonLogReader.start();
     }
 
     @Test(groups = "wso2.esb", description = "Passthrough Transport Http.proxy test case")
     public void passthroughTransportHttpProxy() throws Exception {
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
 
         try {
             axis2Client.sendSimpleStockQuoteRequest(getProxyServiceURLHttp("PassthroughTransportHttpTestProxy"), "", "IBM");
@@ -54,11 +54,11 @@ public class PassthroughTransportHttpProxyTestCase extends ESBIntegrationTest {
         }
         assertTrue(carbonLogReader.checkForLog("111.wso2.com:7777", DEFAULT_TIMEOUT),
                 "The log message with http proxy host was not found in passthroughTransportHttpProxy testcase.");
-        carbonLogReader.stop();
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
         serverConfigurationManager.restoreToLastMIConfiguration();
+        carbonLogReader.stop();
     }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/SetPropertyMessageBuilderInvokedWithEmptyContentTypeTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/SetPropertyMessageBuilderInvokedWithEmptyContentTypeTestCase.java
@@ -34,11 +34,13 @@ public class SetPropertyMessageBuilderInvokedWithEmptyContentTypeTestCase extend
     private static final String EXPECTED_ERROR_MESSAGE = "Could not save JSON payload. Invalid input stream found";
     private JSONClient jsonclient;
     private SimpleSocketServer simpleSocketServer;
+    CarbonLogReader carbonLogReader = new CarbonLogReader();
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
         jsonclient = new JSONClient();
+        carbonLogReader.start();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test whether the msg builder invoked property is set when the content"
@@ -59,9 +61,6 @@ public class SetPropertyMessageBuilderInvokedWithEmptyContentTypeTestCase extend
         final String jsonPayload = "{\"album\":\"Hello\",\"singer\":\"Peter\"}";
         String apiEp = getApiInvocationURL("setMessageBuilderInvokedWithEmptyContentType");
         jsonclient.sendUserDefineRequest(apiEp, jsonPayload.trim());
-
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
-        carbonLogReader.start();
 
         Assert.assertTrue(carbonLogReader.checkForLog("messageBuilderInvokedValue = true", 20),
                 "'message.builder.invoked' value is not set when the content type is empty.");


### PR DESCRIPTION
## Purpose
Fix Intermittent Test failures as part of Test Hackathon
-Remove obosolete methods
-Start the logReader thread @BeforeClass and stop @Afterclass (Reduce thread creation overhead)

