### PR TITLE
Avoid using fully qualified name in console log

### DIFF
--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -44,7 +44,7 @@ appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CAR
 appender.CARBON_CONSOLE.type = Console
 appender.CARBON_CONSOLE.name = CARBON_CONSOLE
 appender.CARBON_CONSOLE.layout.type = PatternLayout
-appender.CARBON_CONSOLE.layout.pattern = [%d] %5p {%c} - %m%ex%n
+appender.CARBON_CONSOLE.layout.pattern = [%d] %5p {%c{1}} - %m%ex%n
 appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
 appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
 


### PR DESCRIPTION
## Purpose
$subject since the console logs are cluttered because of this. Anyway the carbon logs will have the fully qualified name.