### PR TITLE
Move AppDeployerServiceComponent to intializer bundle

### DIFF
--- a/components/org.wso2.carbon.micro.integrator.extensions/org.wso2.carbon.micro.integrator.management.apis/src/main/java/org/wso2/carbon/micro/integrator/management/apis/CarbonAppResource.java
+++ b/components/org.wso2.carbon.micro.integrator.extensions/org.wso2.carbon.micro.integrator.management.apis/src/main/java/org/wso2/carbon/micro/integrator/management/apis/CarbonAppResource.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.wso2.micro.integrator.core.deployment.application.deployer.CAppDeploymentManager.getCarbonApps;
+import static org.wso2.carbon.micro.integrator.initializer.deployment.application.deployer.CAppDeploymentManager.getCarbonApps;
 
 public class CarbonAppResource extends APIResource {
 

--- a/components/org.wso2.carbon.micro.integrator.extensions/org.wso2.carbon.micro.integrator.management.apis/src/main/java/org/wso2/carbon/micro/integrator/management/apis/ConnectorResource.java
+++ b/components/org.wso2.carbon.micro.integrator.extensions/org.wso2.carbon.micro.integrator.management.apis/src/main/java/org/wso2/carbon/micro/integrator/management/apis/ConnectorResource.java
@@ -33,7 +33,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.carbon.mediation.initializer.ServiceBusUtils;
 import org.wso2.carbon.mediation.initializer.persistence.MediationPersistenceManager;
-import org.wso2.micro.integrator.core.deployment.synapse.deployer.SynapseAppDeployer;
+import org.wso2.carbon.micro.integrator.initializer.deployment.synapse.deployer.SynapseAppDeployer;
 
 import java.io.IOException;
 import java.util.HashSet;

--- a/components/org.wso2.carbon.micro.integrator.initializer/pom.xml
+++ b/components/org.wso2.carbon.micro.integrator.initializer/pom.xml
@@ -123,6 +123,7 @@
                             org.wso2.carbon.micro.integrator.initializer.services.SynapseEnvironmentService
                         </CAPP_MANAGER-RequiredServices>
                         <Export-Package>
+                            !org.wso2.carbon.micro.integrator.initializer.deployment.internal,
                             org.wso2.carbon.micro.integrator.initializer.*;version="${project.version}"
                         </Export-Package>
                         <Import-Package>

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/AppDeployerServiceComponent.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/AppDeployerServiceComponent.java
@@ -15,11 +15,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.wso2.micro.integrator.core.deployment;
+package org.wso2.carbon.micro.integrator.initializer.deployment;
 
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.deployment.DeploymentEngine;
-import org.apache.axis2.deployment.DeploymentException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
@@ -29,26 +28,22 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.micro.integrator.initializer.services.SynapseEnvironmentService;
 import org.wso2.micro.core.util.CarbonException;
 import org.wso2.micro.application.deployer.handler.DefaultAppDeployer;
-import org.wso2.carbon.application.deployer.synapse.FileRegistryResourceDeployer;
-//import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.micro.integrator.core.deployment.application.deployer.CAppDeploymentManager;
-import org.wso2.micro.integrator.core.deployment.artifact.deployer.ArtifactDeploymentManager;
-import org.wso2.micro.integrator.core.deployment.internal.DeploymentServiceImpl;
-import org.wso2.micro.integrator.core.deployment.synapse.deployer.SynapseAppDeployer;
-import org.wso2.micro.integrator.core.internal.PrivilegedCarbonContext;
-import org.wso2.carbon.dataservices.core.DBDeployer;
-import org.wso2.carbon.mediation.initializer.services.SynapseEnvironmentService;
+import org.wso2.carbon.micro.integrator.initializer.deployment.application.deployer.CAppDeploymentManager;
+import org.wso2.carbon.micro.integrator.initializer.deployment.artifact.deployer.ArtifactDeploymentManager;
+import org.wso2.carbon.micro.integrator.initializer.deployment.internal.DeploymentServiceImpl;
+import org.wso2.carbon.micro.integrator.initializer.deployment.synapse.deployer.SynapseAppDeployer;
+//import org.wso2.carbon.dataservices.core.DBDeployer;
 import org.wso2.carbon.ntask.core.service.TaskService;
-import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.micro.integrator.core.services.Axis2ConfigurationContextService;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Properties;
 
-@Component(name = "org.wso2.micro.integrator.core.deployment.AppDeployerServiceComponent", immediate = true)
+@Component(name = "org.wso2.carbon.micro.integrator.initializer.deployment.AppDeployerServiceComponent", immediate = true)
 public class AppDeployerServiceComponent {
 
     private static final Log log = LogFactory.getLog(AppDeployerServiceComponent.class);
@@ -62,10 +57,6 @@ public class AppDeployerServiceComponent {
 
         log.debug("Activating AppDeployerServiceComponent");
 
-        PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext
-                .getThreadLocalCarbonContext();
-        privilegedCarbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-        privilegedCarbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
         // Update DataHolder with SynapseEnvironmentService
         DataHolder.getInstance().setSynapseEnvironmentService(this.synapseEnvironmentService);
         DataHolder.getInstance().setConfigContext(this.configCtx);
@@ -127,7 +118,8 @@ public class AppDeployerServiceComponent {
         this.configCtx = null;
     }
 
-    @Reference(
+    // TODO :- uncomment when satisfied
+  /*  @Reference(
             name = "ntask.service",
             service = org.wso2.carbon.ntask.core.service.TaskService.class,
             cardinality = ReferenceCardinality.MANDATORY,
@@ -138,7 +130,7 @@ public class AppDeployerServiceComponent {
     }
 
     protected void unsetTaskService(TaskService taskService) {
-    }
+    }*/
 
     /**
      * Receive an event about the creation of a SynapseEnvironment. If this is
@@ -150,7 +142,7 @@ public class AppDeployerServiceComponent {
      */
     @Reference(
             name = "synapse.env.service",
-            service = org.wso2.carbon.mediation.initializer.services.SynapseEnvironmentService.class,
+            service = org.wso2.carbon.micro.integrator.initializer.services.SynapseEnvironmentService.class,
             cardinality = ReferenceCardinality.AT_LEAST_ONE,
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetSynapseEnvironmentService")
@@ -181,17 +173,18 @@ public class AppDeployerServiceComponent {
 
         log.debug("Initializing ArtifactDeploymentManager deployment manager");
 
+        // TODO :- unComment after installing DSS
         // Create data services deployer
-        DBDeployer dbDeployer = new DBDeployer();
-        dbDeployer.setDirectory(artifactRepoPath + DeploymentConstants.DSS_DIR_NAME);
-        dbDeployer.setExtension(DeploymentConstants.DSS_TYPE_EXTENSION);
+//        DBDeployer dbDeployer = new DBDeployer();
+//        dbDeployer.setDirectory(artifactRepoPath + DeploymentConstants.DSS_DIR_NAME);
+//        dbDeployer.setExtension(DeploymentConstants.DSS_TYPE_EXTENSION);
 
         // Register artifact deployers in ArtifactDeploymentManager
-        try {
-            artifactDeploymentManager.registerDeployer(artifactRepoPath + DeploymentConstants.DSS_DIR_NAME, dbDeployer);
-        } catch (DeploymentException e) {
-            log.error("Error occurred while registering data services deployer");
-        }
+//        try {
+//            artifactDeploymentManager.registerDeployer(artifactRepoPath + DeploymentConstants.DSS_DIR_NAME, dbDeployer);
+//        } catch (DeploymentException e) {
+//            log.error("Error occurred while registering data services deployer");
+//        }
 
         Properties properties = new Properties();
         try (FileInputStream fis = new FileInputStream(System.getProperty("conf.location") + File.separator + "synapse.properties")) {
@@ -208,7 +201,8 @@ public class AppDeployerServiceComponent {
 
         // Register deployers in DeploymentEngine (required for CApp deployment)
         DeploymentEngine deploymentEngine = (DeploymentEngine) configCtx.getAxisConfiguration().getConfigurator();
-        deploymentEngine.addDeployer(dbDeployer, DeploymentConstants.DSS_DIR_NAME, DeploymentConstants.DSS_TYPE_DBS);
+      // TODO :- Uncomment after having DSS
+        //  deploymentEngine.addDeployer(dbDeployer, DeploymentConstants.DSS_DIR_NAME, DeploymentConstants.DSS_TYPE_DBS);
 
         // Register application deployment handlers
         //TODO

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/DataHolder.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/DataHolder.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.micro.integrator.core.deployment;
+package org.wso2.carbon.micro.integrator.initializer.deployment;
 
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.deployment.Deployer;
@@ -27,13 +27,12 @@ import org.apache.synapse.deployers.InboundEndpointDeployer;
 import org.apache.synapse.deployers.MessageProcessorDeployer;
 import org.apache.synapse.deployers.MessageStoreDeployer;
 import org.apache.synapse.deployers.TemplateDeployer;
-import org.wso2.carbon.endpoint.EndpointDeployer;
-import org.wso2.micro.integrator.core.deployment.synapse.deployer.SynapseAppDeployerConstants;
-import org.wso2.carbon.localentry.LocalEntryDeployer;
-import org.wso2.carbon.mediation.initializer.services.SynapseEnvironmentService;
-import org.wso2.carbon.mediation.startup.StartupTaskDeployer;
+//import org.wso2.carbon.endpoint.EndpointDeployer;
+import org.wso2.carbon.micro.integrator.initializer.deployment.synapse.deployer.SynapseAppDeployerConstants;
+//import org.wso2.carbon.localentry.LocalEntryDeployer;
+//import org.wso2.carbon.mediation.startup.StartupTaskDeployer;
+import org.wso2.carbon.micro.integrator.initializer.services.SynapseEnvironmentService;
 import org.wso2.carbon.proxyadmin.ProxyServiceDeployer;
-import org.wso2.carbon.sequences.SequenceDeploymentInterceptor;
 
 import java.util.HashMap;
 
@@ -101,16 +100,19 @@ public class DataHolder {
      * Function to initialize deployers with default deployers. Need to invoke this before adding custom implementations
      */
     public void initializeDefaultSynapseDeployers() {
-        addSynapseDeployer(SynapseAppDeployerConstants.LOCAL_ENTRY_TYPE, new LocalEntryDeployer());
-        addSynapseDeployer(SynapseAppDeployerConstants.ENDPOINT_TYPE, new EndpointDeployer());
-        addSynapseDeployer(SynapseAppDeployerConstants.SEQUENCE_TYPE, new SequenceDeploymentInterceptor());
+        // TODO :- uncomment after having these.
+      //  addSynapseDeployer(SynapseAppDeployerConstants.LOCAL_ENTRY_TYPE, new LocalEntryDeployer());
+     //   addSynapseDeployer(SynapseAppDeployerConstants.ENDPOINT_TYPE, new EndpointDeployer());
+       // addSynapseDeployer(SynapseAppDeployerConstants.SEQUENCE_TYPE, new SequenceDeploymentInterceptor());
         addSynapseDeployer(SynapseAppDeployerConstants.TEMPLATE_TYPE, new TemplateDeployer());
-        addSynapseDeployer(SynapseAppDeployerConstants.TASK_TYPE, new StartupTaskDeployer());
+// TODO Caused by: java.lang.ClassNotFoundException: org.wso2.carbon.mediation.initializer.ServiceBusUtils cannot be
+        //  found by org.wso2.carbon.mediation.startup_4.7.10
+      //  addSynapseDeployer(SynapseAppDeployerConstants.TASK_TYPE, new StartupTaskDeployer());
         addSynapseDeployer(SynapseAppDeployerConstants.MESSAGE_STORE_TYPE, new MessageStoreDeployer());
         addSynapseDeployer(SynapseAppDeployerConstants.MESSAGE_PROCESSOR_TYPE, new MessageProcessorDeployer());
         addSynapseDeployer(SynapseAppDeployerConstants.INBOUND_ENDPOINT_TYPE, new InboundEndpointDeployer());
         addSynapseDeployer(SynapseAppDeployerConstants.API_TYPE, new APIDeployer());
-        addSynapseDeployer(SynapseAppDeployerConstants.PROXY_SERVICE_TYPE, new ProxyServiceDeployer());
+//        addSynapseDeployer(SynapseAppDeployerConstants.PROXY_SERVICE_TYPE, new ProxyServiceDeployer());
     }
 
     /**

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/DeploymentConstants.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/DeploymentConstants.java
@@ -16,27 +16,16 @@
  * under the License.
  */
 
-package org.wso2.micro.integrator.core.deployment;
+package org.wso2.carbon.micro.integrator.initializer.deployment;
 
-import org.wso2.micro.integrator.core.deployment.application.deployer.CAppDeploymentManager;
-import org.wso2.micro.integrator.core.deployment.artifact.deployer.ArtifactDeploymentManager;
+public class DeploymentConstants {
 
-/**
- * This interface represent the task OSGI service
- */
-public interface DeploymentService {
+    public static final String CAPP_DIR_NAME = "carbonapps";
+    public static final String DSS_DIR_NAME = "dataservices";
+    public static final String EVENT_STREAMS_DIR_NAME = "eventstreams";
+    public static final String EVENT_PUBLISHERS_DIR_NAME = "eventpublishers";
 
-     /**
-      * Return ArtifactDeploymentManager
-      *
-      * @return
-      */
-     public ArtifactDeploymentManager getArtifactDeploymentManager();
-
-     /**
-      * Return CAppDeploymentManager
-      *
-      * @return
-      */
-     public CAppDeploymentManager getCAppDeploymentManager();
+    public static final String DSS_TYPE_DBS = "dbs";
+    public static final String XML_TYPE_EXTENSION = "xml";
+    public static final String DSS_TYPE_EXTENSION = ".dbs";
 }

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/DeploymentService.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/DeploymentService.java
@@ -16,16 +16,27 @@
  * under the License.
  */
 
-package org.wso2.micro.integrator.core.deployment;
+package org.wso2.carbon.micro.integrator.initializer.deployment;
 
-public class DeploymentConstants {
+import org.wso2.carbon.micro.integrator.initializer.deployment.application.deployer.CAppDeploymentManager;
+import org.wso2.carbon.micro.integrator.initializer.deployment.artifact.deployer.ArtifactDeploymentManager;
 
-    public static final String CAPP_DIR_NAME = "carbonapps";
-    public static final String DSS_DIR_NAME = "dataservices";
-    public static final String EVENT_STREAMS_DIR_NAME = "eventstreams";
-    public static final String EVENT_PUBLISHERS_DIR_NAME = "eventpublishers";
+/**
+ * This interface represent the task OSGI service
+ */
+public interface DeploymentService {
 
-    public static final String DSS_TYPE_DBS = "dbs";
-    public static final String XML_TYPE_EXTENSION = "xml";
-    public static final String DSS_TYPE_EXTENSION = ".dbs";
+     /**
+      * Return ArtifactDeploymentManager
+      *
+      * @return
+      */
+     public ArtifactDeploymentManager getArtifactDeploymentManager();
+
+     /**
+      * Return CAppDeploymentManager
+      *
+      * @return
+      */
+     public CAppDeploymentManager getCAppDeploymentManager();
 }

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/application/deployer/CAppDeploymentManager.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/application/deployer/CAppDeploymentManager.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.micro.integrator.core.deployment.application.deployer;
+package org.wso2.carbon.micro.integrator.initializer.deployment.application.deployer;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/artifact/deployer/ArtifactDeploymentManager.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/artifact/deployer/ArtifactDeploymentManager.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.micro.integrator.core.deployment.artifact.deployer;
+package org.wso2.carbon.micro.integrator.initializer.deployment.artifact.deployer;
 
 import org.apache.axis2.deployment.Deployer;
 import org.apache.axis2.deployment.DeploymentException;

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/internal/DeploymentServiceImpl.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/internal/DeploymentServiceImpl.java
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-package org.wso2.micro.integrator.core.deployment.internal;
+package org.wso2.carbon.micro.integrator.initializer.deployment.internal;
 
-import org.wso2.micro.integrator.core.deployment.application.deployer.CAppDeploymentManager;
-import org.wso2.micro.integrator.core.deployment.DeploymentService;
-import org.wso2.micro.integrator.core.deployment.artifact.deployer.ArtifactDeploymentManager;
+import org.wso2.carbon.micro.integrator.initializer.deployment.application.deployer.CAppDeploymentManager;
+import org.wso2.carbon.micro.integrator.initializer.deployment.DeploymentService;
+import org.wso2.carbon.micro.integrator.initializer.deployment.artifact.deployer.ArtifactDeploymentManager;
 
 public class DeploymentServiceImpl implements DeploymentService{
 

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.wso2.micro.integrator.core.deployment.synapse.deployer;
+package org.wso2.carbon.micro.integrator.initializer.deployment.synapse.deployer;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMException;
@@ -51,11 +51,11 @@ import org.wso2.micro.application.deployer.CarbonApplication;
 import org.wso2.micro.application.deployer.config.Artifact;
 import org.wso2.micro.application.deployer.config.CappFile;
 import org.wso2.micro.application.deployer.handler.AppDeploymentHandler;
-import org.wso2.carbon.mediation.initializer.ServiceBusConstants;
-import org.wso2.carbon.mediation.initializer.ServiceBusUtils;
-import org.wso2.carbon.mediation.initializer.persistence.MediationPersistenceManager;
+import org.wso2.carbon.micro.integrator.initializer.ServiceBusConstants;
+import org.wso2.carbon.micro.integrator.initializer.ServiceBusUtils;
+import org.wso2.carbon.micro.integrator.initializer.persistence.MediationPersistenceManager;
 import org.wso2.carbon.mediation.library.util.LocalEntryUtil;
-import org.wso2.micro.integrator.core.deployment.DataHolder;
+import org.wso2.carbon.micro.integrator.initializer.deployment.DataHolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployerConstants.java
+++ b/components/org.wso2.carbon.micro.integrator.initializer/src/main/java/org/wso2/carbon/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployerConstants.java
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.wso2.micro.integrator.core.deployment.synapse.deployer;
+package org.wso2.carbon.micro.integrator.initializer.deployment.synapse.deployer;
 
 public class SynapseAppDeployerConstants {
 

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/StartupFinalizerServiceComponent.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/StartupFinalizerServiceComponent.java
@@ -15,10 +15,10 @@
  */
 package org.wso2.micro.integrator.core.internal;
 
-//import org.apache.axis2.AxisFault;
+import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.ConfigurationContext;
-//import org.apache.axis2.description.Parameter;
-//import org.apache.axis2.engine.ListenerManager;
+import org.apache.axis2.description.Parameter;
+import org.apache.axis2.engine.ListenerManager;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.Bundle;
@@ -36,12 +36,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.CarbonConstants;
-//import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.micro.integrator.core.deployment.DeploymentService;
-//import org.wso2.carbon.micro.integrator.core.util.MicroIntegratorBaseUtils;
-//import org.wso2.carbon.micro.integrator.core.util.MicroIntegratorBaseUtils;
+import org.wso2.micro.core.ServerStatus;
 import org.wso2.micro.integrator.core.services.Axis2ConfigurationContextService;
-import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,8 +57,6 @@ import java.util.TimerTask;
 public class StartupFinalizerServiceComponent implements ServiceListener {
     private static final Log log = LogFactory.getLog(StartupFinalizerServiceComponent.class);
     private static final String START_TIME = "wso2carbon.start.time";
-//    private static final String TRANSPORT_MANAGER =
-//            "org.wso2.carbon.tomcat.ext.transport.ServletTransportManager";
 
     private ConfigurationContext configCtx;
     private List<String> requiredServices = new ArrayList<String>();
@@ -77,11 +71,7 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
         try {
 
             bundleContext = ctxt.getBundleContext();
-//            PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext
-//                    .getThreadLocalCarbonContext();
-//            privilegedCarbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-//            privilegedCarbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
-//            populateRequiredServices();
+            populateRequiredServices();
             if (requiredServices.isEmpty()) {
                 completeInitialization(bundleContext);
                 return;
@@ -117,7 +107,7 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
 
     @Deactivate
     protected void deactivate(ComponentContext ctxt) {
-//        listerManagerServiceRegistration.unregister();
+        listerManagerServiceRegistration.unregister();
     }
 
     private void populateRequiredServices() {
@@ -156,12 +146,12 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
 
         bundleContext.removeServiceListener(this);
         pendingServicesObservationTimer.cancel();
-//        ListenerManager listenerManager = configCtx.getListenerManager();
-//        if (listenerManager == null) {
-//            listenerManager = new ListenerManager();
-//        }
-//        listenerManager.setShutdownHookRequired(false);
-//        listenerManager.startSystem(configCtx);
+        ListenerManager listenerManager = configCtx.getListenerManager();
+        if (listenerManager == null) {
+            listenerManager = new ListenerManager();
+        }
+        listenerManager.setShutdownHookRequired(false);
+        listenerManager.startSystem(configCtx);
 
         //if (CarbonUtils.isRunningInStandaloneMode()) {
 //            try {
@@ -175,8 +165,8 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
 //                return;
 //            }
        // }
-//        listerManagerServiceRegistration =
-//                bundleContext.registerService(ListenerManager.class.getName(), listenerManager, null);
+        listerManagerServiceRegistration =
+                bundleContext.registerService(ListenerManager.class.getName(), listenerManager, null);
 /*        try {
             new JMXServerManager().startJMXService();
         } catch (ServerException e) {
@@ -193,25 +183,25 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
     }
     
     private void setServerStartTimeParam() {
-//        Parameter startTimeParam = new Parameter();
-//        startTimeParam.setName(CarbonConstants.SERVER_START_TIME);
-//        startTimeParam.setValue(System.getProperty(CarbonConstants.START_TIME));
-//        try {
-//            configCtx.getAxisConfiguration().addParameter(startTimeParam);
-//        } catch (AxisFault e) {
-//            log.error("Could not set the  server start time parameter", e);
-//        }
+        Parameter startTimeParam = new Parameter();
+        startTimeParam.setName(CarbonConstants.SERVER_START_TIME);
+        startTimeParam.setValue(System.getProperty(CarbonConstants.START_TIME));
+        try {
+            configCtx.getAxisConfiguration().addParameter(startTimeParam);
+        } catch (AxisFault e) {
+            log.error("Could not set the  server start time parameter", e);
+        }
     }
     
     private void setServerStartUpDurationParam(String startupTime) {
-//        Parameter startupDurationParam = new Parameter();
-//        startupDurationParam.setName(CarbonConstants.START_UP_DURATION);
-//        startupDurationParam.setValue(startupTime);
-//        try {
-//            configCtx.getAxisConfiguration().addParameter(startupDurationParam);
-//        } catch (AxisFault e) {
-//            log.error("Could not set the  server start up duration parameter", e);
-//        }
+        Parameter startupDurationParam = new Parameter();
+        startupDurationParam.setName(CarbonConstants.START_UP_DURATION);
+        startupDurationParam.setValue(startupTime);
+        try {
+            configCtx.getAxisConfiguration().addParameter(startupDurationParam);
+        } catch (AxisFault e) {
+            log.error("Could not set the  server start up duration parameter", e);
+        }
     }
 
     private void printInfo() {
@@ -225,12 +215,12 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
         } catch (Exception e) {
             log.debug("Error while retrieving server configuration",e);
         }
-//        try {
-//            ServerStatus.setServerRunning();
-//        } catch (AxisFault e) {
-//            String msg = "Cannot set server to running mode";
-//            log.error(msg, e);
-//        }
+        try {
+            ServerStatus.setServerRunning();
+        } catch (AxisFault e) {
+            String msg = "Cannot set server to running mode";
+            log.error(msg, e);
+        }
         log.info("WSO2 Micro Integrator started in " + startupTime + " milli sec");
         setServerStartUpDurationParam(String.valueOf(startupTime));
 //        System.getProperties().remove(CarbonConstants.START_TIME);
@@ -251,6 +241,7 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
         this.configCtx = null;
     }
 
+    // TODO Move this component to a higher level so that this doesn't depend on initializer.
   /*  @Reference(
             name = "org.wso2.carbon.micro.integrator.core.deployment.DeploymentService",
             service = org.wso2.carbon.micro.integrator.core.deployment.DeploymentService.class,
@@ -261,10 +252,10 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
         log.debug("Set DeploymentService");
     }*/
 
-    protected void unsetDeploymentService(DeploymentService deploymentService) {
+    /*protected void unsetDeploymentService(DeploymentService deploymentService) {
         log.debug("Unset DeploymentService");
     }
-
+*/
     public synchronized void serviceChanged(ServiceEvent event) {
         if (event.getType() == ServiceEvent.REGISTERED) {
             String service =


### PR DESCRIPTION
## Purpose
> $subject

AppDeployerServiceComponent which resides in core bundle has a reference to the service SynapseEnvironmentService which is in initializer. Hence moving this to the initializer bundle to avoid cyclic dependency.