### PR TITLE
Downgrade automation.framework version

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -778,7 +778,7 @@
         <httpclient.version>4.3.2</httpclient.version>
         <httpcore-nio.wso2.version>4.3.3.wso2v4</httpcore-nio.wso2.version>
         <httpcore.wso2.version>4.3.0.wso2v1</httpcore.wso2.version>
-        <automation.framework.version>4.4.4</automation.framework.version>
+        <automation.framework.version>4.4.3</automation.framework.version>
         <automation.framework.utils.version>4.5.0</automation.framework.utils.version>
         <commons-digester.version>2.1</commons-digester.version>
         <groovy.version>1.1-rc-1</groovy.version>


### PR DESCRIPTION
## Purpose
When building MI pack with java version 1.8.0_191 and  Apache Maven 3.6.2 the following error occurs,
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process (default) on project automation-extensions: Execution default of goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process failed.: NullPointerException -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```
Downgrading automation.framework.version from 4.4.4 to 4.4.3 fixes this issue.

A separate issue is opened in #1020  for the test case failures when JDK-11 is used.