### PR TITLE
CLI: implement authenticated calls to MI Management API

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -62,11 +62,13 @@ Command Line tool for managing the WSO2 Micro Integrator
             mi remote [command] [arguments]
                        
         Available Commands:
-            add [nick-name] [host] [port]        Add a Micro Integrator
-            remove [nick-name]                   Remove a Micro Integrator
-            update [nick-name] [host] [port]     Update a Micro Integrator
-            select [nick-name]                   Select a Micro Integrator on which commands are executed
-            show                                 Show available Micro Integrators
+            add [name] [host] [port]        Add a Micro Integrator
+            remove [name]                   Remove a Micro Integrator
+            update [name] [host] [port]     Update a Micro Integrator
+            select [name]                   Select a Micro Integrator instance on which commands are to be executed
+            show                            Show added Micro Integrator instances
+            login                           Login to the current Micro Integrator instance
+            logout                          Logout of the current Micro Integrator instance
 
         Examples:
             # To add a Micro Integrator
@@ -83,6 +85,12 @@ Command Line tool for managing the WSO2 Micro Integrator
             
             # To show available Micro Integrators
             mi remote show
+            
+            # login to the current (selected)  Micro Integrator instance
+            mi remote login     # will be prompted for username and password
+            
+            # login (with inline username and password)
+            mi remote login username password # or
 ```
    * #### log-level
 ```bash

