### PR TITLE
Remove tenant check for inbound dispatch

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/micro/integrator/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/micro/integrator/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -319,11 +319,6 @@ public class InboundHttpServerWorker extends ServerWorker {
         String reqUri = request.getUri();
         String servicePath = getSourceConfiguration().getConfigurationContext().getServicePath();
 
-        //for tenants, service path will be appended by tenant name
-        if (!reqUri.equalsIgnoreCase(SUPER_TENANT_DOMAIN_NAME)) {
-            servicePath = servicePath + "/t/" + SUPER_TENANT_DOMAIN_NAME;
-        }
-
         //Get the operation part from the request URL
         // e.g. '/services/TestProxy/' > TestProxy when service path is '/service/' > result 'TestProxy/'
         String serviceOpPart = Utils.getServiceAndOperationPart(reqUri, servicePath);


### PR DESCRIPTION
## Purpose
> $subject.

Since we have only super tenant in MI, we don't need to check the tenant domain and append it to the url.

Fixes HttpInboundDispatchTestCase