### PR TITLE
Change server startup

### DIFF
--- a/integration/automation-extensions/src/main/java/org/wso2/esb/integration/common/extensions/carbonserver/CarbonServerManager.java
+++ b/integration/automation-extensions/src/main/java/org/wso2/esb/integration/common/extensions/carbonserver/CarbonServerManager.java
@@ -68,6 +68,7 @@ public class CarbonServerManager {
     private static int defaultHttpsPort = Integer.parseInt(FrameworkConstants.SERVER_DEFAULT_HTTPS_PORT);
     private String scriptName;
     private static final String SERVER_STARTUP_MESSAGE = "WSO2 Micro Integrator started";
+    private int managementPort;
 
     public CarbonServerManager(AutomationContext context) {
         this.automationContext = context;
@@ -143,9 +144,10 @@ public class CarbonServerManager {
                 }
             }));
 
-            waitTill(() -> !inputStreamHandler.getOutput().contains(SERVER_STARTUP_MESSAGE), 60, TimeUnit.SECONDS);
+            managementPort = 9154 + portOffset;
+            waitTill(() -> !isRemotePortInUse("localhost", managementPort), 180, TimeUnit.SECONDS);
 
-            if (!inputStreamHandler.getOutput().contains(SERVER_STARTUP_MESSAGE)) {
+            if (!isRemotePortInUse("localhost", managementPort)) {
                 throw new RuntimeException("Server initialization failed");
             }
 
@@ -238,7 +240,7 @@ public class CarbonServerManager {
             try {
 
                 startProcess(carbonHome, getStartScriptCommand("stop"));
-                waitTill(() -> isRemotePortInUse("localhost", 8280 + portOffset), 60, TimeUnit.SECONDS);
+                waitTill(() -> isRemotePortInUse("localhost", managementPort), 180, TimeUnit.SECONDS);
 
                 log.info("Server stopped successfully ...");
 
@@ -281,7 +283,8 @@ public class CarbonServerManager {
     private void waitTill(BooleanSupplier predicate, int maxWaitTime, TimeUnit timeUnit) throws InterruptedException {
         long time = System.currentTimeMillis() + timeUnit.toMillis(maxWaitTime);
         while (predicate.getAsBoolean() && System.currentTimeMillis() < time) {
-            TimeUnit.MILLISECONDS.sleep(1);
+            log.info("waiting for server startup/shutdown");
+            TimeUnit.SECONDS.sleep(1);
         }
     }
 

--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/automation.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/automation.xml
@@ -210,6 +210,7 @@
                     <parameter name="-DportOffset" value="200" />
                     <parameter name="-DavoidConfigUpdate" value="true"/>
                     <parameter name="startupScript" value="micro-integrator" />
+                    <parameter name="-DenableManagementApi" value="true"/>
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
                 </class>
             </extentionClasses>


### PR DESCRIPTION
## Purpose
Change server startup in tests so that the startup/shutdown is identified depending on whether a connection could be made to the management api (port 9154 + offset). 