### PR TITLE
Uncomment loggers for HTTP headers and messages in log4j2 prop file

### DIFF
--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -192,7 +192,8 @@ loggers = AUDIT_LOG, SERVICE_LOGGER, trace-messages, org-apache-coyote, com-haze
   BlueprintExtender, ModuleDeployer, VFSTransportSender, PassThroughHttpSender, PassThroughHttpSSLSender, \
   PassThroughHttpListener, PassThroughHttpSSLListener, DeploymentEngine, TaskServiceImpl, SynapseControllerFactory, \
   Axis2SynapseController, MultiXMLConfigurationBuilder, XMLConfigurationBuilder, \
-  VFSTransportListener, NTaskTaskManager, MediationStatisticsComponent, SynapseConfigurationBuilder, ServerManager, correlation
+  VFSTransportListener, NTaskTaskManager, MediationStatisticsComponent, SynapseConfigurationBuilder, ServerManager, correlation, \
+  synapse-transport-http-headers, synapse-transport-http-wire, httpclient-wire-header, httpclient-wire-content
 
 # Uncomment the following section and comment the above for verbose logging
 #loggers = AUDIT_LOG, SERVICE_LOGGER, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, \
@@ -287,23 +288,23 @@ logger.com-hazelcast.level = ERROR
 logger.Owasp-CsrfGuard.name = Owasp.CsrfGuard
 logger.Owasp-CsrfGuard.level = WARN
 
-# uncomment the following logs to see HTTP headers and messages
-#logger.synapse-transport-http-headers.name=org.apache.synapse.transport.http.headers
-#logger.synapse-transport-http-headers.level=DEBUG
-#logger.synapse-transport-http-headers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-#
-#logger.synapse-transport-http-wire.name=org.apache.synapse.transport.http.wire
-#logger.synapse-transport-http-wire.level=DEBUG
-#logger.synapse-transport-http-wire.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+# Following are to log HTTP headers and messages
+logger.synapse-transport-http-headers.name=org.apache.synapse.transport.http.headers
+logger.synapse-transport-http-headers.level=OFF
+logger.synapse-transport-http-headers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
-# uncomment the flowing entries to see HTTP headers and messages of Callout mediator/MessageProcessor
-#logger.httpclient-wire-header.name=httpclient.wire.header
-#logger.httpclient-wire-header.level=DEBUG
-#logger.httpclient-wire-header.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-#
-#logger.httpclient-wire-content.name=httpclient.wire.content
-#logger.httpclient-wire-content.level=DEBUG
-#logger.httpclient-wire-content.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.synapse-transport-http-wire.name=org.apache.synapse.transport.http.wire
+logger.synapse-transport-http-wire.level=OFF
+logger.synapse-transport-http-wire.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+# Following entries are to see HTTP headers and messages of Callout mediator/MessageProcessor
+logger.httpclient-wire-header.name=httpclient.wire.header
+logger.httpclient-wire-header.level=OFF
+logger.httpclient-wire-header.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.httpclient-wire-content.name=httpclient.wire.content
+logger.httpclient-wire-content.level=OFF
+logger.httpclient-wire-content.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.name = org.apache.axis2.wsdl.codegen.writer.PrettyPrinter
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.level = ERROR


### PR DESCRIPTION
## Purpose
> This PR uncomments loggers for HTTP headers and messages in log4j2.properties file so that the log level can be updated using the MI CLI.

Related PR: https://github.com/wso2/micro-integrator/pull/1158/


