### PR TITLE
Fix build failure

### DIFF
--- a/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml
+++ b/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml
@@ -20,7 +20,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.wso2.ei</groupId>
-        <artifactId>mediators</artifactId>
+        <artifactId>builtin-mediators</artifactId>
         <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>


### PR DESCRIPTION
## Purpose
Fixes the following error:
```
The project org.wso2.ei:org.wso2.micro.integrator.mediators.server.feature:1.1.0-SNAPSHOT (/home/sasikala/Documents/ei/git/micro-integrator/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for org.wso2.ei:org.wso2.micro.integrator.mediators.server.feature:1.1.0-SNAPSHOT: Could not find artifact org.wso2.ei:mediators:pom:1.1.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 21, column 13 -> [Help 2]
```