### PR TITLE
Add Null check for secureVaultRegex

### DIFF
--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/vault/VaultTool.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/vault/VaultTool.java
@@ -234,6 +234,8 @@ public class VaultTool {
         }
 
         String secureVaultRegex = properties.getProperty(Constants.SECURE_VALULT_PASSWORD_REGEX_SYSTEM_PROPERTY);
-        System.setProperty(Constants.SECURE_VALULT_PASSWORD_REGEX_SYSTEM_PROPERTY, secureVaultRegex);
+        if (secureVaultRegex != null) {
+            System.setProperty(Constants.SECURE_VALULT_PASSWORD_REGEX_SYSTEM_PROPERTY, secureVaultRegex);
+        }
     }
 }


### PR DESCRIPTION
+ This is required as setting null to a property throws an error

Related Issue : https://github.com/wso2/micro-integrator/pull/650 