### PR TITLE
Fix hot undeployment failure in Windows

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -451,10 +451,9 @@ public class CappDeployer extends AbstractDeployer {
      * @throws DeploymentException - error while un-deploying cApp
      */
     public void undeploy(String filePath) throws DeploymentException {
-        String artifactPath = AppDeployerUtils.formatPath(filePath);
         CarbonApplication existingApp = null;
         for (CarbonApplication carbonApp : getCarbonApps()) {
-            if (artifactPath.equals(carbonApp.getAppFilePath())) {
+            if (filePath.equals(carbonApp.getAppFilePath())) {
                 existingApp = carbonApp;
                 break;
             }


### PR DESCRIPTION
## Purpose
Hot undeployment was failing in Windows due to incorrect file path with "/" to the .car file to be undeployed. This PR fixes this issue.