### PR TITLE
Resolve exceptions in shutdown

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/MbeanManagementFactory.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/MbeanManagementFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.micro.core;
+
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+
+/**
+ * The <tt>ManagementFactory</tt> class is a factory class for getting
+ * managed beans for the Java platform.
+ */
+public final class MbeanManagementFactory {
+
+    private MbeanManagementFactory() {
+        //disable external instantiation
+    }
+
+    /**
+     * @return An MBeanServer instance.
+     * If one already exists, will return that, else will create a new one and return
+     */
+    public static MBeanServer getMBeanServer() {
+        MBeanServer mserver;
+        if (MBeanServerFactory.findMBeanServer(null).size() > 0) {
+            mserver = MBeanServerFactory.findMBeanServer(null).get(0);
+        } else {
+            mserver = MBeanServerFactory.createMBeanServer();
+        }
+        return mserver;
+    }
+}

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/ServerManagement.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/ServerManagement.java
@@ -26,9 +26,7 @@ import org.osgi.util.tracker.ServiceTracker;
 import org.wso2.micro.integrator.core.internal.CarbonCoreDataHolder;
 import org.wso2.micro.integrator.core.util.MicroIntegratorBaseUtils;
 import org.wso2.carbon.utils.FileManipulator;
-import org.wso2.carbon.utils.ManagementFactory;
 import org.wso2.carbon.utils.ServerConstants;
-import org.wso2.carbon.utils.WaitBeforeShutdownObserver;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -106,9 +104,9 @@ public class ServerManagement {
         BundleContext bundleContext = dataHolder.getBundleContext();
         if (bundleContext != null) {
             @SuppressWarnings("unchecked")
-            ServiceTracker tracker =
-                    new ServiceTracker(bundleContext,
-                            WaitBeforeShutdownObserver.class.getName(), null);
+            ServiceTracker tracker = new ServiceTracker(bundleContext,
+                                                        WaitBeforeShutdownObserver.class.getName(),
+                                                        null);
             tracker.open();
             Object[] services = tracker.getServices();
             if (services != null) {
@@ -199,7 +197,7 @@ public class ServerManagement {
          * Get all MBeans with names such as Catalina:type=RequestProcessor,worker=http-9762,name=HttpRequest<n>
          * & Catalina:type=RequestProcessor,worker=http-9762,name=HttpsRequest<n>
          */
-        MBeanServer mbs = ManagementFactory.getMBeanServer();
+        MBeanServer mbs = MbeanManagementFactory.getMBeanServer();
         boolean areRequestsInService;
         long start = System.currentTimeMillis();
         do {

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/WaitBeforeShutdownObserver.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/WaitBeforeShutdownObserver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.micro.core;
+
+/**
+ * This interface must be implemented by classes (mainly threads etc), that require notification
+ * and waiting before the shutdown sequence commences in the process of a graceful shutdown.
+ */
+public interface WaitBeforeShutdownObserver {
+
+    /**
+     * This method will be invoked on all running components before shutdown happens.
+     */
+    void startingShutdown();
+
+    /**
+     * The server will wait for all tasks to complete before shutting down.
+     *
+     * @return true if the server needs to wait or false if not.
+     */
+    boolean isTaskComplete();
+
+}

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/StartupFinalizerServiceComponent.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/StartupFinalizerServiceComponent.java
@@ -117,7 +117,7 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
 
     @Deactivate
     protected void deactivate(ComponentContext ctxt) {
-        listerManagerServiceRegistration.unregister();
+//        listerManagerServiceRegistration.unregister();
     }
 
     private void populateRequiredServices() {


### PR DESCRIPTION
## Purpose
Fixes the issue of no classDef MbeanManagementFactory by moving the class from carbon kernel to mi core.

Fixes the NPE StartupFinalizerServiceComponent.deactivate() by commenting out the code inside it which need to be uncommented after the initialization is corrected.