### PR TITLE
Fix test case failures due to registry update in Windows

### DIFF
--- a/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/MicroRegistryManager.java
+++ b/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/MicroRegistryManager.java
@@ -20,6 +20,7 @@ package org.wso2.esb.integration.common.utils;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.esb.integration.common.utils.common.FileManager;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,9 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.rmi.RemoteException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -113,7 +112,7 @@ public class MicroRegistryManager {
         }
 
         try {
-            Files.copy(Paths.get(sourcePath), Paths.get(targetPath), StandardCopyOption.REPLACE_EXISTING);
+            FileManager.copyFile(Paths.get(sourcePath).toFile(), Paths.get(targetPath).toString());
             log.info("Successfully copied" + message);
         } catch (IOException e) {
             throw new MicroRegistryManagerException("Error occurred while copying" + message, e);


### PR DESCRIPTION
## Purpose
ValidateIntegrationDynamicSchemaChangeTestCase and CachableDurationTestCase were failing in Windows with the following error message when trying to update an existing resource in the Micro Registry. 

`The process cannot access the file because it is being used by another process.`

This occurs when using the Files.copy() method from java.nio.file. This PR fixes this issue by replacing the file copy with the functionality given in the org.wso2.esb.integration.common.utils.common.FileManager.

Related issue #1169 