### PR TITLE
Revert "Update carbon kernel version"

### DIFF
--- a/p2-profile/carbon.product
+++ b/p2-profile/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.5.3" useFeatures="true" includeLaunchers="true">
+version="4.5.0" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.5.3" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.5.3"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.5.0"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -1254,7 +1254,7 @@
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
 
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.5.3</carbon.kernel.version>
+        <carbon.kernel.version>4.5.0</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
 
         <synapse.version>2.1.7-wso2v148</synapse.version>


### PR DESCRIPTION
Reverts wso2/micro-integrator#1268
Integration tests are failing because of the certificates. Need to update the tests with the new certificates.