### PR TITLE
Fix improper restriction of XXE

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/XSLTTransformer.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/XSLTTransformer.java
@@ -42,6 +42,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+import static org.wso2.micro.core.util.CarbonUtils.getSecuredTransformerFactory;
+
 /**
  * This class is used in transforming data services result using XSLT.
  */
@@ -58,7 +60,7 @@ public class XSLTTransformer {
     public XSLTTransformer(String xsltPath) throws TransformerConfigurationException,
                                                    DataServiceFault, IOException {
         this.xsltPath = xsltPath;
-        TransformerFactory tFactory = TransformerFactory.newInstance();
+        TransformerFactory tFactory = getSecuredTransformerFactory();
         try {
             getSecuredDocumentBuilder(false).parse(DBUtils.getInputStreamFromPath(this.getXsltPath()));
         } catch (SAXException e) {

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/util/CarbonUtils.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/util/CarbonUtils.java
@@ -25,11 +25,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -134,12 +136,26 @@ public class CarbonUtils {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             Source xmlSource = new DOMSource(doc);
             Result result = new StreamResult(outputStream);
-            TransformerFactory.newInstance().newTransformer().transform(xmlSource, result);
+            TransformerFactory factory = getSecuredTransformerFactory();
+            factory.newTransformer().transform(xmlSource, result);
             InputStream in = new ByteArrayInputStream(outputStream.toByteArray());
             return in;
         } catch (TransformerException var5) {
             throw new CarbonException("Error in transforming DOM to InputStream", var5);
         }
+    }
+
+    /**
+     * Create a secure process enabled TransformerFactory.
+     *
+     * @return
+     * @throws TransformerConfigurationException
+     */
+    public static TransformerFactory getSecuredTransformerFactory() throws TransformerConfigurationException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        return factory;
     }
 
     private static DocumentBuilderFactory getSecuredDocumentBuilder() {

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/util/MicroIntegratorBaseUtils.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/util/MicroIntegratorBaseUtils.java
@@ -67,6 +67,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import static org.wso2.micro.core.util.CarbonUtils.getSecuredTransformerFactory;
+
 public class MicroIntegratorBaseUtils {
 
     private static final String REPOSITORY = "repository";
@@ -464,7 +466,8 @@ public class MicroIntegratorBaseUtils {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             Source xmlSource = new DOMSource(doc);
             Result result = new StreamResult(outputStream);
-            TransformerFactory.newInstance().newTransformer().transform(xmlSource, result);
+            TransformerFactory factory = getSecuredTransformerFactory();
+            factory.newTransformer().transform(xmlSource, result);
             in = new ByteArrayInputStream(outputStream.toByteArray());
         } catch (TransformerException e) {
             throw new CarbonException("Error in transforming DOM to InputStream", e);


### PR DESCRIPTION
## Purpose
> Implement secure use of TransformerFactory in compliance with OWASP Guidelines [1] and Sonar rules [2] to fix improper restriction of External XML Entity (XXE) Reference.

[1]https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md#transformerfactory
[2]https://rules.sonarsource.com/java/RSPEC-2755?search=documentbuilderfactory