### PR TITLE
Fix org.apache.bsf.xml.XMLHelper cannot be found

### DIFF
--- a/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml
+++ b/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml
@@ -38,6 +38,18 @@
             <groupId>org.wso2.ei</groupId>
             <artifactId>org.wso2.carbon.mediator.cache</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>rhino.wso2</groupId>
+            <artifactId>js</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.bsf.wso2</groupId>
+            <artifactId>bsf-all</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -66,6 +78,11 @@
                                     org.wso2.ei:org.wso2.carbon.mediator.cache:${product.mi.version}
                                 </bundleDef>
                             </bundles>
+                            <importBundles>
+                                <importBundleDef>rhino.wso2:js</importBundleDef>
+                                <importBundleDef>org.apache.velocity:velocity</importBundleDef>
+                                <importBundleDef>org.apache.bsf.wso2:bsf-all</importBundleDef>
+                            </importBundles>
                             <importFeatures>
                                 <importFeatureDef>org.apache.synapse.wso2:${synapse.version}</importFeatureDef>
                             </importFeatures>

--- a/features/org.wso2.micro.integrator.server.feature/pom.xml
+++ b/features/org.wso2.micro.integrator.server.feature/pom.xml
@@ -123,8 +123,8 @@
                                 <bundleDef>
                                     org.wso2.orbit.org.apache.tomcat:tomcat-jsp-api:${orbit.version.tomcat.jsp.api}
                                 </bundleDef>
-<!--                                <bundleDef>org.wso2.orbit.org.apache.tomcat:tomcat-el-api:${orbit.version.tomcat.el.api}-->
-<!--                                </bundleDef>-->
+                                <bundleDef>org.wso2.orbit.org.apache.tomcat:tomcat-el-api:${orbit.version.tomcat.el.api}
+                                </bundleDef>
 
 <!--                                for javax.servelt pkg-->
                                 <bundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,21 @@
                 <artifactId>stax2-api</artifactId>
                 <version>${stax2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.bsf.wso2</groupId>
+                <artifactId>bsf-all</artifactId>
+                <version>${org.apache.bsf.wso2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>rhino.wso2</groupId>
+                <artifactId>js</artifactId>
+                <version>${rhino.wso2.js.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.velocity</groupId>
+                <artifactId>velocity</artifactId>
+                <version>${org.apache.velocity.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -657,6 +672,10 @@
         <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
         <axiom.osgi.version.range>[1.2.11, 1.3.0)</axiom.osgi.version.range>
         <imp.package.version.osgi.services>[1.2.0,2.0.0)</imp.package.version.osgi.services>
+
+        <org.apache.bsf.wso2.version>3.0.0.wso2v5</org.apache.bsf.wso2.version>
+        <rhino.wso2.js.version>1.7.0.R4.wso2v1</rhino.wso2.js.version>
+        <org.apache.velocity.version>1.7</org.apache.velocity.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Fixes 
```
Caused by: java.lang.ClassNotFoundException: org.apache.bsf.xml.XMLHelper cannot be found by synapse-core_2.1.7.wso2v118
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:512)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:423)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:415)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:155)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	... 53 more
``
while running integration tests
