### PR TITLE
Resume tasks upon scheduling for the second time

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/TaskEventListener.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/TaskEventListener.java
@@ -113,7 +113,6 @@ public class TaskEventListener extends MemberEventListener {
         tasks.forEach(task -> {
             try {
                 taskManager.stopExecution(task);
-                LOG.info("Stopped execution of task " + task);
             } catch (TaskException e) {
                 LOG.error("Unable to pause the task " + task, e);
             }

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/AbstractQuartzTaskManager.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/AbstractQuartzTaskManager.java
@@ -158,6 +158,7 @@ public abstract class AbstractQuartzTaskManager implements TaskManager {
         String taskGroup = this.getTenantTaskGroup();
         try {
             this.getScheduler().pauseJob(new JobKey(taskName, taskGroup));
+            log.info("Task paused: [" + this.getTaskType() + "][" + taskName + "]");
         } catch (SchedulerException e) {
             throw new TaskException("Error in pausing task with name: " + taskName, TaskException.Code.UNKNOWN, e);
         }
@@ -276,6 +277,7 @@ public abstract class AbstractQuartzTaskManager implements TaskManager {
                 ((OperableTrigger) trigger).setNextFireTime(trigger.getFireTimeAfter(null));
             }
             this.getScheduler().resumeJob(new JobKey(taskName, taskGroup));
+            log.info("Task resumed: [" + this.getTaskType() + "][" + taskName + "]");
         } catch (SchedulerException e) {
             throw new TaskException("Error in resuming task with name: " + taskName, TaskException.Code.UNKNOWN, e);
         }


### PR DESCRIPTION
## Purpose
> When we are re scheduling the previously stopped tasks, we need to resume rather re scheduled if it was stopped earlier. This is done by maintaining a list of stopped tasks and checking on it before scheduling.