### PR TITLE
Remove unnecessary features

### DIFF
--- a/p2-profile/pom.xml
+++ b/p2-profile/pom.xml
@@ -165,10 +165,6 @@
 <!--                                    org.wso2.carbon.commons:org.wso2.carbon.ndatasource.datasources.feature:${carbon.commons.version}-->
 <!--                                </featureArtifactDef>-->
 
-<!--                                <featureArtifactDef>-->
-<!--                                    org.wso2.carbon.commons:org.wso2.carbon.transaction.manager.feature:${carbon.commons.version}-->
-<!--                                </featureArtifactDef>-->
-
 <!--                                &lt;!&ndash;10 Carbon-rules&ndash;&gt;-->
 <!--                                <featureArtifactDef>-->
 <!--                                    org.wso2.carbon.rules:org.wso2.carbon.rule.mediation.server.feature:${carbon.rule.version}-->
@@ -373,11 +369,6 @@
 <!--                                </feature>-->
 <!--                                <feature>-->
 <!--                                    <id>org.wso2.carbon.ndatasource.datasources.feature.group</id>-->
-<!--                                    <version>${carbon.commons.version}</version>-->
-<!--                                </feature>-->
-
-<!--                                <feature>-->
-<!--                                    <id>org.wso2.carbon.transaction.manager.feature.group</id>-->
 <!--                                    <version>${carbon.commons.version}</version>-->
 <!--                                </feature>-->
 

--- a/p2-profile/pom.xml
+++ b/p2-profile/pom.xml
@@ -161,9 +161,6 @@
                                 <featureArtifactDef>
                                     org.wso2.ei:org.wso2.micro.integrator.ntask.core.feature:${project.version}
                                 </featureArtifactDef>
-<!--                                <featureArtifactDef>-->
-<!--                                    org.wso2.carbon.commons:org.wso2.carbon.ndatasource.datasources.feature:${carbon.commons.version}-->
-<!--                                </featureArtifactDef>-->
 
 <!--                                &lt;!&ndash;10 Carbon-rules&ndash;&gt;-->
 <!--                                <featureArtifactDef>-->
@@ -366,10 +363,6 @@
 <!--                                <feature>-->
 <!--                                    <id>org.wso2.carbon.das.messageflow.data.publisher.feature.group</id>-->
 <!--                                    <version>${carbon.mediation.version}</version>-->
-<!--                                </feature>-->
-<!--                                <feature>-->
-<!--                                    <id>org.wso2.carbon.ndatasource.datasources.feature.group</id>-->
-<!--                                    <version>${carbon.commons.version}</version>-->
 <!--                                </feature>-->
 
 <!--                                &lt;!&ndash;10 Carbon rule&ndash;&gt;-->


### PR DESCRIPTION
## Purpose
> $subject

org.wso2.carbon.transaction.manager.feature  registers TransactionManagerDummyService which is used in dataservcies core only. We need to check whether we need this there and add it in the data services core itself if we need it ( removing its service component behavior ) as this need some classes from kernel.

org.wso2.carbon.ndatasource.datasources.feature is used in carbon-data which is being refactored as it is using kenel and will be added here.
