### PR TITLE
Add method to enable HTTP wire logs using Management API

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/EI1622JMSInboundMessagePollingConsumerTest.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/EI1622JMSInboundMessagePollingConsumerTest.java
@@ -49,7 +49,7 @@ public class EI1622JMSInboundMessagePollingConsumerTest extends ESBIntegrationTe
         pushMessageToQue(addEndpoint());
 
         assertTrue(Utils.checkForLog(carbonLogReader, "Suspending polling as the pollingSuspensionLimit of 2 "
-                        + "reached. Polling will be re-started after 3000 milliseconds", 10),
+                        + "reached. Polling will be re-started after 3000 milliseconds", 60),
                 "JMS Polling suspension is not enabled.");
         Utils.undeploySynapseConfiguration(ENDPOINT_NAME, "inbound-endpoints", true);
     }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -41,11 +41,8 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
     public void setEnvironment() throws Exception {
 
         init();
-        context = new AutomationContext("ESB", TestUserMode.SUPER_TENANT_ADMIN);
-        serverConfigurationManager = new ServerConfigurationManager(context);
-        File modifiedLog4j2File = serverConfigurationManager.enableHTTPWireLogs();
-        serverConfigurationManager.applyMIConfiguration(modifiedLog4j2File);
-        serverConfigurationManager.restartMicroIntegrator();
+        // Set HTTP wire logs to DEBUG level
+        configureHTTPWireLogs("DEBUG");
         carbonLogReader = new CarbonLogReader();
     }
 
@@ -72,7 +69,8 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
     @AfterClass(alwaysRun = true)
     public void stop() throws Exception {
         carbonLogReader.stop();
-        serverConfigurationManager.restoreToLastMIConfiguration();
+        // Disable HTTP wire logs
+        configureHTTPWireLogs("OFF");
     }
 
 }

--- a/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/common/ServerConfigurationManager.java
+++ b/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/common/ServerConfigurationManager.java
@@ -324,41 +324,6 @@ public class ServerConfigurationManager {
     }
 
     /**
-     * A util function which edits the log4j2 properties file and the entries to enable http
-     * wire logs.
-     *
-     * @return - A new File object with wire logs configurations applied.
-     */
-    public File enableHTTPWireLogs() {
-
-        String carbonHome = System.getProperty(ServerConstants.CARBON_HOME);
-        File log4j2PropertiesFile = new File(
-                carbonHome + File.separator + "conf" + File.separator + "log4j2.properties");
-        String loggers = getProperty(log4j2PropertiesFile, "loggers");
-
-        if (loggers == null) {
-            Assert.fail("Loggers property became null");
-        }
-        File destinationFile = new File(log4j2PropertiesFile.getName());
-
-        try (FileInputStream fis = new FileInputStream(log4j2PropertiesFile);
-                FileOutputStream fos = new FileOutputStream(destinationFile)) {
-
-            Properties properties = new Properties();
-            properties.load(fis);
-            properties.setProperty("loggers", "" + loggers + ", synapse-transport-http-wire");
-            properties.setProperty("logger.synapse-transport-http-wire.name", "org.apache.synapse.transport.http.wire");
-            properties.setProperty("logger.synapse-transport-http-wire.level", "DEBUG");
-            properties.store(fos, null);
-            fos.flush();
-
-        } catch (Exception e) {
-            Assert.fail("Exception occurred with the message : " + e.getMessage());
-        }
-        return destinationFile;
-    }
-
-    /**
      * Util method to return the specified  property from a properties file.
      *
      * @param srcFile - The source file which needs to be looked up.


### PR DESCRIPTION
## Purpose
This PR adds configHTTPWireLogs() method to configure HTTP wire logs using Management API. The **ESBJAVA3336HostHeaderValuePortCheckTestCase** is also fixed to use the Management API to enable/disable wire logs.  (Related PR: https://github.com/wso2/micro-integrator/pull/1178)

In commit 1f2576cddd545b8d49663f2ca194653f95de61aa, the polling timeout of log reader is increased to fix the **testPollingWithSuspensionLimit()** test case in **EI1622JMSInboundMessagePollingConsumerTest**.


