### PR TITLE
Fix DynamicSSLProfilesPTTListenerTestCase failure in Windows due to hostname verification.

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/sslTestProxy.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/sslTestProxy.xml
@@ -9,7 +9,7 @@
         <inSequence>
             <call>
                 <endpoint>
-                    <address uri="https://127.0.0.1:8443/services/echo"/>
+                    <address uri="https://localhost:8443/services/echo"/>
                 </endpoint>
             </call>
         <respond />


### PR DESCRIPTION
## Purpose
$subject

Related issue #1169