### PR TITLE
Fix MI-1130

### DIFF
--- a/distribution/src/resources/config-tool/deployment-full.toml
+++ b/distribution/src/resources/config-tool/deployment-full.toml
@@ -120,7 +120,7 @@ content_type = "application/json/badgerfish"
 class = "org.apache.axis2.json.JSONBadgerfishOMBuilder"
 
 ################## Massege builders and formatters for blocking transport #########################
-[message_formatters.blocking]
+[blocking.message_formatters]
 form_urlencoded =  "org.apache.synapse.commons.formatters.XFormURLEncodedFormatter"
 multipart_form_data =  "org.apache.axis2.transport.http.MultipartFormDataFormatter"
 application_xml = "org.apache.axis2.transport.http.ApplicationXMLFormatter"
@@ -133,7 +133,7 @@ text_javascript = "org.apache.axis2.json.JSONMessageFormatter"
 octet_stream = "org.wso2.carbon.relay.ExpandingMessageFormatter"
 application_binary =  "org.apache.axis2.format.BinaryFormatter"
 
-[message_builders.blocking]
+[blocking.message_builders]
 application_xml = "org.apache.axis2.builder.ApplicationXMLBuilder"
 form_urlencoded = "org.apache.synapse.commons.builders.XFormURLEncodedBuilder"
 multipart_form_data = "org.apache.axis2.builder.MultipartFormDataBuilder"
@@ -144,11 +144,11 @@ text_javascript = "org.apache.axis2.json.JSONBuilder"
 octet_stream =  "org.wso2.carbon.relay.BinaryRelayBuilder"
 application_binary = "org.apache.axis2.format.BinaryBuilder"
 
-[[custom_message_formatters.blocking]]
+[[blocking.custom_message_formatters]]
 content_type = "application/json/badgerfish"
 class = "org.apache.axis2.json.JSONBadgerfishMessageFormatter"
 
-[[custom_message_builders.blocking]]
+[[blocking.custom_message_builders]]
 content_type = "application/json/badgerfish"
 class = "org.apache.axis2.json.JSONBadgerfishOMBuilder"
 

--- a/distribution/src/resources/config-tool/templates/conf/axis2/axis2_blocking_client.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/axis2/axis2_blocking_client.xml.j2
@@ -115,28 +115,28 @@
     <!-- expected to be resolved based on the content type. -->
     <messageFormatters>
         <messageFormatter contentType="application/x-www-form-urlencoded"
-                          class="{{message_formatters.blocking.form_urlencoded}}"/>
+                          class="{{blocking.message_formatters.form_urlencoded}}"/>
         <messageFormatter contentType="multipart/form-data"
-                          class="{{message_formatters.blocking.multipart_form_data}}"/>
+                          class="{{blocking.message_formatters.multipart_form_data}}"/>
         <messageFormatter contentType="application/xml"
-                          class="{{message_formatters.blocking.application_xml}}"/>
+                          class="{{blocking.message_formatters.application_xml}}"/>
         <messageFormatter contentType="text/xml"
-                          class="{{message_formatters.blocking.text_xml}}"/>
+                          class="{{blocking.message_formatters.text_xml}}"/>
         <messageFormatter contentType="application/soap+xml"
-                          class="{{message_formatters.blocking.soap_xml}}"/>
+                          class="{{blocking.message_formatters.soap_xml}}"/>
         <messageFormatter contentType="text/plain"
-                          class="{{message_formatters.blocking.text_plain}}"/>
+                          class="{{blocking.message_formatters.text_plain}}"/>
         <messageFormatter contentType="application/json"
-                          class="{{message_formatters.blocking.application_json}}"/>
+                          class="{{blocking.message_formatters.application_json}}"/>
         <messageFormatter contentType="application/json/badgerfish"
-                          class="{{message_formatters.blocking.json_badgerfish}}"/>
+                          class="{{blocking.message_formatters.json_badgerfish}}"/>
         <messageFormatter contentType="text/javascript"
-                          class="{{message_formatters.blocking.text_javascript}}"/>
+                          class="{{blocking.message_formatters.text_javascript}}"/>
         <messageFormatter contentType="application/octet-stream"
-                          class="{{message_formatters.blocking.octet_stream}}"/>
+                          class="{{blocking.message_formatters.octet_stream}}"/>
         <messageFormatter contentType="application/binary"
-                          class="{{message_formatters.blocking.application_binary}}"/>
-        {% for message_formatter in custom_message_formatters.blocking %}
+                          class="{{blocking.message_formatters.application_binary}}"/>
+        {% for message_formatter in blocking.custom_message_formatters %}
         <messageFormatter contentType="{{message_formatter.content_type}}"
                           class="{{message_formatter.class}}"/>
         {% endfor %}
@@ -150,24 +150,24 @@
     <!-- resolved based on the content type. -->
     <messageBuilders>
         <messageBuilder contentType="application/xml"
-                        class="{{message_builders.blocking.application_xml}}"/>
+                        class="{{blocking.message_builders.application_xml}}"/>
         <messageBuilder contentType="application/x-www-form-urlencoded"
-                        class="{{message_builders.blocking.form_urlencoded}}"/>
+                        class="{{blocking.message_builders.form_urlencoded}}"/>
         <messageBuilder contentType="multipart/form-data"
-                        class="{{message_builders.blocking.multipart_form_data}}"/>
+                        class="{{blocking.message_builders.multipart_form_data}}"/>
         <messageBuilder contentType="application/json"
-                        class="{{message_builders.blocking.application_json}}"/>
+                        class="{{blocking.message_builders.application_json}}"/>
         <messageBuilder contentType="application/json/badgerfish"
-                        class="{{message_builders.blocking.json_badgerfish}}"/>
+                        class="{{blocking.message_builders.json_badgerfish}}"/>
         <messageBuilder contentType="text/javascript"
-                        class="{{message_builders.blocking.text_javascript}}"/>
+                        class="{{blocking.message_builders.text_javascript}}"/>
         <messageBuilder contentType="text/plain"
-                        class="{{message_builders.blocking.text_plain}}"/>
+                        class="{{blocking.message_builders.text_plain}}"/>
         <messageBuilder contentType="application/octet-stream"
-                        class="{{message_builders.blocking.octet_stream}}"/>
+                        class="{{blocking.message_builders.octet_stream}}"/>
         <messageBuilder contentType="application/binary"
-                        class="{{message_builders.blocking.application_binary}}"/>
-        {% for message_builder in custom_message_builders.blocking %}
+                        class="{{blocking.message_builders.application_binary}}"/>
+        {% for message_builder in blocking.custom_message_builders %}
         <messageBuilder contentType="{{message_builder.content_type}}"
                         class="{{message_builder.class}}"/>
         {% endfor %}


### PR DESCRIPTION
Fixes the issue of custom message builders and formatters configured for blocking mode in deployment.toml not getting updated in axis2_blocking_client.xml. This only happens when configurations are added for both non-blocking and blocking transports. It happens
because the key 'custom_message_builders.blocking' falls under the parent 'custom_message_builders' which is used for the non blocking transports. The solution was to introduce the key 'blocking_custom_message_formatters' which brakes the relationship.

Resolves: https://github.com/wso2/micro-integrator/issues/1130