### PR TITLE
Set tenantId as Super tenant in ConfigurationManager

### DIFF
--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/configurations/ConfigurationManager.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/configurations/ConfigurationManager.java
@@ -104,9 +104,6 @@ public class ConfigurationManager {
         if (parameter != null && parameter.getValue() != null) {
             synpaseConfigurationsRoot = parameter.getValue().toString();
         }
-
-        tenantId = PrivilegedCarbonContext.
-                getThreadLocalCarbonContext().getTenantId();
     }
 
     /**


### PR DESCRIPTION
## Purpose
Set tenantId as Super tenant in ConfigurationManager
Since tenant support is not available in MI set super tenant ID for tenantID