### PR TITLE
Add XQuery contentType to mediaType mapping in MI Registry

### DIFF
--- a/migration/registry/from-mi-1.0.0-to-later/src/main/java/RegistryMigrator.java
+++ b/migration/registry/from-mi-1.0.0-to-later/src/main/java/RegistryMigrator.java
@@ -140,6 +140,7 @@ public class RegistryMigrator {
         map.put(".xslt", "application/xslt+xml");
         map.put(".zip", "application/zip");
         map.put(".wsdl", "WSDL");
+        map.put(".xqy", "XQuery");
 
         return map;
     }


### PR DESCRIPTION
Add support for contentType XQuery in the RegistryMigrator tool

## Purpose
> Resolves #626 