### PR TITLE
Fix FailoverEndpointTestCase failure in Windows

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/endpoint/test/FailoverEndpointTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/endpoint/test/FailoverEndpointTestCase.java
@@ -275,7 +275,7 @@ public class FailoverEndpointTestCase extends ESBIntegrationTest {
         for (int i = 0; i < 4; i++) {
             try {
                 lbClient.sendLoadBalanceRequest(getProxyServiceURLHttp("failoverEndPoint_Specific_Errors"), null,
-                                                "5000");
+                                                "10000");
             } catch (AxisFault e) {
                 Assert.assertFalse(e.getMessage().equalsIgnoreCase(ESBTestConstant.READ_TIME_OUT),
                                    "The client was timeout due to Failover Logic doesn't retry for connection refused");


### PR DESCRIPTION
## Purpose
FailoverEndpointTestCase is failing in Windows locally due to read timed out for the failoverEndPoint_Specific_Errors proxy. This PR has increased the client time out value to 10000ms.