### PR TITLE
Fix proper shutdown of the server in integration tests

### DIFF
--- a/integration/automation-extensions/src/main/java/org/wso2/esb/integration/common/extensions/carbonserver/CarbonServerManager.java
+++ b/integration/automation-extensions/src/main/java/org/wso2/esb/integration/common/extensions/carbonserver/CarbonServerManager.java
@@ -238,9 +238,20 @@ public class CarbonServerManager {
             log.info("Shutting down server ...");
 
             try {
+                // Waiting for 3 mins max until the server gets shut down
+                int retryCount = 36;
+                for (int i = 0; i < retryCount; i++) {
+                    if (isRemotePortInUse("localhost", managementPort)) {
+                        startProcess(carbonHome, getStartScriptCommand("stop"));
+                        waitTill(() -> isRemotePortInUse("localhost", managementPort), 5, TimeUnit.SECONDS);
+                    } else {
+                        break;
+                    }
+                }
 
-                startProcess(carbonHome, getStartScriptCommand("stop"));
-                waitTill(() -> isRemotePortInUse("localhost", managementPort), 180, TimeUnit.SECONDS);
+                if (isRemotePortInUse("localhost", managementPort)) {
+                    throw new AutomationFrameworkException("Failed shutting down the sever");
+                }
 
                 log.info("Server stopped successfully ...");
 


### PR DESCRIPTION
## Purpose
There can be occasions where the server does not get shut down properly even after waiting for 180s after executing stop command once. At that point, the server prints the log as _"Server stopped successfully ..."_ even though it is not properly shut down.

This PR addresses the above issue by trying to execute the stop command multiple times until it gets properly shutdown.  Here, assuming the server takes around 5s to stop the server, we are waiting for 180s in total until the server gets shut down. 

If the server still not gets shut down properly, we will throw a RuntimeException with the message _"Failed shutting down the sever"_.