### PR TITLE
Fix CipherTool failure in Windows

### DIFF
--- a/distribution/src/conf/security/cipher-tool.properties
+++ b/distribution/src/conf/security/cipher-tool.properties
@@ -26,5 +26,6 @@ Carbon.Security.KeyStore.Password=conf/carbon.xml//Server/Security/KeyStore/Pass
 Carbon.Security.KeyStore.KeyPassword=conf/carbon.xml//Server/Security/KeyStore/KeyPassword,false
 Carbon.Security.TrustStore.Password=conf/carbon.xml//Server/Security/TrustStore/Password,false
 UserManager.AdminUser.Password=conf/user-mgt.xml//UserManager/Realm/Configuration/AdminUser/Password,false
-Datasources.WSO2_CARBON_DB.Configuration.Password=conf/datasources/master-datasources.xml//datasources-configuration/datasources/datasource[name='WSO2_CARBON_DB']/definition[@type='RDBMS']/configuration/password,false
-Management.Api.AdminUser.Password=conf/internal-apis.xml//internalApis/apis/api[@name='ManagementApi']/handlers/handler[@name='BasicSecurityHandler']/UserStore/users/user[username='admin']/password,true
+
+#Uncomment the following to configure an alias for WSO2_CARBON_DB RDBMS data-source password.
+#Datasources.WSO2_CARBON_DB.Configuration.Password=conf/datasources/master-datasources.xml//datasources-configuration/datasources/datasource[name='WSO2_CARBON_DB']/definition[@type='RDBMS']/configuration/password,false


### PR DESCRIPTION
## Purpose
- Remove **Management.Api.AdminUser.Password** from _cipher-tool.properties_ file since the assigned xPath is not valid as the _BasicSecurityHandler_ has been commented out in the _conf/internal-apis.xml_ file.

- Comment out the _Datasources.WSO2_CARBON_DB.Configuration.Password_ from _cipher-tool.properties_ file since, unless a data source is not configured from the deployment.toml, the content inside the _conf/datasources/master-datasources.xml//datasources-configuration/datasources_ will be empty and will cause a failure in Cipher tool.

Fixes https://github.com/wso2/micro-integrator/issues/1095