### PR TITLE
Add method to set hot deployment parameter value

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -113,7 +113,8 @@ public class ConfigurationLoader {
                                     System.getProperty(Constants.PREFIX_TO_ENABLE_INTERNAL_APIS + name))) {
                                 continue;
                             }
-                            if (READINESS_PROBE.equals(name) && MicroIntegratorBaseUtils.isHotDeploymentEnabled()) {
+                            if (READINESS_PROBE.equals(name) && MicroIntegratorBaseUtils.getCarbonAxisConfigurator()
+                                    .isHotDeploymentEnabled()) {
                                 log.warn("Hot Deployment and Readiness Probe configurations are both enabled "
                                                  + "in your server! Note that the readiness probe will not "
                                                  + "identify faulty artifacts that are hot deployed. Be sure to "

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/CarbonAxisConfigurator.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/CarbonAxisConfigurator.java
@@ -46,6 +46,7 @@ import org.apache.axis2.description.Parameter;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.axis2.engine.AxisConfigurator;
 import org.apache.axis2.i18n.Messages;
+import org.apache.axis2.util.JavaUtils;
 import org.apache.axis2.util.XMLUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -86,6 +87,7 @@ public class CarbonAxisConfigurator extends DeploymentEngine implements AxisConf
     }
 
     public CarbonAxisConfigurator() {
+        this.hotDeployment = false;
     }
 
 
@@ -224,6 +226,7 @@ public class CarbonAxisConfigurator extends DeploymentEngine implements AxisConf
             Parameter contextRootParam = new Parameter("contextRoot", carbonContextRoot);
             axisConfig.addParameter(contextRootParam);
         }
+        updateHotDeploymentParameter();
         return axisConfig;
     }
 
@@ -236,6 +239,26 @@ public class CarbonAxisConfigurator extends DeploymentEngine implements AxisConf
             }
         }
         return false;
