### PR TITLE
Change docker entry point to exec form

### DIFF
--- a/distribution/src/docker-distribution/filtered/Dockerfile
+++ b/distribution/src/docker-distribution/filtered/Dockerfile
@@ -44,6 +44,8 @@ RUN \
 
 # copy Micro Intergator product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${MICROESB_NAME}/ ${MICROESB_HOME}
+# copy init script to user home
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 
 # set the user and work directory
 USER ${USER}
@@ -57,4 +59,4 @@ ENV WORKING_DIRECTORY=${USER_HOME} \
 EXPOSE 8290 8253
 
 # initiate container and execute the Micro Integrator product startup script
-ENTRYPOINT $WSO2_SERVER_HOME/bin/micro-integrator.sh
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/distribution/src/docker-distribution/filtered/docker-entrypoint.sh
+++ b/distribution/src/docker-distribution/filtered/docker-entrypoint.sh
@@ -20,10 +20,10 @@
 set -e
 
 # check if the WSO2 non-root user home exists
-test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not exist" && exit 1
+test ! -d "${WORKING_DIRECTORY}" && echo "WSO2 Docker non-root user home does not exist" && exit 1
 
 # check if the WSO2 product home exists
-test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+test ! -d "${WSO2_SERVER_HOME}" && echo "WSO2 Docker product home does not exist" && exit 1
 
-# start WSO2 server
-sh ${WSO2_SERVER_HOME}/bin/micro-integrator.sh "$@"
+# start Micro Integrator
+sh "${WSO2_SERVER_HOME}"/bin/micro-integrator.sh "$@"

--- a/distribution/src/docker-distribution/filtered/docker-entrypoint.sh
+++ b/distribution/src/docker-distribution/filtered/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  WSO2 Inc. licenses this file to you under the Apache License,
+#  Version 2.0 (the "License"); you may not use this file except
+#  in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+# ---------------------------------------------------------------------------
+
+set -e
+
+# check if the WSO2 non-root user home exists
+test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not exist" && exit 1
+
+# check if the WSO2 product home exists
+test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# start WSO2 server
+sh ${WSO2_SERVER_HOME}/bin/micro-integrator.sh "$@"


### PR DESCRIPTION
## Purpose
> This PR changes the docker entry point to exec form so that command-line arguments can be passed to the entry point.

The debug command line argument can be passed as, `docker run -p 8290:8290 -p 5005:5005  wso2/micro-integrator:1.1.0 -debug 5005`

Related issue: https://github.com/wso2/micro-integrator/issues/1114