### PR TITLE
Fix single TOML configuration issues

### DIFF
--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -392,8 +392,17 @@
   "database.enable_config": true,
   "database.enable_gov": true,
 
-  "system.parameter": {
-    "org.wso2.CipherTransformation": "RSA/ECB/OAEPwithSHA1andMGF1Padding",
-    "org.wso2.SecureVaultPasswordRegEx": "^[\\\\S]{5,30}$"
-  }
+  "monitoring.jmx.rmi_registry_port": "9999",
+  "monitoring.jmx.rmi_server_port": "11111",
+  "monitoring.jmx.rmi_server_start": true,
+  "monitoring.jmx.rmi_hostname": "$ref{server.hostname}",
+
+  "monitoring.ei_analytics.server_url": "tcp://localhost:7612",
+  "monitoring.ei_analytics.auth_server_url": "ssl://localhost:7712",
+  "monitoring.ei_analytics.username": "admin",
+  "monitoring.ei_analytics.password": "admin",
+
+  "system.parameter.'org.wso2.CipherTransformation'": "RSA/ECB/OAEPwithSHA1andMGF1Padding",
+  "system.parameter.'org.wso2.SecureVaultPasswordRegEx'": "^[\\\\S]{5,30}$"
+
 }

--- a/distribution/src/resources/config-tool/deployment-full.toml
+++ b/distribution/src/resources/config-tool/deployment-full.toml
@@ -4,6 +4,7 @@
 hostname = "localhost"
 offset  = 0     # inferred
 hide_admin_service_wsdl = true #inferred
+proxy_context_path = "" # empty by default
 
 # axis2.xml file
 enable_mtom = false # optional  default: false
@@ -11,6 +12,10 @@ enable_swa = false # optional   default: false
 userAgent = "WSO2 ${product.key} ${product.version}"    #inferred
 serverDetails = "WSO2 ${product.key} ${product.version}"    #inferred
 synapse_config_file_path = "repository/deployment/server/synapse-configs"  #inferred no docs for the end user
+http_content_negotiation = true     # true by default
+auth2_token_validation_service = "https://localhost:9444/services/OAuth2TokenValidationService"
+identity_server_username = "admin"
+identity_server_password = "admin"
 
 # swagger handlers in carbon.xml file
 [[server.get_request_processor]]
@@ -181,6 +186,7 @@ listener.secured_wsdl_epr_prefix = "$ref{server.hostname}"  # no default
 listener.secured_bind_address = "$ref{server.hostname}"
 listener.secured_protocols = "TLSv1,TLSv1.1,TLSv1.2" # inferred default: TLSv1,TLSv1.1,TLSv1.2
 listener.verify_client = "require"              # inferred disable by default, mutual ssl   optional/required/none
+listener.preferred_ciphers = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256" # no defaults
 listener.ssl_profile.file_path = "conf/sslprofiles/listenerprofiles.xml" # type 0
 listener.ssl_profile.read_interval = 3600000       # inferred in milliseconds
 listener.certificate_revocation_verifier_enable = false # false by default
@@ -199,8 +205,11 @@ sender.enable = true        # inferred default true
 sender.warn_on_http_500 = "*"       # optional
 sender.proxy_host = "$ref{server.hostname}"
 sender.proxy_port = 3128
+sender.secured_proxy_host = "$ref{server.hostname}"
+sender.secured_proxy_port = 3128
 sender.non_proxy_hosts = ["$ref{server.hostname}"]
 sender.hostname_verifier = "AllowAll"
+sender.secured_protocols = "TLSv1,TLSv1.1,TLSv1.2" # no defaults
 sender.certificate_revocation_verifier_enable = false # false by default
 sender.certificate_revocation_cache_size = 1024     # inferred
 sender.certificate_revocation_cache_delay = 1000     # inferred delay in milliseconds
@@ -254,6 +263,17 @@ sender.transfer_encoding = "chunked"            # inferred default chunked
 sender.default_connections_per_host = 200       # inferred default 200
 sender.omit_soap12_action = true                # inferred default true
 sender.so_timeout = 60000                       # inferred default 60000 timeout in milliseconds
+sender.proxy_host = "$ref{server.hostname}"     # no defaults
+sender.proxy_port = 3128                        # no defaults
+
+sender.secured_enable = true                            # true by default
+sender.secured_enable_client_caching = true             # inferred default true
+sender.secured_transfer_encoding = "chunked"            # inferred default chunked
+sender.secured_default_connections_per_host = 200       # inferred default 200
+sender.secured_omit_soap12_action = true                # inferred default true
+sender.secured_so_timeout = 60000                       # inferred default 60000 timeout in milliseconds
+sender.secured_proxy_host = "$ref{server.hostname}"     # no defaults
+sender.secured_proxy_port = 3128                        # no defaults
 
 ###################################   VFS configurations              ###################################
 [transport.vfs] # enable by default
