### PR TITLE
Add SERVICE_LOGFILE appender to log4j2 properties files

### DIFF
--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -39,7 +39,7 @@
 
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, osgi
+appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, osgi, SERVICE_LOGFILE
 #, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, CARBON_MEMORY, osgi
 #, syslog
 
@@ -68,6 +68,19 @@ appender.CARBON_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.CARBON_LOGFILE.strategy.max = 20
 appender.CARBON_LOGFILE.filter.threshold.type = ThresholdFilter
 appender.CARBON_LOGFILE.filter.threshold.level = DEBUG
+        
+# Appender config to SERVICE_LOGFILE
+appender.SERVICE_LOGFILE.type = RollingFile
+appender.SERVICE_LOGFILE.name = SERVICE_LOGFILE
+appender.SERVICE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-mi-service.log
+appender.SERVICE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-mi-service-%d{MM-dd-yyyy}.log
+appender.SERVICE_LOGFILE.layout.type = PatternLayout
+appender.SERVICE_LOGFILE.layout.pattern = TID: [%d] %5p {%c} - %m%ex%n
+appender.SERVICE_LOGFILE.policies.type = Policies
+appender.SERVICE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_LOGFILE.policies.size.size=10MB
+appender.SERVICE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_LOGFILE.strategy.max = 20
 
 # Appender config to AUDIT_LOGFILE
 appender.AUDIT_LOGFILE.type = RollingFile


### PR DESCRIPTION
## Purpose
> $subject

Fixes following error in server startup.

```
org.ops4j.pax.logging.pax-logging-api [log4j2] ERROR : Unable to locate appender "SERVICE_LOGFILE" for logger config "SERVICE_LOGGER" Ignored FQCN: org.apache.logging.log4j.spi.AbstractLogger
```