### PR TITLE
Clear local metadata upon removal

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/FileBasedTaskRepository.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/FileBasedTaskRepository.java
@@ -258,6 +258,7 @@ public class FileBasedTaskRepository implements TaskRepository {
             if (metaFile.exists()) {
                 if (metaFile.delete()) {
                     deleteSuccess = true;
+                    taskMetaPropMap.remove(getSystemDependentPath(resourcePath + taskName));
                 } else {
                     log.error("Error occurred while deleting task. Unable to delete: " + getSystemDependentPath(
                             resourcePath + tasksPath + "/_meta_" + taskName));


### PR DESCRIPTION
Fixes https://github.com/wso2/micro-integrator/issues/1301

## Approach
Since we aren't clearing the local meta data while deleting it, is is hashed and the subsequent executions give false values which affects in hot deployment.