### PR TITLE
Increase ReadTimeOut in Windows

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/aggregate/AggregatedRequestClient.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/aggregate/AggregatedRequestClient.java
@@ -24,6 +24,7 @@ import org.apache.axiom.om.OMNamespace;
 import org.apache.axiom.soap.SOAPFactory;
 import org.testng.Assert;
 import org.wso2.esb.integration.common.utils.clients.axis2client.AxisOperationClient;
+import org.wso2.esb.integration.common.utils.clients.axis2client.AxisServiceClient;
 
 import java.io.IOException;
 
@@ -62,14 +63,17 @@ public class AggregatedRequestClient {
     }
 
     public OMElement getResponsenew() throws IOException {
-        AxisOperationClient operationClient = new AxisOperationClient();
+//        AxisOperationClient operationClient = new AxisOperationClient();
+        AxisServiceClient serviceClient = new AxisServiceClient();
         OMElement response = null;
         try {
-            response = operationClient
-                    .send(proxyServiceUrl, null, createMultipleQuoteRequestBodynew(symbol, no_of_iterations),
-                            "urn:getQuote");
+            response = serviceClient.sendReceive(createMultipleQuoteRequestBodynew(symbol, no_of_iterations), proxyServiceUrl,
+                                                 "getQuote");
+//            response = operationClient
+//                    .send(proxyServiceUrl, null, createMultipleQuoteRequestBodynew(symbol, no_of_iterations),
+//                            "urn:getQuote");
         } finally {
-            operationClient.destroy();
+//            operationClient.destroy();
         }
 
         return response;

--- a/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/axis2client/AxisServiceClient.java
+++ b/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/axis2client/AxisServiceClient.java
@@ -46,7 +46,13 @@ public class AxisServiceClient {
             options = new Options();
             options.setTo(new EndpointReference(endPointReference));
             options.setProperty(org.apache.axis2.transport.http.HTTPConstants.CHUNKED, Boolean.FALSE);
-            options.setTimeOutInMilliSeconds(45000);
+            //Increase ReadTimeOut to 3 mins in Windows environments since the operation execution is taking longer in
+            // Windows
+            if (System.getProperty("os.name").contains("Windows")) {
+                options.setTimeOutInMilliSeconds(180000);
+            } else {
+                options.setTimeOutInMilliSeconds(45000);
+            }
             options.setAction("urn:" + operation);
             sender.setOptions(options);
 


### PR DESCRIPTION
## Purpose
Increases ReadTimeOut in Windows since the time taken for certain actions is higher compared to other environments