### PR TITLE
Disable mailto by default

### DIFF
--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -115,7 +115,7 @@
 
   "transport.mqtt.listener.mqttConFactory.parameter.'mqtt.server.host.name'": "$ref{server.hostname}",
 
-  "transport.mail.listener.enable": true,
+  "transport.mail.listener.enable": false,
   "transport.mail.listener.name": "mailto",
 
   "transport.blocking.mail.listener.enable": true,


### PR DESCRIPTION
## Purpose
> $subject.

We need to enable mailto when required only as in docs https://ei.docs.wso2.com/en/latest/micro-integrator/setup/transport_configurations/configuring-transports/#configuring-the-mailto-transport. There is no need to enable this by default and this will reduce startup time.