### PR TITLE
Add env variable support for secret resolving

### DIFF
--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/EnvironmentSecretRepository.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/EnvironmentSecretRepository.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.integrator.mediation.security.vault;
+
+import org.wso2.securevault.secret.SecretRepository;
+import java.util.Properties;
+
+public class EnvironmentSecretRepository implements SecretRepository {
+
+    /* Parent secret repository */
+    private SecretRepository parentRepository;
+
+    @Override
+    public void init(Properties properties, String s) {
+        // Nothing to do here
+    }
+
+    @Override
+    public String getSecret(String alias) {
+        String rawValue = getPlainTextSecret(alias);
+        return SecureVaultUtils.decryptSecret(rawValue);
+    }
+
+    /**
+     * Returns the plaintext value from the environment.
+     *
+     * @param alias Environment variable name.
+     */
+    public String getPlainTextSecret(String alias) {
+        String planTextSecret = System.getenv(alias);
+        if (planTextSecret == null) {
+            return null;
+        }
+        return planTextSecret.trim();
+    }
+
+    @Override
+    public String getEncryptedData(String s) {
+        return null;
+    }
+
+    @Override
+    public void setParent(SecretRepository secretRepository) {
+        parentRepository = secretRepository;
+    }
+
+    @Override
+    public SecretRepository getParent() {
+        return parentRepository;
+    }
+}

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/FileSecretRepository.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/FileSecretRepository.java
@@ -21,7 +21,6 @@ package org.wso2.micro.integrator.mediation.security.vault;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
-import org.wso2.securevault.DecryptionProvider;
 import org.wso2.securevault.secret.SecretRepository;
 
 import java.io.BufferedReader;
@@ -59,14 +58,7 @@ public class FileSecretRepository implements SecretRepository {
     public String getSecret(String alias) {
         // Read from file
         String secretRawValue = getPlainTextSecret(alias);
-        DecryptionProvider decyptProvider = CipherInitializer.getInstance().getDecryptionProvider();
-
-        if (decyptProvider == null) {
-            // This cannot happen unless someone mess with OSGI references
-            LOG.error("Can not proceed decryption due to the secret repository initialization error");
-            throw new SynapseException("Secret repository is null for alias "+ alias);
-        }
-        return new String(decyptProvider.decrypt(secretRawValue.trim().getBytes()));
+        return SecureVaultUtils.decryptSecret(secretRawValue);
     }
 
     /**

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecretCipherHander.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecretCipherHander.java
@@ -31,6 +31,7 @@ class SecretCipherHander {
 	/* Root Secret Repository */
 	private RegistrySecretRepository parentRepository = new RegistrySecretRepository();
 	private FileSecretRepository fileSecretRepository = new FileSecretRepository();
+	private EnvironmentSecretRepository environmentSecretRepository =  new EnvironmentSecretRepository();
 
 	SecretCipherHander(org.apache.synapse.MessageContext synCtx) {
 		super();
@@ -56,6 +57,11 @@ class SecretCipherHander {
 				return fileSecretRepository.getSecret(resolvedAlias);
 			}
 			return fileSecretRepository.getPlainTextSecret(resolvedAlias);
+		} else if (VaultType.ENV.equals(secretSrcData.getVaultType())) {
+			if (secretSrcData.isEncrypted()) {
+				return environmentSecretRepository.getSecret(alias);
+			}
+			return environmentSecretRepository.getPlainTextSecret(alias);
 		} else if (VaultType.REG.equals(secretSrcData.getVaultType())) {
 			// For registry type we only support plain text
 			return parentRepository.getSecret(alias);

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecretSrcData.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecretSrcData.java
@@ -62,6 +62,8 @@ public class SecretSrcData {
         if (VaultType.DOCKER.toString().equals(vaultType)) {
             this.vaultType = VaultType.DOCKER;
             this.secretRoot = dockerSecretRoot;
+        } else if (VaultType.ENV.toString().equals(vaultType)) {
+            this.vaultType = VaultType.ENV;
         } else {
             this.vaultType = VaultType.FILE;
             this.secretRoot = fileSecretRoot;

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecureVaultUtils.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecureVaultUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.integrator.mediation.security.vault;
+
+import org.apache.synapse.SynapseException;
+import org.wso2.securevault.DecryptionProvider;
+
+public class SecureVaultUtils {
+
+    /**
+     * Returns the decrypted value for a secret.
+     *
+     * @param encryptedValue encrypted password text
+     */
+    public static String decryptSecret(String encryptedValue) {
+        DecryptionProvider decyptProvider = CipherInitializer.getInstance().getDecryptionProvider();
+        if (encryptedValue == null || encryptedValue.isEmpty()) {
+          return encryptedValue;
+        }
+        if (decyptProvider == null) {
+            // This cannot happen unless someone mess with OSGI references
+            throw new SynapseException("Secret repository has not been initialized.");
+        }
+        return new String(decyptProvider.decrypt(encryptedValue.trim().getBytes()));
+    }
+}

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/VaultType.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/VaultType.java
@@ -24,5 +24,6 @@ package org.wso2.micro.integrator.mediation.security.vault;
 public enum VaultType {
     REG,
     FILE,
-    DOCKER
+    DOCKER,
+    ENV
 }


### PR DESCRIPTION
Fixes: https://github.com/wso2/micro-integrator/issues/1098

## Purpose
> Add secret resolving from environment variables. This will be used in **kubernetes** secrets.
```
wso2:vault-lookup('<alias>', '<type>', '<isEncripted>')
```
alias - environment variable name
type - ENV