+    }
+
+    /**
+     * Update the hotDeployment variable after reading the hot deployment parameter from the axis configuration. If the
+     * value is null, then the hotDeployment variable will be set to false which is the default value.
+     */
+    private void updateHotDeploymentParameter() {
+        Parameter hotDeployment = axisConfig.getParameter(org.wso2.micro.integrator.core.Constants.HOT_DEPLOYMENT);
+        if (hotDeployment != null) {
+            this.hotDeployment = JavaUtils.isTrue(hotDeployment.getValue(), false);
+        }
+    }
+
+    /**
+     * This will return the value of hotDeployment.
+     *
+     * @return <code>true</code> if the hot deployment is enabled, <code>false</code> otherwise.
+     */
+    public boolean isHotDeploymentEnabled() {
+        return this.hotDeployment;
     }
 
     public void engageGlobalModules() throws AxisFault {

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/CoreServerInitializer.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/CoreServerInitializer.java
@@ -282,6 +282,7 @@ public class CoreServerInitializer {
             bundleContext.registerService(Axis2ConfigurationContextService.class.getName(),
                     axis2ConfigurationContextService, null);
             CarbonCoreDataHolder.getInstance().setAxis2ConfigurationContextService(axis2ConfigurationContextService);
+            MicroIntegratorBaseUtils.setCarbonAxisConfigurator(carbonAxisConfigurator);
 
         } catch (Throwable e) {
             log.fatal("WSO2 Carbon initialization Failed", e);

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/util/MicroIntegratorBaseUtils.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/util/MicroIntegratorBaseUtils.java
@@ -54,7 +54,6 @@ import org.apache.axis2.deployment.DeploymentConstants;
 import org.apache.axis2.description.AxisService;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.axis2.transport.http.HTTPConstants;
-import org.apache.axis2.util.JavaUtils;
 import org.apache.axis2.util.XMLUtils;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.logging.Log;
@@ -64,6 +63,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.wso2.micro.core.CarbonAxisConfigurator;
 import org.wso2.micro.core.util.CarbonException;
 import org.wso2.micro.integrator.core.internal.MicroIntegratorBaseConstants;
 import org.wso2.micro.integrator.core.resolver.CarbonEntityResolver;
@@ -79,7 +79,7 @@ public class MicroIntegratorBaseUtils {
     private static OMElement axis2Config;
     private static final String TRUE = "true";
     private static final int ENTITY_EXPANSION_LIMIT = 0;
-    private static Boolean hotDeployment;
+    private static CarbonAxisConfigurator carbonAxisConfigurator;
 
     public static String getServerXml() {
 
@@ -333,22 +333,6 @@ public class MicroIntegratorBaseUtils {
         }
     }
 
-    public static synchronized boolean isHotDeploymentEnabled() {
-        if (hotDeployment == null) {
-            try {
-                String hotDeploymentParam = getPropertyFromAxisConf(
-                        org.wso2.micro.integrator.core.Constants.HOT_DEPLOYMENT);
-                hotDeployment = JavaUtils.isTrue(hotDeploymentParam, false);
-            } catch (IOException | XMLStreamException e) {
-                log.error("Error while reading the " + org.wso2.micro.integrator.core.Constants.HOT_DEPLOYMENT
-                                  + " parameter from axis2.xml. Hot Deployment will be set to false.", e);
-                // Setting hotDeployment as false in any occurrence of an error while reading the axis2.xml file.
-                hotDeployment = false;
-            }
-        }
-        return hotDeployment;
-    }
-
     private static String getPropertyFromAxisConf(String parameter) throws IOException, XMLStreamException {
 
         try (InputStream file = new FileInputStream(Paths.get(getCarbonConfigDirPath(), "axis2",
@@ -559,5 +543,21 @@ public class MicroIntegratorBaseUtils {
         //to available at the other context as required (fix 2011-11-30)
         System.setProperty("portOffset", portOffset);
         return portOffset == null? portNumber : portNumber + Integer.parseInt(portOffset);
+    }
+
+    /**
+     * This is to set the carbonAxisConfigurator instance.
+     *
+     * @param carbonAxisConfig Carbon Axis Configurator
+     */
+    public static void setCarbonAxisConfigurator(CarbonAxisConfigurator carbonAxisConfig) {
+        carbonAxisConfigurator = carbonAxisConfig;
+    }
+
+    /**
+     * This is to get the carbonAxisConfigurator instance.
+     */
+    public static CarbonAxisConfigurator getCarbonAxisConfigurator() {
+        return carbonAxisConfigurator;
     }
 }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.probes/src/main/java/org/wso2/micro/integrator/probes/ReadinessResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.probes/src/main/java/org/wso2/micro/integrator/probes/ReadinessResource.java
@@ -98,7 +98,7 @@ public class ReadinessResource extends APIResource {
 
         axisCtx.setProperty(HTTP_SC, CACHED_RESPONSE_CODE);
 
-        if (MicroIntegratorBaseUtils.isHotDeploymentEnabled()) {
+        if (MicroIntegratorBaseUtils.getCarbonAxisConfigurator().isHotDeploymentEnabled()) {
             log.warn("Hot Deployment and Readiness Probe configurations are both enabled in your server! Note that "
                              + "the readiness probe will not identify faulty artifacts that are hot deployed. Be sure "
                              + "to disable hot deployment if the readiness probe is enabled.");

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
@@ -809,7 +809,7 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                 log.info("Copying main sequence to " + mainXMLPath);
                 FileUtils.copyFile(new File(artifactPath), new File(mainXMLPath));
 
-                if (!MicroIntegratorBaseUtils.isHotDeploymentEnabled()) {
+                if (!MicroIntegratorBaseUtils.getCarbonAxisConfigurator().isHotDeploymentEnabled()) {
                     deployer.deploy(new DeploymentFileData(new File(mainXMLPath), deployer));
                 }
                 artifact.setDeploymentStatus(AppDeployerConstants.DEPLOYMENT_STATUS_DEPLOYED);
@@ -837,7 +837,7 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                 log.info("Copying fault sequence to " + faultXMLPath);
                 FileUtils.copyFile(new File(artifactPath), new File(faultXMLPath));
 
-                if (!MicroIntegratorBaseUtils.isHotDeploymentEnabled()) {
+                if (!MicroIntegratorBaseUtils.getCarbonAxisConfigurator().isHotDeploymentEnabled()) {
                     deployer.deploy(new DeploymentFileData(new File(faultXMLPath), deployer));
                 }
                 artifact.setDeploymentStatus(AppDeployerConstants.DEPLOYMENT_STATUS_DEPLOYED);


### PR DESCRIPTION
## Purpose
Before this PR, the default value of the hotDeployment parameter was being taken as true by default during the server startup time and the value was being read from axis configuration using the following code line. 

`Parameter hotDeployment = axisConfiguration.getParameter("hotdeployment");`

Other than that, in some places `isHotDeploymentEnabled()` method inside MicroIntegratorBaseUtils class was being used which will read the axis2.xml file directly and return the value of the hot deployment.

Having two different methods and considering their implementations, this may lead to two contradicting behavior in the server since the two methods can give contradicting values for hot deployment at the same time. (one method can give true as a result while other one is giving false at the same time).

Therefore to address the above issues and to reduce the code redundancy, this PR has created a reference to hot deployment in the CarbonAxisConfigurator class and access it via a util class whenever needed. This will also make the hotDeployment as false by default.

