### PR TITLE
Update p2 profile

### DIFF
--- a/distribution/src/conf/synapse-handlers.xml
+++ b/distribution/src/conf/synapse-handlers.xml
@@ -17,5 +17,8 @@
   -->
 
 <handlers>
-<!--  <handler name="IntegratorHandler" class="org.wso2.carbon.integrator.core.handler.IntegratorSynapseHandler"/>-->
+    <!--
+      Example
+    <handler name="IntegratorHandler" class="org.wso2.micro.integrator.example.SynapseHandler"/>
+      -->
 </handlers>

--- a/p2-profile/pom.xml
+++ b/p2-profile/pom.xml
@@ -228,10 +228,6 @@
 <!--                                    org.wso2.carbon.data:org.wso2.carbon.dataservices.task.server.feature:${carbon.data.version}-->
 <!--                                </featureArtifactDef>-->
 
-<!--                                <featureArtifactDef>-->
-<!--                                    org.wso2.carbon.mediation:org.wso2.carbon.integrator.server.feature:${carbon.mediation.version}-->
-<!--                                </featureArtifactDef>-->
-
                                 <featureArtifactDef>
                                     org.wso2.ei:org.wso2.micro.integrator.server.feature:${product.mi.version}
                                 </featureArtifactDef>
@@ -459,12 +455,6 @@
 <!--                                    <id>org.wso2.carbon.dataservices.task.server.feature.group</id>-->
 <!--                                    <version>${carbon.data.version}</version>-->
 <!--                                </feature>-->
-
-<!--                                <feature>-->
-<!--                                    <id>org.wso2.carbon.integrator.server.feature.group</id>-->
-<!--                                    <version>${carbon.mediation.version}</version>-->
-<!--                                </feature>-->
-
                                 <feature>
                                     <id>org.wso2.micro.integrator.server.feature.group</id>
                                     <version>${product.mi.version}</version>


### PR DESCRIPTION
## Purpose
> $subject

This PR removes org.wso2.carbon.integrator.server.feature from P2.

This feature was packing the following

IntegratorSynapseHandler -- used to dispatch requests to tomcat , hence not required.
IntegratorStatefulHandler  -- Moved to MI
RESTBasicAuthHandler    -- Not used in MI 
JsonStreamBuilder            -- Moved to MI
JsonStreamFormatter       -- Moved to MI
HeaderMapRequestWrapper -- Relates to tomcat.
IntegratorValve                       -- relates to Servelet transport.