### PR TITLE
Fix hotDeployment variable set to true for any random string

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/CarbonAxisConfigurator.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/CarbonAxisConfigurator.java
@@ -247,8 +247,8 @@ public class CarbonAxisConfigurator extends DeploymentEngine implements AxisConf
      */
     private void updateHotDeploymentParameter() {
         Parameter hotDeployment = axisConfig.getParameter(org.wso2.micro.integrator.core.Constants.HOT_DEPLOYMENT);
-        if (hotDeployment != null) {
-            this.hotDeployment = JavaUtils.isTrue(hotDeployment.getValue(), false);
+        if (hotDeployment != null && "true".equalsIgnoreCase(hotDeployment.getValue().toString())) {
+            this.hotDeployment = true;
         }
     }
 

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/CarbonAxisConfigurator.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/CarbonAxisConfigurator.java
@@ -246,6 +246,7 @@ public class CarbonAxisConfigurator extends DeploymentEngine implements AxisConf
      * value is null, then the hotDeployment variable will be set to false which is the default value.
      */
     private void updateHotDeploymentParameter() {
+        this.hotDeployment = false;
         Parameter hotDeployment = axisConfig.getParameter(org.wso2.micro.integrator.core.Constants.HOT_DEPLOYMENT);
         if (hotDeployment != null && "true".equalsIgnoreCase(hotDeployment.getValue().toString())) {
             this.hotDeployment = true;


### PR DESCRIPTION
## Purpose
> hotDeployment variable is set to true for any random string that is set in hot_deployment configuration in deployment.toml. Because isTrue() method returns true for any string value. 
This PR fixes the issue by setting the hotDeployment variable to true if and only if true is set for hot_deployment in deployment.toml
