### PR TITLE
Add woodstox to classpath

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -59,6 +59,10 @@
             <groupId>org.wso2.ei</groupId>
             <artifactId>org.wso2.micro.integrator.bootstrap</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -541,6 +541,11 @@
                 <include>net.sf.saxon:Saxon-HE:jar</include>
                 <include>xerces.wso2:xercesImpl</include>
                 <include>commons-logging:commons-logging</include>
+                <!--
+                    woodstox should be in class path to xml builder (need javax.xml.stream.XMLInputFactory
+                        implementation to axis2)
+                -->
+                <include>org.codehaus.woodstox:woodstox-core-asl:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -552,6 +552,11 @@
                 <version>${stax2.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.codehaus.woodstox</groupId>
+                <artifactId>woodstox-core-asl</artifactId>
+                <version>${version.woodstox.core.asl}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
                 <artifactId>org.wso2.carbon.identity.oauth.stub</artifactId>
                 <version>${carbon.identity.oauth.version}</version>
@@ -866,6 +871,7 @@
         <aries.version>1.1.0</aries.version>
         <aries.proxy.version>1.0.1</aries.proxy.version>
         <stax2.version>3.1.4</stax2.version>
+        <version.woodstox.core.asl>4.4.1</version.woodstox.core.asl>
         <javax.jsr311.api.version>1.1.1</javax.jsr311.api.version>
 
         <javax.xml.parsers.import.pkg.version>[0.0.0, 1.0.0)</javax.xml.parsers.import.pkg.version>


### PR DESCRIPTION
## Purpose
> woodstox should be in class path to xml builder (need javax.xml.stream.XMLInputFactory implementation to axis2)
Originally this was identified when testcase fail org.wso2.carbon.esb.passthru.transport.test.PartialInputStreamReadError (Test case for Jira ESBJAVA-4616)