### PR TITLE
Enable Swagger tests

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
@@ -37,9 +37,8 @@
     <test name="API-Test" preserve-order="true" verbose="2">
         <classes>
             <class name="org.wso2.carbon.esb.api.test.ESBJAVA3751UriTemplateReservedCharacterEncodingTest"/>
-            <!-- Disable testcases due to https://github.com/wso2/micro-integrator/issues/341
             <class name="org.wso2.carbon.esb.api.apidefinition.ESBJAVA4907SwaggerGenerationTestCase"/>
-            <class name="org.wso2.carbon.esb.api.apidefinition.ESBJAVA4936SwaggerGenerationJsonYamlTestCase"/-->
+            <class name="org.wso2.carbon.esb.api.apidefinition.ESBJAVA4936SwaggerGenerationJsonYamlTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
Enables the test cases that were disabled by https://github.com/menuka94/micro-integrator/commit/d56be13f89a2e64e0b3d4d41fd95f494ca6cc14f due to https://github.com/wso2/micro-integrator/issues/341 since the correct PassThroughNHttpGetProcessor is now added.