--- a/cmd/cmd/apiShow.go
+++ b/cmd/cmd/apiShow.go
@@ -81,7 +81,7 @@ func executeGetAPICmd(apiname string) {
 
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixAPIs, "apiName", apiname)
 
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.API{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.API{})
 
 	if err == nil {
 		// Printing the details of the API
@@ -130,7 +130,7 @@ func executeListAPIsCmd() {
 
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixAPIs
 
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.APIList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.APIList{})
 
 	if err == nil {
 		// Printing the list of available APIs

--- a/cmd/cmd/compositeAppShow.go
+++ b/cmd/cmd/compositeAppShow.go
@@ -83,7 +83,7 @@ func executeGetCarbonAppCmd(appname string) {
 
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixCarbonApps, "carbonAppName", appname)
 
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.CompositeApp{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.CompositeApp{})
 
 	if err == nil {
 		// Printing the details of the Carbon App
@@ -122,7 +122,7 @@ func executeListCarbonAppsCmd() {
 
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixCarbonApps
 
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.CompositeAppList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.CompositeAppList{})
 
 	if err == nil {
 		// Printing the list of available Carbon apps

--- a/cmd/cmd/dataServiceShow.go
+++ b/cmd/cmd/dataServiceShow.go
@@ -70,7 +70,7 @@ func handleDataServiceCmdArguments(args []string) {
 func executeDataServiceListCmd() {
 	finalURL := utils.GetRESTAPIBase() + utils.PrefixDataServices
 
-	resp, err := utils.UnmarshalData(finalURL, nil, &artifactUtils.DataServicesList{})
+	resp, err := utils.UnmarshalData(finalURL, nil, nil, &artifactUtils.DataServicesList{})
 
 	if err == nil {
 		// print the list of available data services
@@ -83,7 +83,7 @@ func executeDataServiceListCmd() {
 
 func executeGetDataServiceCmd(dataServiceName string) {
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixDataServices, "dataServiceName", dataServiceName)
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.DataServiceInfo{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.DataServiceInfo{})
 
 	if err == nil {
 		// printing the details of the Data Service

--- a/cmd/cmd/endpointShow.go
+++ b/cmd/cmd/endpointShow.go
@@ -81,7 +81,7 @@ func executeGetEndpointCmd(endpointname string) {
 
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixEndpoints, "endpointName", endpointname)
 
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.Endpoint{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.Endpoint{})
 
 	if err == nil {
 		// Printing the details of the Endpoint
@@ -108,7 +108,7 @@ func executeListEndpointsCmd() {
 
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixEndpoints
 
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.EndpointList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.EndpointList{})
 
 	if err == nil {
 		// Printing the list of available Endpoints

--- a/cmd/cmd/inboundEndpointShow.go
+++ b/cmd/cmd/inboundEndpointShow.go
@@ -83,7 +83,7 @@ func executeGetInboundEndpointCmd(inboundEndpointname string) {
 
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixInboundEndpoints, "inboundEndpointName", inboundEndpointname)
 
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.InboundEndpoint{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.InboundEndpoint{})
 
 	if err == nil {
 		// Printing the details of the InboundEndpoint
@@ -124,7 +124,7 @@ func printInboundEndpoint(inbound artifactUtils.InboundEndpoint) {
 func executeListInboundEndpointsCmd() {
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixInboundEndpoints
 
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.InboundEndpointList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.InboundEndpointList{})
 
 	if err == nil {
 		// Printing the list of available Inbound endpoints

--- a/cmd/cmd/localEntryShow.go
+++ b/cmd/cmd/localEntryShow.go
@@ -81,7 +81,7 @@ func printLocalEntryHelp() {
 
 func executeGetLocalEntryCmd(localEntryName string) {
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixLocalEntries, "name", localEntryName)
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.LocalEntryData{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.LocalEntryData{})
 
 	if err == nil {
 		// Printing the details of the LocalEntry
@@ -100,7 +100,7 @@ func printLocalEntry(localEntry artifactUtils.LocalEntryData) {
 
 func executeListLocalEntryCmd() {
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixLocalEntries
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.LocalEntryList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.LocalEntryList{})
 
 	if err == nil {
 		// Printing the list of available Local Entries

--- a/cmd/cmd/logLevelShow.go
+++ b/cmd/cmd/logLevelShow.go
@@ -51,7 +51,8 @@ var loggerShowCmd = &cobra.Command{
 
 func init() {
 	logLevelCmd.AddCommand(loggerShowCmd)
-	loggerShowCmd.SetHelpTemplate(showLogLevelCmdLongDesc + showLogLevelCmdUsage + showLogLevelCmdExamples + utils.GetCmdFlags(logLevelCmdLiteral))
+	loggerShowCmd.SetHelpTemplate(showLogLevelCmdLongDesc + showLogLevelCmdUsage + showLogLevelCmdExamples +
+		utils.GetCmdFlags(logLevelCmdLiteral))
 }
 
 func handleShowLoggerCmdArguments(args []string) {
@@ -77,7 +78,7 @@ func executeGetLoggerCmd(loggerName string) {
 
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixLogging, "loggerName", loggerName)
 
-	resp, err := utils.UnmarshalData(finalUrl, params, &utils.Logger{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &utils.Logger{})
 
 	if err == nil {
 		// Printing the details of the Logger

--- a/cmd/cmd/login.go
+++ b/cmd/cmd/login.go
@@ -1,0 +1,102 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
+	"github.com/wso2/micro-integrator/cmd/utils"
+)
+
+var username string
+var password string
+
+const loginCmdLiteral = "login"
+const loginCmdShortDesc = "Login to the current Micro Integrator instance (current remote)"
+
+var loginCmdExamples = dedent.Dedent(`
+Example: 
+	` + utils.ProjectName + ` ` + remoteCmdLiteral + ` ` + loginCmdLiteral + `  # will be prompted for username and password
+	` + utils.ProjectName + ` ` + remoteCmdLiteral + ` ` + loginCmdLiteral + ` admin  admin
+`)
+
+// loginCmd represents the login command
+var loginCmd = &cobra.Command{
+	Use:   loginCmdLiteral,
+	Short: loginCmdLiteral,
+	Long:  dedent.Dedent(loginCmdShortDesc + loginCmdExamples),
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + loginCmdLiteral + " called")
+		executeLoginCmd(args)
+	},
+}
+
+func executeLoginCmd(args []string) {
+	if len(args) == 0 {
+		if username == "" {
+			username = utils.PromptForUsername()
+		}
+
+		if password == "" {
+			password = utils.PromptForPassword()
+		}
+	} else if len(args) == 1 {
+		username = args[0]
+		password = utils.PromptForPassword()
+	} else if len(args) == 2 {
+		username = args[0]
+		password = args[1]
+	} else {
+		fmt.Println("Too many arguments. See the usage of " + loginCmdLiteral)
+		fmt.Println("Execute " + remoteCmdLiteral + " " + loginCmdLiteral + " --help")
+	}
+
+	if username != "" && password != "" {
+		b64encodedCredentials := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+		// call the login resource of MI management API
+		url := utils.GetRESTAPIBase() + utils.LoginResource
+		headers := map[string]string{
+			utils.HeaderAuthorization: utils.HeaderValueAuthPrefixBasic + " " + b64encodedCredentials,
+		}
+		resp, err := utils.UnmarshalData(url, headers, nil, &utils.LoginResponse{})
+		if err != nil {
+			fmt.Println(utils.LogPrefixError + err.Error())
+		} else {
+			loginResponse := resp.(*utils.LoginResponse)
+			err := utils.RemoteConfigData.UpdateCurrentRemoteToken(loginResponse.AccessToken)
+			if err != nil {
+				utils.HandleErrorAndExit("Error updating credentials", err)
+			} else {
+				utils.Logln(utils.LogPrefixInfo + "Persisting auth credentials for current remote")
+				fmt.Println("Login successful for remote: " + utils.RemoteConfigData.CurrentServer + "!")
+				utils.RemoteConfigData.Persist(utils.GetServerConfigFilePath())
+			}
+		}
+	} else {
+		utils.HandleErrorAndExit("Username and Password cannot be blank", nil)
+	}
+}
+
+func init() {
+	remoteCmd.AddCommand(loginCmd)
+	loginCmd.SetHelpTemplate(loginCmdShortDesc + loginCmdExamples)
+}

--- a/cmd/cmd/logout.go
+++ b/cmd/cmd/logout.go
@@ -1,0 +1,70 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/lithammer/dedent"
+	"github.com/wso2/micro-integrator/cmd/utils"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+const logoutCmdLiteral = "logout"
+const logoutCmdShortDesc = "Logout of the current Micro Integrator instance (current remote)"
+
+var logoutCmdExamples = dedent.Dedent(`
+Example:
+	` + utils.ProjectName + ` ` + remoteCmdLiteral + ` ` + logoutCmdLiteral + `
+`)
+
+// logoutCmd represents the logout command
+var logoutCmd = &cobra.Command{
+	Use:   logoutCmdLiteral,
+	Short: logoutCmdShortDesc,
+	Long:  dedent.Dedent(loginCmdShortDesc + logoutCmdExamples),
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + logoutCmdLiteral + " called")
+		executeLogoutCmd()
+	},
+}
+
+func executeLogoutCmd() {
+	// call the logout resource of MI management API
+	url := utils.GetRESTAPIBase() + utils.LogoutResource
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthPrefixBearer + " " +
+		utils.RemoteConfigData.Remotes[utils.RemoteConfigData.CurrentServer].AccessToken
+	resp, err := utils.InvokeGETRequest(url, headers, nil)
+	if err != nil {
+		utils.HandleErrorAndExit("Error logging out of the current remote", err)
+	} else {
+		if resp.StatusCode() == http.StatusOK {
+			fmt.Println("Successfully logged out of the current remote: " + utils.RemoteConfigData.CurrentServer)
+		} else {
+			utils.HandleErrorAndExit("Error logging out of the current remote: "+resp.Status(), nil)
+		}
+	}
+}
+
+func init() {
+	remoteCmd.AddCommand(logoutCmd)
+	logoutCmd.SetHelpTemplate(logoutCmdShortDesc + logoutCmdExamples)
+}

--- a/cmd/cmd/messageProcessorShow.go
+++ b/cmd/cmd/messageProcessorShow.go
@@ -81,7 +81,7 @@ func printMessageProcessorHelp() {
 
 func executeGetMessageProcessorCmd(messageProcessorName string) {
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixMessageProcessors, "name", messageProcessorName)
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.MessageProcessorData{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.MessageProcessorData{})
 
 	if err == nil {
 		// Printing the details of the MessageProcessor
@@ -104,7 +104,7 @@ func printMessageProcessor(messageProcessor artifactUtils.MessageProcessorData) 
 
 func executeListMessageProcessorCmd() {
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixMessageProcessors
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.MessageProcessorList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.MessageProcessorList{})
 
 	if err == nil {
 		// Printing the list of available Endpoints

--- a/cmd/cmd/messageStoreShow.go
+++ b/cmd/cmd/messageStoreShow.go
@@ -82,7 +82,7 @@ func printMessageStoreHelp() {
 
 func executeGetMessageStoreCmd(messageStoreName string) {
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixMessageStores, "name", messageStoreName)
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.MessageStoreData{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.MessageStoreData{})
 
 	if err == nil {
 		// Printing the details of the MessageStore
@@ -105,7 +105,7 @@ func printMessageStore(messageStore artifactUtils.MessageStoreData) {
 
 func executeListMessageStoreCmd() {
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixMessageStores
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.MessageStoreList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.MessageStoreList{})
 
 	if err == nil {
 		// Printing the list of available Message Stores

--- a/cmd/cmd/proxyServiceShow.go
+++ b/cmd/cmd/proxyServiceShow.go
@@ -82,7 +82,7 @@ func executeGetProxyServiceCmd(proxyServiceName string) {
 
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixProxyServices, "proxyServiceName", proxyServiceName)
 
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.Proxy{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.Proxy{})
 
 	if err == nil {
 		// Printing the details of the Proxy Service
@@ -109,7 +109,7 @@ func executeListProxyServicesCmd() {
 
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixProxyServices
 
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.ProxyServiceList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.ProxyServiceList{})
 
 	if err == nil {
 		// Printing the list of available Endpoints

--- a/cmd/cmd/resourceConnectorShow.go
+++ b/cmd/cmd/resourceConnectorShow.go
@@ -69,7 +69,7 @@ func handleConnectorCmdArguments(args []string) {
 
 func executeListConnectorCmd() {
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixConnectors
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.ConnectorList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.ConnectorList{})
 
 	if err == nil {
 		// Printing the list of available Connectors

--- a/cmd/cmd/sequenceShow.go
+++ b/cmd/cmd/sequenceShow.go
@@ -81,7 +81,7 @@ func executeGetSequenceCmd(sequencename string) {
 
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixSequences, "sequenceName", sequencename)
 
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.Sequence{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.Sequence{})
 
 	if err == nil {
 		// Printing the details of the Sequence
@@ -119,7 +119,7 @@ func executeListSequencesCmd() {
 
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixSequences
 
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.SequenceList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.SequenceList{})
 
 	if err == nil {
 		// Printing the list of available Sequences

--- a/cmd/cmd/serverSelect.go
+++ b/cmd/cmd/serverSelect.go
@@ -74,6 +74,7 @@ func executeServerSelectCmd(args []string) {
 	if result != nil {
 		utils.HandleErrorAndExit("Error: ", result)
 	}
+	fmt.Println("Selected remote: " + args[0])
 	utils.RemoteConfigData.Persist(utils.GetServerConfigFilePath())
 }
 

--- a/cmd/cmd/serverUpdate.go
+++ b/cmd/cmd/serverUpdate.go
@@ -70,11 +70,14 @@ func handleServerUpdateCmdArguments(args []string) {
 }
 
 func executeServerUpdateCmd(args []string) {
-	var result = utils.RemoteConfigData.UpdateRemote(args[0], args[1], args[2])
-	if result != nil {
-		utils.HandleErrorAndExit("Error: ", result)
+	var err = utils.RemoteConfigData.UpdateRemote(args[0], args[1], args[2])
+	if err != nil {
+		utils.HandleErrorAndExit("Error: ", err)
+	} else {
+		utils.Logln(utils.LogPrefixInfo + "Persisting remote " + args[0])
+		utils.RemoteConfigData.Persist(utils.GetServerConfigFilePath())
+		fmt.Println("Remote " + args[0] + " updated successfully!")
 	}
-	utils.RemoteConfigData.Persist(utils.GetServerConfigFilePath())
 }
 
 func printServerUpdateHelp() {

--- a/cmd/cmd/taskShow.go
+++ b/cmd/cmd/taskShow.go
@@ -81,7 +81,7 @@ func executeGetTaskCmd(taskname string) {
 
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixTasks, "taskName", taskname)
 
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.Task{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.Task{})
 
 	if err == nil {
 		// Printing the details of the Task
@@ -110,7 +110,7 @@ func executeListTasksCmd() {
 
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixTasks
 
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.TaskList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.TaskList{})
 
 	if err == nil {
 		// Printing the list of available Tasks

--- a/cmd/cmd/templateShow.go
+++ b/cmd/cmd/templateShow.go
@@ -96,7 +96,7 @@ func printTemplateHelp() {
 
 func executeListTemplatesCmd() {
 	finalUrl := utils.GetRESTAPIBase() + utils.PrefixTemplates
-	resp, err := utils.UnmarshalData(finalUrl, nil, &artifactUtils.TemplateList{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, nil, &artifactUtils.TemplateList{})
 
 	if err == nil {
 		// Printing the list of available Templates
@@ -109,7 +109,7 @@ func executeListTemplatesCmd() {
 
 func executeGetTemplateByTypeCmd(templateType string) {
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixTemplates, "type", templateType)
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.TemplateListByType{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.TemplateListByType{})
 
 	if err == nil {
 		// Printing the details of the Templates by type
@@ -123,7 +123,7 @@ func executeGetTemplateByTypeCmd(templateType string) {
 func executeGetTemplateByNameCmd(templateType string, templateName string) {
 	finalUrl, params := utils.GetUrlAndParams(utils.PrefixTemplates, "type", templateType)
 	params = utils.PutQueryParamsToMap(params, "name", templateName)
-	resp, err := utils.UnmarshalData(finalUrl, params, &artifactUtils.TemplateListByName{})
+	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.TemplateListByName{})
 
 	if err == nil {
 		// Printing the details of the Template by name

--- a/cmd/utils/constants.go
+++ b/cmd/utils/constants.go
@@ -95,6 +95,8 @@ const PrefixServer = "server"
 const PrefixDataServices = "data-services"
 const ShowCommand = "show"
 const HelpCommand = "help"
+const LoginResource = "login"
+const LogoutResource = "logout"
 
 const Name = "NAME"
 const Type = "TYPE"

--- a/cmd/utils/remoteConfig.go
+++ b/cmd/utils/remoteConfig.go
@@ -48,11 +48,23 @@ func (remoteConfig *RemoteConfig) UpdateRemote(name string, host string, port st
 
 	remotes := &RemoteConfigData.Remotes
 	if _, exists := (*remotes)[name]; !exists {
-		return errors.New("no such remote")
+		return errors.New("no such remote: " + name)
 	}
 
 	remote := Remote{Url: host, Port: port}
 	(*remotes)[name] = remote
+
+	return nil
+}
+
+// update the access token of the current remote
+func (remoteConfig *RemoteConfig) UpdateCurrentRemoteToken(accessToken string) error {
+	currentRemote := RemoteConfigData.Remotes[RemoteConfigData.CurrentServer]
+
+	remotes := &RemoteConfigData.Remotes
+
+	remote := Remote{Url: currentRemote.Url, Port: currentRemote.Port, AccessToken: accessToken}
+	(*remotes)[RemoteConfigData.CurrentServer] = remote
 
 	return nil
 }

--- a/cmd/utils/remoteConfig_test.go
+++ b/cmd/utils/remoteConfig_test.go
@@ -61,9 +61,11 @@ func TestAddServer(t *testing.T) {
   default:
     server_address: localhost
     server_port: "9164"
+    access_token: ""
   testServer1:
     server_address: localhost
     server_port: "1234"
+    access_token: ""
 current_server: default
 `
 	AssertEqual(t, expectedContent, GetFileContent(GetServerConfigFilePath()))
@@ -95,9 +97,11 @@ func TestUpdateServer(t *testing.T) {
   default:
     server_address: localhost
     server_port: "9164"
+    access_token: ""
   testServer1:
     server_address: localhost2
     server_port: "1235"
+    access_token: ""
 current_server: default
 `
 	AssertEqual(t, expectedContent, GetFileContent(GetServerConfigFilePath()))
@@ -134,9 +138,11 @@ func TestRemoveServer(t *testing.T) {
   default:
     server_address: localhost
     server_port: "9164"
+    access_token: ""
   testServer2:
     server_address: localhost22
     server_port: "1236"
+    access_token: ""
 current_server: default
 `
 	AssertEqual(t, expectedContent, GetFileContent(GetServerConfigFilePath()))
@@ -184,12 +190,15 @@ func TestSelectServer(t *testing.T) {
   default:
     server_address: localhost
     server_port: "9164"
+    access_token: ""
   testServer1:
     server_address: localhost
     server_port: "1234"
+    access_token: ""
   testServer2:
     server_address: localhost2
     server_port: "1235"
+    access_token: ""
 current_server: testServer2
 `
 	AssertEqual(t, expectedContent, GetFileContent(GetServerConfigFilePath()))

--- a/cmd/utils/structs.go
+++ b/cmd/utils/structs.go
@@ -26,8 +26,9 @@ type RemoteConfig struct {
 type Remotes map[string]Remote
 
 type Remote struct {
-	Url  string `yaml:"server_address"`
-	Port string `yaml:"server_port"`
+	Url         string `yaml:"server_address"`
+	Port        string `yaml:"server_port"`
+	AccessToken string `yaml:"access_token"`
 }
 
 type Logger struct {
@@ -50,18 +51,11 @@ type ServerSummary struct {
 	Location string `json:"location"`
 }
 
-type RegistrationResponse struct {
-	ClientSecretExpiresAt string `xml:"client_secret_expires_at"`
-	ClientID              string `xml:"client_id"`
-	ClientSecret          string `xml:"client_secret"`
-	ClientName            string `xml:"client_name"`
+type LoginResponse struct {
+	AccessToken string `yaml:"AccessToken"`
 }
 
-type TokenResponse struct {
-	AccessToken  string `xml:"access_token"`
-	RefreshToken string `xml:"refresh_token"`
-	TokenType    string `xml:"token_type"`
-	ExpiresIn    int32  `xml:"expires_in"`
+type LogoutResponse struct {
 }
 
 type IterableStringArray interface {

--- a/cmd/utils/utils_test.go
+++ b/cmd/utils/utils_test.go
@@ -113,7 +113,7 @@ func TestGetArtifactListOK(t *testing.T) {
 	}))
 	defer server.Close()
 
-	resp, err := UnmarshalData(server.URL, nil, &artifactUtils.APIList{})
+	resp, err := UnmarshalData(server.URL, nil, nil, &artifactUtils.APIList{})
 	list := resp.(*artifactUtils.APIList)
 
 	if list.Count != 2 {
@@ -149,7 +149,7 @@ func TestUnmarshalDataApiOK(t *testing.T) {
 
 	params := createParamMap("apiName", "HealthcareAPI")
 
-	resp, err := UnmarshalData(server.URL, params, &artifactUtils.API{})
+	resp, err := UnmarshalData(server.URL, nil, params, &artifactUtils.API{})
 	api := resp.(*artifactUtils.API)
 
 	expected := artifactUtils.API{
@@ -192,7 +192,7 @@ func TestUnmarshalDataAppOK(t *testing.T) {
 
 	params := createParamMap("carbonAppName", "SampleServicesCompositeApplication")
 
-	resp, err := UnmarshalData(server.URL, params, &artifactUtils.CompositeApp{})
+	resp, err := UnmarshalData(server.URL, nil, params, &artifactUtils.CompositeApp{})
 	capp := resp.(*artifactUtils.CompositeApp)
 
 	expected := artifactUtils.CompositeApp{
@@ -229,7 +229,7 @@ func TestUnmarshalDataEndpointOK(t *testing.T) {
 
 	params := createParamMap("endpointName", "ClemencyEP")
 
-	resp, err := UnmarshalData(server.URL, params, &artifactUtils.Endpoint{})
+	resp, err := UnmarshalData(server.URL, nil, params, &artifactUtils.Endpoint{})
 	endpoint := resp.(*artifactUtils.Endpoint)
 
 	expected := artifactUtils.Endpoint{
@@ -268,7 +268,7 @@ func TestUnmarshalDataInboundEndpointOK(t *testing.T) {
 
 	params := createParamMap("inboundEndpointName", "TestInbound")
 
-	resp, err := UnmarshalData(server.URL, params, &artifactUtils.InboundEndpoint{})
+	resp, err := UnmarshalData(server.URL, nil, params, &artifactUtils.InboundEndpoint{})
 	inboundEndpoint := resp.(*artifactUtils.InboundEndpoint)
 
 	expected := artifactUtils.InboundEndpoint{
@@ -307,7 +307,7 @@ func TestUnmarshalDataProxyOK(t *testing.T) {
 
 	params := createParamMap("proxyServiceName", "TestProxy")
 
-	resp, err := UnmarshalData(server.URL, params, &artifactUtils.Proxy{})
+	resp, err := UnmarshalData(server.URL, nil, params, &artifactUtils.Proxy{})
 	proxy := resp.(*artifactUtils.Proxy)
 
 	expected := artifactUtils.Proxy{
@@ -343,7 +343,7 @@ func TestUnmarshalDataSequenceOK(t *testing.T) {
 
 	params := createParamMap("sequenceName", "InjectXMLSequence")
 
-	resp, err := UnmarshalData(server.URL, params, &artifactUtils.Sequence{})
+	resp, err := UnmarshalData(server.URL, nil, params, &artifactUtils.Sequence{})
 	sequence := resp.(*artifactUtils.Sequence)
 
 	expected := artifactUtils.Sequence{
@@ -378,7 +378,7 @@ func TestUnmarshalDataTaskOK(t *testing.T) {
 
 	params := createParamMap("taskName", "InjectXMLTask")
 
-	resp, err := UnmarshalData(server.URL, params, &artifactUtils.Task{})
+	resp, err := UnmarshalData(server.URL, nil, params, &artifactUtils.Task{})
 	sequence := resp.(*artifactUtils.Task)
 
 	expected := artifactUtils.Task{
@@ -407,7 +407,7 @@ func TestUnmarshalDataNotFound(t *testing.T) {
 	params := make(map[string]string)
 	params["apiName"] = "ABC"
 
-	resp, err := UnmarshalData(server.URL, params, &artifactUtils.API{})
+	resp, err := UnmarshalData(server.URL, nil, params, &artifactUtils.API{})
 
 	if resp != nil {
 		t.Error("Response should be nil")
@@ -432,7 +432,7 @@ func TestUnmarshalDataBadRequest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	resp, err := UnmarshalData(server.URL, nil, &Logger{})
+	resp, err := UnmarshalData(server.URL, nil, nil, &Logger{})
 
 	if resp == nil {
 		t.Error(`Response should be, "Error": "Invalid log level abc"`)


### PR DESCRIPTION
## Purpose
> Use authorization headers on calling MI management API.

## Usage (Adding a new MI instance and logging in to it)
First, add a new remote.
```
mi remote add TestServer1 localhost 9164
```

Then, select `TestServer1` as the current remote (`remote login` only works for the current remote).

```
mi remote select TestServer1
```

Now you can log in to the remote `TestServer1` using the newly introduced`login` command.
Login:
```
mi remote login # will be prompted for username and password
```

Login (with in-line username and password):
```
mi remote login admin admin
```

Logout:
```
mi remote logout
```


## Related to
> #842 