### PR TITLE
Update message processor activate and deactivate flow in task

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/TaskEventListener.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/TaskEventListener.java
@@ -108,7 +108,7 @@ public class TaskEventListener extends MemberEventListener {
             taskScheduler.shutdown();
             dataHolder.setTaskScheduler(null);
         }
-        List<String> tasks = taskManager.getAllCoordinatedTasksDeployed();
+        List<String> tasks = taskManager.getLocallyRunningCoordinatedTasks();
         // stop all running coordinated tasks.
         tasks.forEach(task -> {
             try {

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/scehduler/CoordinatedTaskScheduler.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/scehduler/CoordinatedTaskScheduler.java
@@ -32,7 +32,6 @@ import org.wso2.micro.integrator.ntask.core.impl.standalone.ScheduledTaskManager
 import org.wso2.micro.integrator.ntask.core.internal.DataHolder;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -173,6 +172,7 @@ public class CoordinatedTaskScheduler implements Runnable {
             return;
         }
         List<String> deployedCoordinatedTasks = taskManager.getAllCoordinatedTasksDeployed();
+        List<String> erroredTasks = new ArrayList<>();
         for (String taskName : tasksOfThisNode) {
             if (deployedCoordinatedTasks.contains(taskName)) {
                 if (LOG.isDebugEnabled()) {
@@ -182,7 +182,7 @@ public class CoordinatedTaskScheduler implements Runnable {
                     taskManager.scheduleCoordinatedTask(taskName);
                 } catch (TaskException ex) {
                     if (!TaskException.Code.DATABASE_ERROR.equals(ex.getCode())) {
-                        taskStore.updateTaskState(Collections.singletonList(taskName), CoordinatedTask.States.NONE);
+                        erroredTasks.add(taskName);
                     }
                     LOG.error("Exception occurred while scheduling coordinated task : " + taskName, ex);
                 }
@@ -191,6 +191,7 @@ public class CoordinatedTaskScheduler implements Runnable {
                                  + "in this node or an invalid entry, hence ignoring it.");
             }
         }
+        taskStore.updateTaskState(erroredTasks, CoordinatedTask.States.NONE);
     }
 
     /**

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/TaskStore.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/TaskStore.java
@@ -22,7 +22,6 @@ import org.wso2.micro.integrator.ntask.coordination.TaskCoordinationException;
 import org.wso2.micro.integrator.ntask.coordination.task.CoordinatedTask;
 import org.wso2.micro.integrator.ntask.coordination.task.store.connector.RDMBSConnector;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -102,7 +101,7 @@ public class TaskStore {
      */
     public void activateTask(String taskName) throws TaskCoordinationException {
 
-        updateTaskState(Collections.singletonList(taskName), CoordinatedTask.States.ACTIVATED);
+        rdmbsConnector.activateTask(taskName);
     }
 
     /**
@@ -112,11 +111,7 @@ public class TaskStore {
      */
     public void deactivateTask(String taskName) throws TaskCoordinationException {
 
-        updateTaskState(Collections.singletonList(taskName), CoordinatedTask.States.DEACTIVATED);
-    }
-
-    public CoordinatedTask.States getTaskState(String taskName) throws TaskCoordinationException {
-        return rdmbsConnector.getTaskState(taskName);
+        rdmbsConnector.deactivateTask(taskName);
     }
 
     /**
@@ -168,6 +163,21 @@ public class TaskStore {
     public void updateTaskState(List<String> tasks, CoordinatedTask.States state) throws TaskCoordinationException {
 
         rdmbsConnector.updateTaskState(tasks, state);
+    }
+
+    /**
+     * Update the state of task.
+     *
+     * @param taskName     Name of the task.
+     * @param updatedState Updated state.
+     * @param destinedId   Destined Node Id.
+     * @return True if update is successful.
+     * @throws TaskCoordinationException when something goes wrong while updating.
+     */
+    public boolean updateTaskState(String taskName, CoordinatedTask.States updatedState, String destinedId)
+            throws TaskCoordinationException {
+
+        return rdmbsConnector.updateTaskState(taskName, updatedState, destinedId);
     }
 
     /**

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/connector/RDMBSConnector.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/connector/RDMBSConnector.java
@@ -38,7 +38,7 @@ import javax.sql.DataSource;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.ACTIVATE_TASK;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.ADD_TASK;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.CLEAN_TASKS_OF_NODE;
-import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.DEACTIVATE_TASK;
+import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.UPDATE_TASK_STATUS_TO_DEACTIVATED;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.DELETE_TASK;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.DESTINED_NODE_ID;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.GET_ALL_ASSIGNED_INCOMPLETE_TASKS;
@@ -190,7 +190,7 @@ public class RDMBSConnector {
      */
     public void deactivateTask(String name) throws TaskCoordinationException {
         try (Connection connection = getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(
-                DEACTIVATE_TASK)) {
+                UPDATE_TASK_STATUS_TO_DEACTIVATED)) {
             preparedStatement.setString(1, name);
             preparedStatement.executeUpdate();
         } catch (SQLException ex) {

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/connector/RDMBSConnector.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/connector/RDMBSConnector.java
@@ -35,8 +35,10 @@ import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
 
+import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.ACTIVATE_TASK;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.ADD_TASK;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.CLEAN_TASKS_OF_NODE;
+import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.DEACTIVATE_TASK;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.DELETE_TASK;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.DESTINED_NODE_ID;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.GET_ALL_ASSIGNED_INCOMPLETE_TASKS;
@@ -44,12 +46,12 @@ import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.REMOVE_TASKS_OF_NODE;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.RETRIEVE_ALL_TASKS;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.RETRIEVE_TASKS_OF_NODE;
-import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.RETRIEVE_TASK_STATE;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.RETRIEVE_UNASSIGNED_NOT_COMPLETED_TASKS;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.TASK_NAME;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.TASK_STATE;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.UPDATE_ASSIGNMENT_AND_STATE;
 import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.UPDATE_TASK_STATE;
+import static org.wso2.micro.integrator.ntask.coordination.task.store.connector.TaskQueryHelper.UPDATE_TASK_STATE_FOR_DESTINED_NODE;
 
 /**
  * The connector class which deals with underlying coordinated task table.
@@ -182,6 +184,36 @@ public class RDMBSConnector {
     }
 
     /**
+     * Deactivates the task.
+     *
+     * @param name - Name of the task.
+     */
+    public void deactivateTask(String name) throws TaskCoordinationException {
+        try (Connection connection = getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(
+                DEACTIVATE_TASK)) {
+            preparedStatement.setString(1, name);
+            preparedStatement.executeUpdate();
+        } catch (SQLException ex) {
+            throw new TaskCoordinationException(ERROR_MSG, ex);
+        }
+    }
+
+    /**
+     * Activates the task.
+     *
+     * @param name - Name of the task.
+     */
+    public void activateTask(String name) throws TaskCoordinationException {
+        try (Connection connection = getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(
+                ACTIVATE_TASK)) {
+            preparedStatement.setString(1, name);
+            preparedStatement.executeUpdate();
+        } catch (SQLException ex) {
+            throw new TaskCoordinationException(ERROR_MSG, ex);
+        }
+    }
+
+    /**
      * Remove the task entry.
      *
      * @param tasks - List of tasks to be removed.
@@ -261,29 +293,6 @@ public class RDMBSConnector {
     }
 
     /**
-     * Retrieve the task state
-     *
-     * @param taskName -  Name of the task.
-     * @return - Task state
-     * @throws TaskCoordinationException Exception
-     */
-    public CoordinatedTask.States getTaskState(String taskName) throws TaskCoordinationException {
-
-        try (Connection connection = getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(
-                RETRIEVE_TASK_STATE)) {
-            preparedStatement.setString(1, taskName);
-            try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                if (resultSet.next()) {
-                    return CoordinatedTask.States.valueOf(resultSet.getString(TASK_STATE));
-                }
-                return null;
-            }
-        } catch (SQLException ex) {
-            throw new TaskCoordinationException(ERROR_MSG, ex);
-        }
-    }
-
-    /**
      * Retrieve all assigned and incomplete tasks.
      *
      * @return - List of tasks.
@@ -346,6 +355,34 @@ public class RDMBSConnector {
                 tasks.forEach((task, destinedNode) -> LOG
                         .debug("Assigned the task [" + task + "] with destined node [" + destinedNode + "]"));
             }
+        } catch (SQLException ex) {
+            throw new TaskCoordinationException(ERROR_MSG, ex);
+        }
+    }
+
+    /**
+     * Update the state of task.
+     *
+     * @param taskName     Name of the task.
+     * @param updatedState Updated state.
+     * @param destinedId   Destined Node Id.
+     * @return True if update is successful.
+     * @throws TaskCoordinationException when something goes wrong while updating.
+     */
+    public boolean updateTaskState(String taskName, CoordinatedTask.States updatedState, String destinedId)
+            throws TaskCoordinationException {
+
+        try (Connection connection = getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(
+                UPDATE_TASK_STATE_FOR_DESTINED_NODE)) {
+            preparedStatement.setString(1, updatedState.name());
+            preparedStatement.setString(2, taskName);
+            preparedStatement.setString(3, destinedId);
+            int result = preparedStatement.executeUpdate();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug((result == 1 ? "Updated" : "Unable to update") + " state to [" + updatedState + "] for task ["
+                                  + "] with destined nodeId [" + destinedId + "]");
+            }
+            return result == 1;
         } catch (SQLException ex) {
             throw new TaskCoordinationException(ERROR_MSG, ex);
         }

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/connector/TaskQueryHelper.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/connector/TaskQueryHelper.java
@@ -46,13 +46,22 @@ class TaskQueryHelper {
             "UPDATE  " + TABLE_NAME + " SET  " + DESTINED_NODE_ID + " = ? , " + TASK_STATE + " = " + TASK_STATE_CONST
                     + " WHERE " + TASK_NAME + " = ?";
 
+    static final String DEACTIVATE_TASK =
+            "UPDATE  " + TABLE_NAME + "  SET " + TASK_STATE + " = \"" + CoordinatedTask.States.DEACTIVATED + "\" "
+                    + "WHERE " + TASK_NAME + " =? AND " + TASK_STATE + " !=\"" + CoordinatedTask.States.PAUSED + "\"";
+
+    static final String ACTIVATE_TASK =
+            "UPDATE  " + TABLE_NAME + "  SET " + TASK_STATE + " = \"" + CoordinatedTask.States.ACTIVATED + "\" WHERE "
+                    + TASK_NAME + " =? AND " + TASK_STATE + " !=\"" + CoordinatedTask.States.RUNNING + "\"";
+
     static final String UPDATE_TASK_STATE =
             "UPDATE  " + TABLE_NAME + "  SET " + TASK_STATE + " = ? WHERE " + TASK_NAME + " =? ";
 
-    static final String RETRIEVE_ALL_TASKS = "SELECT  " + TASK_NAME + " FROM " + TABLE_NAME;
+    static final String UPDATE_TASK_STATE_FOR_DESTINED_NODE =
+            "UPDATE  " + TABLE_NAME + "  SET " + TASK_STATE + " = ? WHERE " + TASK_NAME + " =? AND " + DESTINED_NODE_ID
+                    + " =?";
 
-    static final String RETRIEVE_TASK_STATE =
-            "SELECT " + TASK_STATE + " FROM " + TABLE_NAME + " WHERE " + TASK_NAME + " =?";
+    static final String RETRIEVE_ALL_TASKS = "SELECT  " + TASK_NAME + " FROM " + TABLE_NAME;
 
     static final String RETRIEVE_UNASSIGNED_NOT_COMPLETED_TASKS =
             "SELECT " + TASK_NAME + " FROM " + TABLE_NAME + " WHERE  " + DESTINED_NODE_ID + " IS NULL AND " + TASK_STATE
@@ -72,7 +81,8 @@ class TaskQueryHelper {
 
     static final String CLEAN_TASKS_OF_NODE =
             "UPDATE " + TABLE_NAME + " SET " + DESTINED_NODE_ID + " = NULL , " + TASK_STATE + " = " + TASK_STATE_CONST
-                    + " WHERE " + DESTINED_NODE_ID + " = ?";
+                    + " WHERE " + DESTINED_NODE_ID + " = ? AND " + TASK_STATE + " !=\""
+                    + CoordinatedTask.States.COMPLETED + "\"";
 
     static final String GET_ALL_ASSIGNED_INCOMPLETE_TASKS =
             "SELECT * FROM " + TABLE_NAME + " WHERE " + DESTINED_NODE_ID + " IS NOT NULL AND " + TASK_STATE + " != \""

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/connector/TaskQueryHelper.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/store/connector/TaskQueryHelper.java
@@ -46,7 +46,7 @@ class TaskQueryHelper {
             "UPDATE  " + TABLE_NAME + " SET  " + DESTINED_NODE_ID + " = ? , " + TASK_STATE + " = " + TASK_STATE_CONST
                     + " WHERE " + TASK_NAME + " = ?";
 
-    static final String DEACTIVATE_TASK =
+    static final String UPDATE_TASK_STATUS_TO_DEACTIVATED =
             "UPDATE  " + TABLE_NAME + "  SET " + TASK_STATE + " = \"" + CoordinatedTask.States.DEACTIVATED + "\" "
                     + "WHERE " + TASK_NAME + " =? AND " + TASK_STATE + " !=\"" + CoordinatedTask.States.PAUSED + "\"";
 

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/TaskManager.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/TaskManager.java
@@ -35,14 +35,6 @@ public interface TaskManager {
     void initStartupTasks() throws TaskException;
 
     /**
-     * Starts a task with the given name.
-     *
-     * @param taskName The name of the task
-     * @throws TaskException Exception
-     */
-    void scheduleTask(String taskName) throws TaskException;
-
-    /**
      * Reschedules a task with the given name, only the trigger information will be updated in the
      * reschedule.
      *
@@ -74,6 +66,13 @@ public interface TaskManager {
      * @return List of deployed coordinated tasks.
      */
     List<String> getAllCoordinatedTasksDeployed();
+
+    /**
+     * Get all the locally running coordinated tasks.
+     *
+     * @return List of all locally running coordinated tasks.
+     */
+    List<String> getLocallyRunningCoordinatedTasks();
 
     /**
      * Handles the pause operation for the task with the given name.

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/internal/DataHolder.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/internal/DataHolder.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ScheduledExecutorService;
 public class DataHolder {
 
     private static final DataHolder instance = new DataHolder();
-    private boolean coordinationEnabledGlobally = false;
     private ClusterCoordinator clusterCoordinator;
     private ScheduledTaskManager taskManager;
     private ScheduledExecutorService taskScheduler;
@@ -45,19 +44,19 @@ public class DataHolder {
     }
 
     public boolean isCoordinationEnabledGlobally() {
-        return coordinationEnabledGlobally;
-    }
-
-    public void setCoordinationEnabledGlobally(boolean coordinationEnabledGlobally) {
-        this.coordinationEnabledGlobally = coordinationEnabledGlobally;
+        return clusterCoordinator != null;
     }
 
     public ClusterCoordinator getClusterCoordinator() {
         return clusterCoordinator;
     }
 
-    public void setClusterCoordinator(ClusterCoordinator clusterCoordinator) {
+    void setClusterCoordinator(ClusterCoordinator clusterCoordinator) {
         this.clusterCoordinator = clusterCoordinator;
+    }
+
+    public String getLocalNodeId() {
+        return clusterCoordinator != null ? clusterCoordinator.getThisNodeId() : null;
     }
 
     public ScheduledTaskManager getTaskManager() {

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/internal/TasksDSComponent.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/internal/TasksDSComponent.java
@@ -107,7 +107,6 @@ public class TasksDSComponent {
                 DataSource coordinationDataSource = (DataSource) coordinationDatasourceObject;
                 clusterCoordinator = new ClusterCoordinator(coordinationDataSource);
                 dataHolder.setClusterCoordinator(clusterCoordinator);
-                dataHolder.setCoordinationEnabledGlobally(true);
                 // initialize task data base.
                 taskStore = new TaskStore(coordinationDataSource);
                 // removing all tasks assigned to this node since this node hasn't even  joined the cluster yet and
@@ -133,6 +132,9 @@ public class TasksDSComponent {
             if (isCoordinationEnabled) {
                 clusterCoordinator.registerListener(new ClusterEventListener(clusterCoordinator.getThisNodeId()));
                 ScheduledTaskManager scheduledTaskManager = dataHolder.getTaskManager();
+                if (scheduledTaskManager == null) {
+                    throw new AssertionError("Task Manager is not initialized properly.");
+                }
                 clusterCoordinator.registerListener(new TaskEventListener(scheduledTaskManager, taskStore, resolver));
                 // the task scheduler should be started after registering task service.
                 coordinatedTaskScheduleManager = new CoordinatedTaskScheduleManager(scheduledTaskManager, taskStore,


### PR DESCRIPTION
**Improvements**

1.  When scheduling tasks, validate db update and react accordingly ( whether failed or not ).
2. When pausing tasks , if they are running locally just pause them and update DB as paused rather than doing all the steps in https://github.com/wso2/micro-integrator/pull/1304
3. While activating and deactivating, if the state is as running or paused respectively ignoring that update so that the relavant nodes doesn't have to retrieve them again and act accordingly. 
