### PR TITLE
Fix Smooks test case failures

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/smooks/SmooksLargeFileProcessingTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/smooks/SmooksLargeFileProcessingTestCase.java
@@ -18,20 +18,23 @@
 
 package org.wso2.carbon.esb.mediator.test.smooks;
 
-import org.apache.axiom.om.util.AXIOMUtil;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
-import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
-import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
-import org.wso2.esb.integration.common.utils.Utils;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.esb.mediator.test.smooks.utils.FileUtils;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.Utils;
 
 /**
  * This test case is for verifying the functionality of processing relatively large files(>16K TCP buffer size) with
@@ -59,12 +62,16 @@ public class SmooksLargeFileProcessingTestCase extends ESBIntegrationTest {
         Files.createDirectories(Paths.get(smooksResourceDir, "test", "in"));
         Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
         /*
-         * The polling interval of the VFS proxy is 1000 ms. Therefore 2000ms waiting time was added to provide
+         * The polling interval of the VFS proxy is 1s. Therefore atmost 10s waiting time was added to provide
          * enough time for the processing
          */
-        Thread.sleep(2000);
+        Path outPutFilePath = Paths.get(smooksResourceDir, "test", "out", "Out.xml");
 
-        String smooksOut = new String(Files.readAllBytes(Paths.get(smooksResourceDir, "test", "out", "Out.xml")));
+        Awaitility.await().pollInterval(1, TimeUnit.SECONDS).atMost(10, TimeUnit.SECONDS).until(
+                FileUtils.checkFileExistence(outPutFilePath));
+        Assert.assertTrue(Files.exists(outPutFilePath), "Output file has not been created");
+
+        String smooksOut = new String(Files.readAllBytes(outPutFilePath));
         Assert.assertTrue(smooksOut.contains(
                 "<csv-record number=\"160\"><firstname>Andun</firstname><lastname>Sameera</lastname>"
                         + "<gender>Male</gender><age>4</age><country>SriLanka</country></csv-record>"),

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/smooks/SmooksMediatorConfigFromConfigRegistryTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/smooks/SmooksMediatorConfigFromConfigRegistryTestCase.java
@@ -17,20 +17,23 @@
  */
 package org.wso2.carbon.esb.mediator.test.smooks;
 
-import org.apache.axiom.om.util.AXIOMUtil;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
-import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
-import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
-import org.wso2.esb.integration.common.utils.Utils;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.esb.mediator.test.smooks.utils.FileUtils;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.Utils;
 
 public class SmooksMediatorConfigFromConfigRegistryTestCase extends ESBIntegrationTest {
 
@@ -52,20 +55,21 @@ public class SmooksMediatorConfigFromConfigRegistryTestCase extends ESBIntegrati
         Files.createDirectories(Paths.get(smooksResourceDir, "test", "in"));
         Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
         /*
-         * The polling interval of the VFS proxy is 1000 ms. Therefore 2000ms waiting time was added to provide
+         * The polling interval of the VFS proxy is 1s. Therefore atmost 10s waiting time was added to provide
          * enough time for the processing
          */
-        Thread.sleep(2000);
-
         Path outPutFilePath = Paths.get(smooksResourceDir, "test", "out", "config-reg-test-out.xml");
+
+        Awaitility.await().pollInterval(1, TimeUnit.SECONDS).atMost(10, TimeUnit.SECONDS).until(
+                FileUtils.checkFileExistence(outPutFilePath));
         Assert.assertTrue(Files.exists(outPutFilePath), "output file has not been created, there could be an issue "
                 + "in picking up smooks configuration from registry");
+
         String smooksOut = new String(Files.readAllBytes(outPutFilePath));
         Assert.assertTrue(smooksOut.contains("<csv-record "
                         + "number=\"1\"><firstname>Tom</firstname><lastname>Fennelly</lastname><gender>Male</gender><age>4"
                         + "</age><country>Ireland</country></csv-record>"),
                 "Transformation may not have happened as " + "expected from the config picked from registry");
-
     }
 
 

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/smooks/utils/FileUtils.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/smooks/utils/FileUtils.java
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.carbon.esb.mediator.test.smooks.utils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+public class FileUtils {
+
+    /**
+     * Wait until a file is checked for its existence.
+     *
+     * @param filePath path to the target file.
+     * @return Whether the file exists or not
+     */
+    public static Callable<Boolean> checkFileExistence(Path filePath) {
+        return new Callable<Boolean>() {
+            public Boolean call() throws Exception {
+                return Files.exists(filePath);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Purpose
This PR will fix the following test cases that were failing in Windows Github actions due to not having enough time for processing  XML. 
```
- SmooksLargeFileProcessingTestCase.testSendingToSmooks
- SmooksMediatorConfigFromConfigRegistryTestCase.testSendingToSmooks
```