### PR TITLE
Resolve server startup

### DIFF
--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/ServiceBusInitializer.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/ServiceBusInitializer.java
@@ -198,9 +198,9 @@ public class ServiceBusInitializer {
                     configurationManager);
             // Start Inbound Endpoint Listeners
             // tOdO need to fix inbound endpoints
-            EndpointListenerLoader.loadListeners();
-            registerInboundDeployer(configCtxSvc.getServerConfigContext().getAxisConfiguration(), contextInfo
-                    .getSynapseEnvironment());
+//            EndpointListenerLoader.loadListeners();
+//            registerInboundDeployer(configCtxSvc.getServerConfigContext().getAxisConfiguration(), contextInfo
+//                    .getSynapseEnvironment());
         } catch (Exception e) {
             handleFatal("Couldn't initialize the ESB...", e);
         } catch (Throwable t) {
@@ -529,7 +529,7 @@ public class ServiceBusInitializer {
     /**
      * Register for inbound hot depoyment
      */
-    private void registerInboundDeployer(AxisConfiguration axisConfig, SynapseEnvironment synEnv) {
+    /*private void registerInboundDeployer(AxisConfiguration axisConfig, SynapseEnvironment synEnv) {
 
         DeploymentEngine deploymentEngine = (DeploymentEngine) axisConfig.getConfigurator();
         SynapseArtifactDeploymentStore deploymentStore = synEnv.getSynapseConfiguration().getArtifactDeploymentStore();
@@ -542,7 +542,7 @@ public class ServiceBusInitializer {
         }
         deploymentEngine.addDeployer(new InboundEndpointDeployer(), inboundDirPath, ServiceBusConstants
                 .ARTIFACT_EXTENSION);
-    }
+    }*/
 
 //    @Reference(
 //            name = "inbound.endpoint.persistence.service",

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/persistence/MediationPersistenceManager.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/persistence/MediationPersistenceManager.java
@@ -41,7 +41,6 @@ import org.apache.synapse.message.processor.MessageProcessor;
 import org.apache.synapse.message.store.MessageStore;
 import org.apache.synapse.rest.API;
 import org.wso2.carbon.micro.integrator.initializer.ServiceBusConstants;
-import org.wso2.carbon.utils.CarbonUtils;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.File;
@@ -335,9 +334,6 @@ public class MediationPersistenceManager {
                 log.debug("Starting the mediation persistence worker thread");
             }
 
-            if(CarbonUtils.isWorkerNode()){
-                log.info("This is a worker node, Mediation persistance manager will be disabled.");
-            }
             while (proceed) {
                 PersistenceRequest request;
 
@@ -354,10 +350,6 @@ public class MediationPersistenceManager {
                     }
 
                     // Simply go to the next iteration
-                    continue;
-                }
-                if(CarbonUtils.isWorkerNode()){
-                    log.debug("Ignoring persist request because this is a worker node");
                     continue;
                 }
                 try {


### PR DESCRIPTION
## Purpose
Resolves 2 issues:

1. NoClassDef CarbonUtils

```
Exception in thread "Thread-8" java.lang.NoClassDefFoundError: org/wso2/carbon/utils/CarbonUtils
	at org.wso2.carbon.micro.integrator.initializer.persistence.MediationPersistenceManager$MediationPersistenceWorker.run(MediationPersistenceManager.java:338)
Caused by: java.lang.ClassNotFoundException: org.wso2.carbon.utils.CarbonUtils cannot be found by org.wso2.carbon.micro.integrator.initializer_1.1.0.SNAPSHOT
```
This was eliminated by removing the reference for CarbonUtils for checking if the current node is a worker node since worker manager deployment pattern is not valid anymore

2. NoClassDef EndpointListenerLoader 

```
[2019-08-30 11:29:58,431] FATAL {org.wso2.carbon.micro.integrator.initializer.ServiceBusInitializer} - Failed to initialize ESB due to a fatal error java.lang.NoClassDefFoundError: org/wso2/carbon/inbound/endpoint/EndpointListenerLoader
	at org.wso2.carbon.micro.integrator.initializer.ServiceBusInitializer.activate(ServiceBusInitializer.java:201)
```
The references for EndpointListenerLoader were commented out for now since the focus is on configuring synapse related components