### PR TITLE
Implement getResource method for MI registry

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -874,8 +874,11 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                 return null;
             }
 
+            String mediaType = DEFAULT_MEDIA_TYPE;
             Properties metadata = getMetadata(url.getPath());
-            String mediaType = metadata.getProperty(METADATA_KEY_MEDIA_TYPE, DEFAULT_MEDIA_TYPE);
+            if (metadata != null) {
+                mediaType = metadata.getProperty(METADATA_KEY_MEDIA_TYPE, DEFAULT_MEDIA_TYPE);
+            }
 
             if (DEFAULT_MEDIA_TYPE.equals(mediaType)) {
                 StringBuilder strBuilder = new StringBuilder();
@@ -1024,6 +1027,12 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                         + METADATA_FILE_SUFFIX;
         File metadataFile = new File(metadataFilePath);
 
+        if (!metadataFile.exists()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Metadata file does not exist in" + metadataFile.getPath());
+            }
+            return null;
+        }
         try (BufferedReader reader = new BufferedReader(new FileReader(metadataFile))) {
             metadata.load(reader);
         } catch (FileNotFoundException e) {
@@ -1034,4 +1043,26 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
 
         return metadata;
     }
+
+    /**
+     * Returns the registry resource object
+     *
+     * @param key - registry key.
+     * @return
+     */
+    public Resource getResource(String key) {
+
+        String resolvedRegKeyPath = resolveRegistryURI(key);
+        try {
+            // here, a URL object is created in order to remove the protocol from the file path
+            new File(new URL(resolvedRegKeyPath).getFile());
+            return new Resource();
+        } catch (MalformedURLException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Requested registry resource does not exist " + key, e);
+            }
+            return null;
+        }
+    }
+
 }

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/Resource.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/Resource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ *
+ */
+
+package org.wso2.micro.integrator.registry;
+
+/**
+ * Adding basic resource object class so that this can be extended when needed.
+ */
+public class Resource {
+
+    public Resource() {
+
+    }
+
+}


### PR DESCRIPTION
## Purpose
This PR implements the get Resource method for MicroIntegratorRegistry which is available in WSO2Registry as the synapse artifacts which uses this method fails in MI ( eg:- https://github.com/wso2-extensions/esb-connector-salesforcebulk/blob/master/src/main/resources/salesforceBulk-config/getAccessTokenByRefreshToken.xml#L63 ).

In addition to this, when adding a new resource using **public void newResource(String path, boolean isDirectory)**  method we don't have any meta data to write to file. Hence avoiding checking metadata file at get resource method.

Fixes https://github.com/wso2/micro-integrator/issues/955 & https://github.com/wso2/micro-integrator/issues/956