@@ -554,8 +574,8 @@ parameter.vender_class_loader = false       # only for IBM MQ
 
 ###################################     JNDI property configuration     ###################################
 [transport.jndi.connection_factories]
-QueueConnectionFactory = "amqp://admin:admin@clientID/carbon?brokerlist='tcp://localhost:5675'"
-TopicConnectionFactory = "amqp://admin:admin@clientID/carbon?brokerlist='tcp://localhost:5675'"
+'connectionfactory.QueueConnectionFactory' = "amqp://admin:admin@clientID/carbon?brokerlist='tcp://localhost:5675'"
+'connectionfactory.TopicConnectionFactory' = "amqp://admin:admin@clientID/carbon?brokerlist='tcp://localhost:5675'"
 
 [transport.jndi.queue]
 JMSMS = "JMSMS"
@@ -788,6 +808,10 @@ stat.tracer.collect_mediation_properties=false
 inbound.core_threads = 20
 inbound.max_threads = 100
 
+internal_http_api_enable = true     # inferred  true by default
+internal_http_api_port = 9191       # inferred 9191 by default
+internal_https_api_port = 9154      # inferred 9154 by default
+
 ###################################   Database configurations   ###################################
 [[datasource]]
 id = "WSO2_CARBON_DB"
@@ -838,6 +862,20 @@ admin_password = "password_2"
 keystore_password = "password_3"
 key_password = "password_4"
 truststrore_password = "password_5"
+
+##################################### Monitoring configurations #########################################
+[monitoring]
+# carbon.xml
+jmx.rmi_registry_port=9999              # inferred default 9999
+jmx.rmi_server_port=11111               # inferred default 11111
+# jmx.xml
+jmx.rmi_server_start=true               # inferred default true
+jmx.rmi_hostname="$ref{server.hostname}"    # inferred default server.hostname
+
+ei_analytics.server_url = "tcp://localhost:7612"    # inferred
+ei_analytics.auth_server_url = "ssl://localhost:7712"       # inferred
+ei_analytics.username = "admin"                             # inferred
+ei_analytics.password = "admin"                             # inferred
 
 ##################################### Hidden properties with no documentations ###################################
 

