### PR TITLE
Add reverseProxyMode property to passthru-http.properties and to deployment-full.toml files

### DIFF
--- a/distribution/src/conf/passthru-http.properties
+++ b/distribution/src/conf/passthru-http.properties
@@ -45,3 +45,4 @@ rest_uri_proxy_regex=\\w+://.+:\\d+/services/t/.*|\\w+://.+\\w+/services/t/.*|^(
 # Message size validation based on the message size in bytes.
 #message.size.validation.enabled=true
 #valid.max.message.size.in.bytes=81920
+reverseProxyMode=false

--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -80,6 +80,7 @@
   "passthru_properties.'http.server.preserve'": true,
   "passthru_properties.'http.connection.disable.keepalive'": false,
   "passthru_properties.'valid.max.message.size.in.bytes'": "81920",
+  "passthru_properties.'force.json.message.reverseProxyMode'": false,
 
   "transport.http.preserve_http_headers": ["Content-Type"],
   "transport.http.listener.enable": true,

--- a/distribution/src/resources/config-tool/deployment-full.toml
+++ b/distribution/src/resources/config-tool/deployment-full.toml
@@ -161,6 +161,7 @@ max_message_size_bytes = 81920
 max_open_connections = -1           # inferred default: -1
 force_xml_validation = false
 force_json_validation = false
+reverse_proxy_mode = false
 
 listener.enable = true                       # inferred default true
 listener.port = 8280    #inferred  default: 8280

--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -77,6 +77,7 @@
   "transport.http.max_open_connections": "passthru_properties.'max_open_connections'",
   "transport.http.force_xml_validation": "passthru_properties.'force.xml.message.validation'",
   "transport.http.force_json_validation": "passthru_properties.'force.json.message.validation'",
+  "transport.http.reverse_proxy_mode": "passthru_properties.'force.json.message.reverseProxyMode'",
 
   "transport.http.listener.port": "transport.http.listener.parameter.port",
   "transport.http.listener.wsdl_epr_prefix":"transport.http.listener.parameter.WSDLEPRPrefix",


### PR DESCRIPTION
### Purpose

- Add reverseProxyMode=false to passthru-http.properties
- Add reverse_proxy_mode = false to deployment-full.toml
- "transport.http.reverse_proxy_mode": "passthru_properties.'force.json.message.reverseProxyMode'" to key-mappings.json
- "passthru_properties.'force.json.message.reverseProxyMode'": false to default.json

