### PR TITLE
Upgrade carbon kernel version to 4.5.0.m1

### DIFF
--- a/components/org.wso2.carbon.micro.integrator.core/pom.xml
+++ b/components/org.wso2.carbon.micro.integrator.core/pom.xml
@@ -108,10 +108,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>de.jflex</groupId>
                 <artifactId>maven-jflex-plugin</artifactId>
                 <version>1.4.3</version>

--- a/components/org.wso2.carbon.micro.integrator.core/src/main/java/org/wso2/carbon/micro/integrator/core/deployment/AppDeployerServiceComponent.java
+++ b/components/org.wso2.carbon.micro.integrator.core/src/main/java/org/wso2/carbon/micro/integrator/core/deployment/AppDeployerServiceComponent.java
@@ -23,6 +23,12 @@ import org.apache.axis2.deployment.DeploymentException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.application.deployer.handler.DefaultAppDeployer;
 import org.wso2.carbon.application.deployer.synapse.FileRegistryResourceDeployer;
@@ -41,20 +47,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.util.Properties;
 
-/**
- * @scr.component name="application.deployer.dscomponent" immediate="true"
- * @scr.reference name="org.wso2.carbon.configCtx"
- * interface="org.wso2.carbon.utils.ConfigurationContextService" cardinality="1..1"
- * policy="dynamic" bind="setConfigurationContext" unbind="unsetConfigurationContext"
- * @scr.reference name="synapse.env.service"
- * interface="org.wso2.carbon.mediation.initializer.services.SynapseEnvironmentService"
- * cardinality="1..n" policy="dynamic" bind="setSynapseEnvironmentService"
- * unbind="unsetSynapseEnvironmentService"
- * @scr.reference name="ntask.service"
- * interface="org.wso2.carbon.ntask.core.service.TaskService"
- * cardinality="1..1" policy="dynamic" bind="setTaskService"
- * unbind="unsetTaskService"
- */
+@Component(
+        name = "micro.application.deployer.dscomponent",
+        immediate = true)
 public class AppDeployerServiceComponent {
 
     private static final Log log = LogFactory.getLog(AppDeployerServiceComponent.class);
@@ -63,6 +58,7 @@ public class AppDeployerServiceComponent {
     private SynapseEnvironmentService synapseEnvironmentService;
     private TaskService taskService;
 
+    @Activate
     protected void activate(ComponentContext ctxt) {
 
         log.debug("Activating AppDeployerServiceComponent");
@@ -103,6 +99,7 @@ public class AppDeployerServiceComponent {
         log.debug("MicroIntegrator artifact/Capp Deployment completed");
     }
 
+    @Deactivate
     protected void deactivate(ComponentContext ctxt) {
         log.debug("Deactivating AppDeployerServiceComponent");
     }
@@ -112,6 +109,12 @@ public class AppDeployerServiceComponent {
      *
      * @param configCtx Instance of ConfigurationContextService which wraps server configuration context
      */
+    @Reference(
+            name = "org.wso2.carbon.configCtx",
+            service = org.wso2.carbon.utils.ConfigurationContextService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetConfigurationContext")
     protected void setConfigurationContext(ConfigurationContextService configCtx) {
         this.configCtx = configCtx.getServerConfigContext();
     }
@@ -125,6 +128,12 @@ public class AppDeployerServiceComponent {
         this.configCtx = null;
     }
 
+    @Reference(
+            name = "ntask.service",
+            service = org.wso2.carbon.ntask.core.service.TaskService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetTaskService")
     protected void setTaskService(TaskService taskService) {
         this.taskService = taskService;
     }
@@ -140,6 +149,12 @@ public class AppDeployerServiceComponent {
      * @param synapseEnvironmentService SynapseEnvironmentService which contains information
      *                                  about the new Synapse Instance
      */
+    @Reference(
+            name = "synapse.env.service",
+            service = org.wso2.carbon.mediation.initializer.services.SynapseEnvironmentService.class,
+            cardinality = ReferenceCardinality.AT_LEAST_ONE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetSynapseEnvironmentService")
     protected void setSynapseEnvironmentService(SynapseEnvironmentService synapseEnvironmentService) {
         this.synapseEnvironmentService = synapseEnvironmentService;
     }

--- a/components/org.wso2.carbon.micro.integrator.core/src/main/java/org/wso2/carbon/micro/integrator/core/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.micro.integrator.core/src/main/java/org/wso2/carbon/micro/integrator/core/internal/ServiceComponent.java
@@ -44,6 +44,12 @@ import org.osgi.framework.ServiceEvent;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.http.HttpContext;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
@@ -103,16 +109,9 @@ import static org.apache.axis2.transport.TransportListener.HOST_ADDRESS;
 
 //import org.wso2.carbon.core.CarbonAxisConfigurator;
 
-/**
- * @scr.component name="micro.server.dscomponent"" immediate="true"
- * @scr.reference name="server.configuration.service" interface="org.wso2.carbon.base.api.ServerConfigurationService"
- * cardinality="1..1" policy="dynamic"  bind="setServerConfigurationService" unbind="unsetServerConfigurationService"
- * @scr.reference name="http.service" interface="org.osgi.service.http.HttpService"
- * cardinality="1..1" policy="dynamic"  bind="setHttpService" unbind="unsetHttpService"
- * @scr.reference name="application.manager"
- * interface="org.wso2.carbon.application.deployer.service.ApplicationManagerService"
- * cardinality="0..1" policy="dynamic" bind="setAppManager" unbind="unsetAppManager"
- **/
+@Component(
+        name = "micro.server.dscomponent",
+        immediate = true)
 public class ServiceComponent {
 
     private static Log log = LogFactory.getLog(ServiceComponent.class);
@@ -163,6 +162,7 @@ public class ServiceComponent {
         return bundleContext;
     }
 
+    @Activate
     protected void activate(ComponentContext ctxt) {
         try {
             // for new caching, every thread should has its own populated CC. During the deployment time we assume super tenant
@@ -193,6 +193,7 @@ public class ServiceComponent {
         }
     }
 
+    @Deactivate
     protected void deactivate(ComponentContext ctxt) {
         try {
         } catch (Throwable e) {
@@ -697,6 +698,12 @@ public class ServiceComponent {
 
     protected static HttpService httpService;
 
+    @Reference(
+            name = "server.configuration.service",
+            service = org.wso2.carbon.base.api.ServerConfigurationService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetServerConfigurationService")
     protected void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
         this.serverConfigurationService = serverConfigurationService;
         CarbonCoreDataHolder.getInstance().setServerConfigurationService(serverConfigurationService);
@@ -706,6 +713,12 @@ public class ServiceComponent {
         this.serverConfigurationService = null;
     }
 
+    @Reference(
+            name = "http.service",
+            service = org.osgi.service.http.HttpService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetHttpService")
     protected void setHttpService(HttpService httpService) {
         this.httpService = httpService;
         CarbonCoreDataHolder.getInstance().setHttpService(httpService);
@@ -715,7 +728,12 @@ public class ServiceComponent {
         this.httpService = null;
     }
 
-
+    @Reference(
+            name = "application.manager",
+            service = org.wso2.carbon.application.deployer.service.ApplicationManagerService.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAppManager")
     protected void setAppManager(ApplicationManagerService applicationManager) {
         this.applicationManager = applicationManager;
         CarbonCoreDataHolder.getInstance().setApplicationManager(applicationManager);

--- a/components/org.wso2.carbon.micro.integrator.core/src/main/java/org/wso2/carbon/micro/integrator/core/internal/StartupFinalizerServiceComponent.java
+++ b/components/org.wso2.carbon.micro.integrator.core/src/main/java/org/wso2/carbon/micro/integrator/core/internal/StartupFinalizerServiceComponent.java
@@ -29,6 +29,12 @@ import org.osgi.framework.ServiceListener;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.ServerStatus;
@@ -51,17 +57,10 @@ import java.util.TimerTask;
  * once all the required OSGi services in the system become available. This is because of the
  * fact  that requests from external parties should only be serviced after the Axis2 engine
  * & Carbon has  reached a stable and consistent state.
- *
- * @scr.component name="org.wso2.carbon.core.internal.StartupFinalizerServiceComponent"
- * immediate="true"
- * @scr.reference name="org.wso2.carbon.configCtx"
- * interface="org.wso2.carbon.utils.ConfigurationContextService" cardinality="1..1"
- * policy="dynamic" bind="setConfigurationContext" unbind="unsetConfigurationContext"
- * @scr.reference name="org.wso2.carbon.micro.integrator.core.deployment.DeploymentService"
- * interface="org.wso2.carbon.micro.integrator.core.deployment.DeploymentService"
- * cardinality="1..1" policy="dynamic" bind="setDeploymentService"
- * unbind="unsetDeploymentService"
- **/
+ */
+@Component(
+        name = "org.wso2.carbon.micro.integrator.core.internal.StartupFinalizerServiceComponent",
+        immediate = true)
 public class StartupFinalizerServiceComponent implements ServiceListener {
     private static final Log log = LogFactory.getLog(StartupFinalizerServiceComponent.class);
     private static final String TRANSPORT_MANAGER =
@@ -75,6 +74,7 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
     private CarbonCoreDataHolder dataHolder = CarbonCoreDataHolder.getInstance();
     private ServiceRegistration listerManagerServiceRegistration;
 
+    @Activate
     protected void activate(ComponentContext ctxt) {
         try {
 
@@ -117,6 +117,7 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
         }
     }
 
+    @Deactivate
     protected void deactivate(ComponentContext ctxt) {
         listerManagerServiceRegistration.unregister();
     }
@@ -238,6 +239,12 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
         System.getProperties().remove("setup"); // Clear the setup System property
     }
 
+    @Reference(
+            name = "org.wso2.carbon.configCtx",
+            service = org.wso2.carbon.utils.ConfigurationContextService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetConfigurationContext")
     protected void setConfigurationContext(ConfigurationContextService configCtx) {
         this.configCtx = configCtx.getServerConfigContext();
     }
@@ -246,6 +253,12 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
         this.configCtx = null;
     }
 
+    @Reference(
+            name = "org.wso2.carbon.micro.integrator.core.deployment.DeploymentService",
+            service = org.wso2.carbon.micro.integrator.core.deployment.DeploymentService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetDeploymentService")
     protected void setDeploymentService(DeploymentService deploymentService) {
         log.debug("Set DeploymentService");
     }

--- a/features/org.wso2.carbon.micro.integrator.server.feature/pom.xml
+++ b/features/org.wso2.carbon.micro.integrator.server.feature/pom.xml
@@ -188,6 +188,10 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.core.common:${carbon.kernel.version}
                                 </bundleDef>
+                                <bundleDef>org.wso2.orbit.commons-text:commons-text:${commons-text.orbit.version}
+                                </bundleDef>
+                                <bundleDef>org.wso2.orbit.org.apache.commons:commons-lang3:${commons-lang3.orbit.version}
+                                </bundleDef>
                                 <!--<bundleDef>org.wso2.carbon:org.wso2.carbon.core:${carbon.kernel.version}</bundleDef>-->
                                 <bundleDef>
                                     org.wso2.carbon:org.wso2.carbon.server.admin.common:${carbon.kernel.version}

--- a/p2-profile/carbon.product
+++ b/p2-profile/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.4.40" useFeatures="true" includeLaunchers="true">
+version="4.5.0.m1" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.4.40" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.4.40"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.5.0.m1"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -296,26 +296,26 @@
         <!-- Maven Plugin Version -->
         <maven.build.helper.plugin.version>3.0.0</maven.build.helper.plugin.version>
         <maven.xmlbeans-maven-plugin.plugin.version>2.3.3</maven.xmlbeans-maven-plugin.plugin.version>
-        <carbon.p2.plugin.version>1.5.8</carbon.p2.plugin.version>
+        <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
 
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.4.40</carbon.kernel.version>
+        <carbon.kernel.version>4.5.0-m1</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.4.0,5.0.0)</carbon.kernel.imp.pkg.version>
 
-        <synapse.version>2.1.7-wso2v111</synapse.version>
+        <synapse.version>2.1.7-wso2v115</synapse.version>
         <orbit.version.axis2>${axis2.wso2.version}</orbit.version.axis2>
         <carbon.mediation.version>4.7.4</carbon.mediation.version>
         <carbon.crypto.version>1.0.3</carbon.crypto.version>
-        <carbon.data.version>4.4.107</carbon.data.version>
-        <securevault.version>1.0.0-wso2v2</securevault.version>
+        <carbon.data.version>4.5.1</carbon.data.version>
+        <securevault.version>1.1.2</securevault.version>
 
         <cipher.tool.version>1.1.1</cipher.tool.version>
-        <axis2.transport.version>2.0.0-wso2v34</axis2.transport.version>
-        <axis2.wso2.version>1.6.1-wso2v35</axis2.wso2.version>
-        <carbon.analytics.common.version>5.1.57</carbon.analytics.common.version>
-        <carbon.commons.version>4.6.65</carbon.commons.version>
-        <carbon.rule.version>4.4.11</carbon.rule.version>
-        <carbon.deployment.version>4.8.3</carbon.deployment.version>
+        <axis2.transport.version>2.0.0-wso2v35</axis2.transport.version>
+        <axis2.wso2.version>1.6.1-wso2v37</axis2.wso2.version>
+        <carbon.analytics.common.version>5.2.1</carbon.analytics.common.version>
+        <carbon.commons.version>4.7.1</carbon.commons.version>
+        <carbon.rule.version>4.5.1</carbon.rule.version>
+        <carbon.deployment.version>4.9.3</carbon.deployment.version>
         <wss4j.version>1.5.11-wso2v18</wss4j.version>
         <rampart.wso2.version>1.6.1-wso2v34</rampart.wso2.version>
         <siddhi.version>3.2.3</siddhi.version>
@@ -341,7 +341,7 @@
         <orbit.version.tiles>2.0.5.wso2v1</orbit.version.tiles>
         <version.ant>1.7.0.wso2v1</version.ant>
         <version.xmlbeans>2.3.0.wso2v1</version.xmlbeans>
-        <orbit.version.axiom>1.2.11.wso2v13</orbit.version.axiom>
+        <orbit.version.axiom>1.2.11-wso2v16</orbit.version.axiom>
         <neethi.osgi.version>2.0.4.wso2v5</neethi.osgi.version>
         <version.woden>1.0.0.M9-wso2v1</version.woden>
         <orbit.version.wsdl4j>1.6.2.wso2v4</orbit.version.wsdl4j>
@@ -373,6 +373,8 @@
         <testng.version>6.11</testng.version>
         <javax.jms-api.version>2.0.1</javax.jms-api.version>
         <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
+        <commons-text.orbit.version>1.6.wso2v1</commons-text.orbit.version>
+        <commons-lang3.orbit.version>3.4.0.wso2v1</commons-lang3.orbit.version>
     </properties>
 
     <repositories>
@@ -489,7 +491,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.0</version>
+                    <version>3.2.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <obrRepository>NONE</obrRepository>


### PR DESCRIPTION
## Purpose
> This PR is related to the kernel version upgrade in Micro Integrator which for 4.5.0-m1. 

## Goals
- Upgrade related repositories pom versions in MI parent pom.
- Change the OSGI component annotations
- Remove maven-scr-plugin from micro.integrator.core