### PR TITLE
Update default heartbeat interval and retry count

### DIFF
--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/util/RDBMSConstantUtils.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/util/RDBMSConstantUtils.java
@@ -47,8 +47,8 @@ public class RDBMSConstantUtils {
     public static final String LOCAL_GROUP_ID = "localGroupId";
     public static final String SCHEDULED_PERIOD = "scheduledPeriod";
 
-    public static final int DEFAULT_HEART_BEAT_INTERVAL = 5000;
-    public static final int DEFAULT_HEART_BEAT_MAX_RETRY = 3;
+    public static final int DEFAULT_HEART_BEAT_INTERVAL = 2000;
+    public static final int DEFAULT_HEART_BEAT_MAX_RETRY = 2;
     public static final String DEFAULT_LOCAL_GROUP_ID = "default";
     public static final int DEFAULT_SCHEDULED_PERIOD_INTERVAL = 1000;
 


### PR DESCRIPTION
## Purpose
> $subject.

Since 5000 is too much when considering task coordination as member removal will be triggered after heartbeat interval * retry count. Hence reducing it. This is still configurable.