### PR TITLE
Pack rampart client module

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -612,6 +612,13 @@
             </includes>
         </dependencySet>
         <dependencySet>
+            <outputDirectory>wso2mi-${pom.version}/repository/deployment/client/modules
+            </outputDirectory>
+            <includes>
+                <include>org.apache.rampart:rampart:mar</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
             <outputDirectory>wso2mi-${pom.version}/bin</outputDirectory>
             <includes>
                 <include>org.wso2.ei:org.wso2.micro.integrator.bootstrap:jar</include>


### PR DESCRIPTION
## Purpose
ws-security used in blocking transport need rampart in client modules. This adds rampart to the client modules.
Issue - https://github.com/wso2/micro-integrator/issues/971