--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -1,6 +1,9 @@
 {
   "server.enable_mtom": "server.enableMTOM",
   "server.enable_swa": "server.enableSwA",
+  "server.auth2_token_validation_service": "axis2_transport.parameter.oauth2TokenValidationService",
+  "server.identity_server_username": "axis2_transport.parameter.identityServerUserName",
+  "server.identity_server_password": "axis2_transport.parameter.identityServerPw",
 
   "user_store.connection_url":"user_store.properties.ConnectionURL",
   "user_store.connection_name":"user_store.properties.ConnectionName",
@@ -91,12 +94,16 @@
   "transport.http.listener.secured_wsdl_epr_prefix": "transport.https.listener.parameter.WSDLEPRPrefix",
   "transport.http.listener.secured_bind_address": "transport.https.listener.parameter.bind-address",
   "transport.http.listener.secured_protocols": "transport.https.listener.parameter.HttpsProtocols",
+  "transport.http.listener.preferred_ciphers": "transport.https.listener.parameter.PreferredCiphers",
 
   "transport.http.sender.warn_on_http_500": "transport.http.sender.parameter.'warnOnHTTP500'",
   "transport.http.sender.proxy_host": "transport.http.sender.parameter.'http.proxyHost'",
   "transport.http.sender.proxy_port": "transport.http.sender.parameter.'http.proxyPort'",
 
   "transport.http.sender.hostname_verifier": "transport.https.sender.parameter.'HostnameVerifier'",
+  "transport.http.sender.secured_protocols": "transport.https.sender.parameter.HttpsProtocols",
+  "transport.http.sender.secured_proxy_host": "transport.https.sender.parameter.'http.proxyHost'",
+  "transport.http.sender.secured_proxy_port": "transport.https.sender.parameter.'http.proxyPort'",
 
   "transport.blocking.http.listener.port": "transport.blocking.http.listener.parameter.port",
   "transport.blocking.http.listener.hostname": "transport.blocking.http.listener.parameter.hostname",
@@ -113,12 +120,16 @@
   "transport.blocking.http.sender.default_connections_per_host": "transport.blocking.http.sender.parameter.defaultMaxConnectionsPerHost",
   "transport.blocking.http.sender.omit_soap12_action": "transport.blocking.http.sender.parameter.OmitSOAP12Action",
   "transport.blocking.http.sender.so_timeout": "transport.blocking.http.sender.parameter.SO_TIMEOUT",
+  "transport.blocking.http.sender.proxy_host": "transport.blocking.http.sender.parameter.'http.proxyHost'",
+  "transport.blocking.http.sender.proxy_port": "transport.blocking.http.sender.parameter.'http.proxyPort'",
 
-  "transport.blocking.https.sender.enable_client_caching": "transport.blocking.https.sender.parameter.cacheHttpClient",
-  "transport.blocking.https.sender.transfer_encoding": "transport.blocking.https.sender.parameter.Transfer-Encoding",
-  "transport.blocking.https.sender.default_connections_per_host": "transport.blocking.https.sender.parameter.defaultMaxConnectionsPerHost",
-  "transport.blocking.https.sender.omit_soap12_action": "transport.blocking.https.sender.parameter.OmitSOAP12Action",
-  "transport.blocking.https.sender.so_timeout": "transport.blocking.https.sender.parameter.SO_TIMEOUT",
+  "transport.blocking.http.sender.secured_enable_client_caching": "transport.blocking.https.sender.parameter.cacheHttpClient",
+  "transport.blocking.http.sender.secured_transfer_encoding": "transport.blocking.https.sender.parameter.Transfer-Encoding",
+  "transport.blocking.http.sender.secured_default_connections_per_host": "transport.blocking.https.sender.parameter.defaultMaxConnectionsPerHost",
+  "transport.blocking.http.sender.secured_omit_soap12_action": "transport.blocking.https.sender.parameter.OmitSOAP12Action",
+  "transport.blocking.http.sender.secured_so_timeout": "transport.blocking.https.sender.parameter.SO_TIMEOUT",
+  "transport.blocking.http.sender.secured_proxy_host": "transport.blocking.https.sender.parameter.'http.proxyHost'",
+  "transport.blocking.http.sender.secured_proxy_port": "transport.blocking.https.sender.parameter.'http.proxyPort'",
 
   "transport.mail.sender:parameter.hostname": "transport.mail.sender:parameter.'mail.smtp.host'",
   "transport.mail.sender:parameter.port": "transport.mail.sender:parameter.'mail.smtp.port'",

--- a/distribution/src/resources/config-tool/templates/conf/axis2/axis2.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/axis2/axis2.xml.j2
@@ -97,6 +97,10 @@
     <parameter name="{{parameter.name}}" locked="false">{{parameter.value}}</parameter>
     {% endfor %}
 
+    {% for parameter_key,parameter_value in axis2_transport.parameter.items() %}
+    <parameter name="{{parameter_key}}" locked="false">{{parameter_value}}</parameter>
+    {% endfor %}
+
     <!-- To override repository/services you need to uncomment following parameter and value -->
     <!-- SHOULD be absolute file path. -->
     <!--<parameter name="ServicesDirectory" locked="false">service</parameter>-->
@@ -388,7 +392,9 @@
         {% for parameter_key,parameter_value in transport.tcp.listener.parameter.items() %}
         <parameter name="{{parameter_key}}">{{parameter_value}}</parameter>
         {% endfor %}
+        {% if transport.tcp.listener.content_type is defined %}
         <parameter name="transport.tcp.contentType">{% for content_item in transport.tcp.listener.content_type %}{{content_item}}{% if loop.index < transport.tcp.listener.content_type|length %},{% endif %}{% endfor %}</parameter>
+        {% endif %}
     </transportReceiver>
     {% endif %}
     {% if transport.udp.listener.enable == true %}

--- a/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
@@ -101,7 +101,7 @@
    	Carbon UI components.
     -->
     <MgtProxyContextPath></MgtProxyContextPath>
-    <ProxyContextPath></ProxyContextPath>
+    <ProxyContextPath>{{server.proxy_context_path}}</ProxyContextPath>
 
     <!-- In-order to  get the registry http Port from the back-end when the default http transport is not the same-->
     <!--RegistryHttpPort>9763</RegistryHttpPort-->
@@ -129,9 +129,9 @@
         <!-- The JMX Ports -->
         <JMX>
             <!--The port RMI registry is exposed-->
-            <RMIRegistryPort>9999</RMIRegistryPort>
+            <RMIRegistryPort>{{monitoring.jmx.rmi_registry_port}}</RMIRegistryPort>
             <!--The port RMI server should be exposed-->
-            <RMIServerPort>11111</RMIServerPort>
+            <RMIServerPort>{{monitoring.jmx.rmi_server_port}}</RMIServerPort>
         </JMX>
 
         <!-- Embedded LDAP server specific ports -->
@@ -577,13 +577,13 @@
             enable publishing events to the servers in a round robin manner.
             e.g.; tcp://analytics-server-1:7612,tcp://analytics-server-2:7612
          -->
-        <ServerURL>tcp://localhost:7612</ServerURL>
-        <AuthServerURL>ssl://localhost:7712</AuthServerURL>
+        <ServerURL>{{monitoring.ei_analytics.server_url}}</ServerURL>
+        <AuthServerURL>{{monitoring.ei_analytics.auth_server_url}}</AuthServerURL>
         <!--
             Credentails of the admin user of the analytics server.
         -->
-        <Username>admin</Username>
-        <Password>admin</Password>
+        <Username>{{monitoring.ei_analytics.username}}</Username>
+        <Password>{{monitoring.ei_analytics.password}}</Password>
     </Analytics>
 
 </Server>

--- a/distribution/src/resources/config-tool/templates/conf/datasources/master-datasources.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/datasources/master-datasources.xml.j2
@@ -20,6 +20,9 @@
                     {% for property_name,property_value in data.pool_options.items() %}
                     <{{property_name}}>{{property_value}}</{{property_name}}>
                     {% endfor %}
+                    {% if data.jmx_enable is defined %}
+                    <jmxEnabled>{{data.jmx_enable}}</jmxEnabled>
+                    {% endif %}
                 </configuration>
             </definition>
         </datasource>

--- a/distribution/src/resources/config-tool/templates/conf/etc/jmx.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/etc/jmx.xml.j2
@@ -1,0 +1,31 @@
+<!--
+~ Copyright 2019 WSO2, Inc. (http://wso2.com)
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<!--
+   This file is used to configuring the JMX server. You can disable the JMX RMI server from starting
+   by setting the value of the StartRMIServer to false.
+-->
+<JMX xmlns="http://wso2.org/projects/carbon/jmx.xml">
+    <StartRMIServer>{{monitoring.jmx.rmi_server_start}}</StartRMIServer>
+
+    <!-- HostName, or Network interface to which this RMI server should be bound -->
+    <HostName>{{monitoring.jmx.rmi_hostname}}</HostName>
+
+    <!--  ${Ports.JMX.RMIRegistryPort} is defined in the Ports section of the carbon.xml-->
+    <RMIRegistryPort>${Ports.JMX.RMIRegistryPort}</RMIRegistryPort>
+
+    <!--  ${Ports.JMX.RMIRegistryPort} is defined in the Ports section of the carbon.xml-->
+    <RMIServerPort>${Ports.JMX.RMIServerPort}</RMIServerPort>
+</JMX>


### PR DESCRIPTION
## Purpose
- Change default from object to plain in default.json file for system variables.
Fix https://github.com/wso2/micro-integrator/issues/1054

- The following monitoring, parameters added.

```toml
[monitoring]
# carbon.xml
jmx.rmi_registry_port=9999
jmx.rmi_server_port=11111
# jmx.xml
jmx.rmi_server_start=true
jmx.rmi_hostname="$ref{server.hostname}"

ei_analytics.server_url = "tcp://localhost:7612"    # inferred
ei_analytics.auth_server_url = "ssl://localhost:7712"       # inferred
ei_analytics.username = "admin"                             # inferred
ei_analytics.password = "admin"                             # inferred
```

- Add preferred cipher parameter as follows
```toml
[transport.http]
listener.preferred_ciphers = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
```

- Add "secured_protocols" parameter to http sender section as follows.
```toml
[transport.http]
sender.secured_protocols = "TLSv1,TLSv1.1,TLSv1.2"
```
Fixed with https://github.com/wso2/micro-integrator/issues/1059

- proxyHost can be used as follows for http/https in blocking/non-blocking mode.
```toml
[transport.http]
sender.proxy_host = "$ref{server.hostname}"
sender.proxy_port = 3128
sender.secured_proxy_host = "$ref{server.hostname}"
sender.secured_proxy_port = 3128

[transport.blocking.http]
sender.proxy_host = "$ref{server.hostname}"
sender.proxy_port = 3128
sender.secured_proxy_host = "$ref{server.hostname}"
sender.secured_proxy_port = 3128
```
Fix https://github.com/wso2/micro-integrator/issues/1061

- Add new property to configure proxyContextPath in carbon.xml
```toml
[server]
proxy_context_path = ""
```

- Blocking https sender changed as follows.
```toml
[transport.blocking.http]
sender.secured_enable = true                            # true by default
sender.secured_enable_client_caching = true             # inferred default true
sender.secured_transfer_encoding = "chunked"            # inferred default chunked
sender.secured_default_connections_per_host = 200       # inferred default 200
sender.secured_omit_soap12_action = true                # inferred default true
sender.secured_so_timeout = 60000                       # inferred default 60000 timeout in milliseconds
```

- Following parameters will be added to configure identity parameters in axis2.xml file.
```toml
[server]
auth2_token_validation_service = "https://localhost:9444/services/OAuth2TokenValidationService"
identity_server_username = "admin"
identity_server_password = "admin"
```

- Following configuration added to configure custom axis2 parameters.
```toml
[axis2_transport]
parameter.customParameter = "value"
```