### PR TITLE
Add message processor cluster intergation tests

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/AbstractQuartzTaskManager.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/AbstractQuartzTaskManager.java
@@ -215,7 +215,7 @@ public abstract class AbstractQuartzTaskManager implements TaskManager {
             if (paused) {
                 this.getScheduler().pauseJob(job.getKey());
             }
-            log.info("Task scheduled: [" + this.getTaskType() + "][" + taskName + "]" + (paused ? " [Paused]" : ""));
+            log.info("Task scheduled: [" + this.getTaskType() + "][" + taskName + "]" + (paused ? " [Paused]." : "."));
         } catch (SchedulerException e) {
             throw new TaskException("Error in scheduling task with name: " + taskName, TaskException.Code.UNKNOWN, e);
         }

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/TestUtils.java
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/TestUtils.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.xml.xpath.XPathExpressionException;
 
-import static org.wso2.esb.integration.common.utils.Utils.ArtifactType.TASK;
+import static org.wso2.esb.integration.common.utils.Utils.ArtifactType;
 
 public class TestUtils {
 
@@ -63,17 +63,17 @@ public class TestUtils {
                                            startupParameters);
     }
 
-    public static void deployTasks(String depDir, String... tasks) throws Exception {
+    public static void deployArtifacts(String depDir, ArtifactType type, String... tasks) throws Exception {
 
         for (int i = 0; i < tasks.length; i++) {
             File task = new File(FrameworkPathUtil.getSystemResourceLocation() + "artifacts" + File.separator + "ESB"
-                                         + File.separator + "tasks" + File.separator + tasks[i] + ".xml");
-            Utils.deploySynapseConfiguration(task, depDir, TASK);
+                                         + File.separator + type.getDirName() + File.separator + tasks[i] + ".xml");
+            Utils.deploySynapseConfiguration(task, depDir, type);
         }
     }
 
     public static String deploymentLog(String name) {
-        return "Task scheduled: [ESB_TASK][" + name + "]";
+        return "Task scheduled: [ESB_TASK][" + name + "].";
     }
 
     public static boolean isTaskExistInStore(String taskName) throws Exception {

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/message/processor/MessageProcessorTests.java
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/message/processor/MessageProcessorTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.integrator.message.processor;
+
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.esb.integration.common.extensions.carbonserver.CarbonTestServerManager;
+import org.wso2.esb.integration.common.extensions.carbonserver.MultipleServersManager;
+import org.wso2.esb.integration.common.utils.CarbonLogReader;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.LogReaderManager;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wso2.esb.integration.common.utils.Utils.ArtifactType;
+import static org.wso2.micro.integrator.TestUtils.CLUSTER_DEP_TIMEOUT;
+import static org.wso2.micro.integrator.TestUtils.LOG_READ_TIMEOUT;
+import static org.wso2.micro.integrator.TestUtils.deployArtifacts;
+import static org.wso2.micro.integrator.TestUtils.deploymentLog;
+import static org.wso2.micro.integrator.TestUtils.getNode;
+
+/**
+ * Test cases to verify message processor behavior when clustered.
+ */
+public class MessageProcessorTests extends ESBIntegrationTest {
+
+    private MultipleServersManager serverManager;
+    private CarbonLogReader reader1;
+    private CarbonLogReader reader2;
+    private LogReaderManager logManager;
+    private boolean taskScheduledInNode1 = false;
+    private static final String MS_1 = "InMemoryStore-1";
+    private static final String MS_2 = "InMemoryStore-2";
+    private static final String MP_1 = "ScheduleMessageForwardingProcessor-1";
+    private static final String MP_2 = "ScheduleMessageForwardingProcessor-2";
+    private static final String STORE_PROXY = "storeProxy";
+    private static final String MP_PREFIX = "MSMP_";
+    private static final String UNDER_SCORE = "_";
+    private static final String DEFAULT_SUFFIX = UNDER_SCORE + "0";
+    private static final String MP_1_TASK_NAME = MP_PREFIX + MP_1 + DEFAULT_SUFFIX;
+    private static final String PAYLOAD = "{\"test_payload\":\"message_processor_cluster_tests\"}";
+    private static final int NODE_1_OFFSET = 50;
+    private static final int NODE_2_OFFSET = 60;
+
+    @BeforeClass
+    void initialize() throws Exception {
+
+        context = new AutomationContext();
+        serverManager = new MultipleServersManager();
+        logManager = new LogReaderManager();
+        CarbonTestServerManager node1 = getNode(NODE_1_OFFSET);
+        CarbonTestServerManager node2 = getNode(NODE_2_OFFSET);
+        serverManager.startServersWithDepSync(true, node1, node2);
+        reader1 = new CarbonLogReader(node1.getCarbonHome());
+        reader2 = new CarbonLogReader(node2.getCarbonHome());
+        logManager.start(reader1, reader2);
+        deployArtifacts(serverManager.getDeploymentDirectory(), ArtifactType.MESSAGE_STORES, MS_1, MS_2);
+        deployArtifacts(serverManager.getDeploymentDirectory(), ArtifactType.MESSAGE_PROCESSOR, MP_1, MP_2);
+        deployArtifacts(serverManager.getDeploymentDirectory(), ArtifactType.PROXY, STORE_PROXY);
+    }
+
+    @Test
+    void testMpScheduling() throws Exception {
+
+        taskScheduledInNode1 = reader1.checkForLog(deploymentLog(MP_1_TASK_NAME), CLUSTER_DEP_TIMEOUT);
+        log.info(MP_1 + " is" + (taskScheduledInNode1 ? " " : " not ") + "scheduled in node 1.");
+        if (taskScheduledInNode1 == reader2.checkForLog(deploymentLog(MP_1_TASK_NAME), CLUSTER_DEP_TIMEOUT)) {
+            Assert.fail("Deployment failed for " + MP_1);
+        }
+    }
+
+    @Test(dependsOnMethods = { "testMpScheduling" })
+    void testMpMemberCount() throws Exception {
+
+        int memberCount = 5;
+        boolean result = true;
+        if (taskScheduledInNode1) {
+            for (int i = 0; i < memberCount; i++) {
+                String mpName = MP_PREFIX + MP_2 + UNDER_SCORE + i;
+                if (!reader1.checkForLog(deploymentLog(mpName), 1)) {
+                    result = false;
+                    break;
+                }
+            }
+        } else {
+            for (int i = 0; i < memberCount; i++) {
+                String mpName = MP_PREFIX + MP_2 + UNDER_SCORE + i;
+                if (!reader2.checkForLog(deploymentLog(mpName), 1)) {
+                    result = false;
+                    break;
+                }
+            }
+        }
+        if (!result) {
+            Assert.fail(memberCount + " tasks are not scheduled for " + MP_2 + " as specified in the member count.");
+        }
+    }
+
+    @Test(dependsOnMethods = { "testMpMemberCount" })
+    void testMpExecution() throws Exception {
+
+        logManager.clearAll();
+        String storeProxyLog = "where = store proxy";
+        if (taskScheduledInNode1) {
+            sendRequest(NODE_1_OFFSET);
+            if (!reader1.checkForLog(storeProxyLog, LOG_READ_TIMEOUT)) {
+                Assert.fail("Message hasn't reached " + STORE_PROXY);
+            }
+            if (!reader1.checkForLog(PAYLOAD, LOG_READ_TIMEOUT)) {
+                Assert.fail("Message Processor execution failed.");
+            }
+        } else {
+            sendRequest(NODE_2_OFFSET);
+            if (!reader2.checkForLog(storeProxyLog, LOG_READ_TIMEOUT)) {
+                Assert.fail("Message hasn't reached " + STORE_PROXY);
+            }
+            if (!reader2.checkForLog(PAYLOAD, LOG_READ_TIMEOUT)) {
+                Assert.fail("Message Processor execution failed.");
+            }
+        }
+    }
+
+    private void sendRequest(int offset) throws Exception {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-type", "application/json");
+        String url = "http://localhost:" + (8280 + offset) + "/services/" + STORE_PROXY;
+        HttpRequestUtil.doPost(new URL(url), PAYLOAD, headers);
+    }
+
+    @AfterClass
+    void stop() throws Exception {
+        logManager.stopAll();
+        serverManager.stopAllServers();
+    }
+}

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/tasks/TaskTests.java
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/tasks/TaskTests.java
@@ -28,16 +28,17 @@ import org.wso2.esb.integration.common.extensions.carbonserver.MultipleServersMa
 import org.wso2.esb.integration.common.utils.CarbonLogReader;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.LogReaderManager;
+import org.wso2.esb.integration.common.utils.Utils;
 
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.wso2.micro.integrator.TestUtils.CLUSTER_DEP_TIMEOUT;
 import static org.wso2.micro.integrator.TestUtils.CLUSTER_TASK_RESCHEDULE_TIMEOUT;
-import static org.wso2.micro.integrator.TestUtils.isTaskExistInStore;
-import static org.wso2.micro.integrator.TestUtils.deployTasks;
+import static org.wso2.micro.integrator.TestUtils.deployArtifacts;
 import static org.wso2.micro.integrator.TestUtils.deploymentLog;
 import static org.wso2.micro.integrator.TestUtils.getNode;
+import static org.wso2.micro.integrator.TestUtils.isTaskExistInStore;
 
 /**
  * Tests to verify tasks scheduling in 2 node cluster.
@@ -71,7 +72,8 @@ public class TaskTests extends ESBIntegrationTest {
         reader1 = new CarbonLogReader(node1.getCarbonHome());
         reader2 = new CarbonLogReader(node2.getCarbonHome());
         logManager.start(reader1, reader2);
-        deployTasks(serverManager.getDeploymentDirectory(), TASK_1, TASK_2, TASK_COMPLETE, TASK_PINNED);
+        deployArtifacts(serverManager.getDeploymentDirectory(), Utils.ArtifactType.TASK, TASK_1, TASK_2, TASK_COMPLETE,
+                        TASK_PINNED);
     }
 
     @Test

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-processors/ScheduleMessageForwardingProcessor-1.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-processors/ScheduleMessageForwardingProcessor-1.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<messageProcessor xmlns="http://ws.apache.org/ns/synapse"
+                  class="org.apache.synapse.message.processor.impl.forwarder.ScheduledMessageForwardingProcessor"
+                  name="ScheduleMessageForwardingProcessor-1" targetEndpoint="log-endpoint"
+                  messageStore="InMemoryStore-2">
+    <parameter name="client.retry.interval">1000</parameter>
+    <parameter name="throttle">false</parameter>
+    <parameter name="max.delivery.attempts">4</parameter>
+    <parameter name="member.count">1</parameter>
+    <parameter name="store.connection.retry.interval">1000</parameter>
+    <parameter name="max.store.connection.attempts">-1</parameter>
+    <parameter name="max.delivery.drop">Disabled</parameter>
+    <parameter name="interval">1000</parameter>
+    <parameter name="message.processor.failMessagesStore">InMemoryStore-1</parameter>
+    <parameter name="is.active">true</parameter>
+    <parameter name="target.endpoint">log-endpoint</parameter>
+</messageProcessor>

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-processors/ScheduleMessageForwardingProcessor-2.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-processors/ScheduleMessageForwardingProcessor-2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<messageProcessor xmlns="http://ws.apache.org/ns/synapse"
+                  class="org.apache.synapse.message.processor.impl.forwarder.ScheduledMessageForwardingProcessor"
+                  name="ScheduleMessageForwardingProcessor-2" targetEndpoint="log-endpoint"
+                  messageStore="InMemoryStore-1">
+    <parameter name="client.retry.interval">1000</parameter>
+    <parameter name="throttle">false</parameter>
+    <parameter name="max.delivery.attempts">4</parameter>
+    <parameter name="member.count">5</parameter>
+    <parameter name="store.connection.retry.interval">1000</parameter>
+    <parameter name="max.store.connection.attempts">-1</parameter>
+    <parameter name="max.delivery.drop">Disabled</parameter>
+    <parameter name="interval">1000</parameter>
+    <parameter name="message.processor.failMessagesStore">InMemoryStore-1</parameter>
+    <parameter name="is.active">true</parameter>
+    <parameter name="target.endpoint">log-endpoint</parameter>
+</messageProcessor>

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-stores/InMemoryStore-1.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-stores/InMemoryStore-1.xml
@@ -17,10 +17,4 @@
   ~ under the License.
   -->
 
-<task xmlns="http://ws.apache.org/ns/synapse" name="pinned-task" pinnedServers="pinnedServerCluster"
-      class="org.apache.synapse.startup.tasks.MessageInjector" group="synapse.simple.quartz">
-    <trigger interval="60"/>
-    <property name="message">
-        <test xmlns="">pinned-server-task</test>
-    </property>
-</task>
+<messageStore xmlns="http://ws.apache.org/ns/synapse" name="InMemoryStore-1"/>

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-stores/InMemoryStore-2.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-stores/InMemoryStore-2.xml
@@ -17,10 +17,4 @@
   ~ under the License.
   -->
 
-<task xmlns="http://ws.apache.org/ns/synapse" name="pinned-task" pinnedServers="pinnedServerCluster"
-      class="org.apache.synapse.startup.tasks.MessageInjector" group="synapse.simple.quartz">
-    <trigger interval="60"/>
-    <property name="message">
-        <test xmlns="">pinned-server-task</test>
-    </property>
-</task>
+<messageStore xmlns="http://ws.apache.org/ns/synapse" name="InMemoryStore-2"/>

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/proxy-services/storeProxy.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/proxy-services/storeProxy.xml
@@ -17,10 +17,16 @@
   ~ under the License.
   -->
 
-<task xmlns="http://ws.apache.org/ns/synapse" name="pinned-task" pinnedServers="pinnedServerCluster"
-      class="org.apache.synapse.startup.tasks.MessageInjector" group="synapse.simple.quartz">
-    <trigger interval="60"/>
-    <property name="message">
-        <test xmlns="">pinned-server-task</test>
-    </property>
-</task>
+<proxy name="storeProxy" startOnLoad="true" transports="http https" xmlns="http://ws.apache.org/ns/synapse">
+    <target>
+        <inSequence>
+            <log level="custom">
+                <property name="where" value="store proxy"/>
+            </log>
+            <store messageStore="InMemoryStore-2"/>
+            <respond/>
+        </inSequence>
+        <outSequence/>
+        <faultSequence/>
+    </target>
+</proxy>

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/endpoints/log-endpoint.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/endpoints/log-endpoint.xml
@@ -17,10 +17,14 @@
   ~ under the License.
   -->
 
-<task xmlns="http://ws.apache.org/ns/synapse" name="pinned-task" pinnedServers="pinnedServerCluster"
-      class="org.apache.synapse.startup.tasks.MessageInjector" group="synapse.simple.quartz">
-    <trigger interval="60"/>
-    <property name="message">
-        <test xmlns="">pinned-server-task</test>
-    </property>
-</task>
+<endpoint name="log-endpoint" xmlns="http://ws.apache.org/ns/synapse">
+    <address uri="http://localhost:8330/services/log-proxy">
+        <suspendOnFailure>
+            <initialDuration>-1</initialDuration>
+            <progressionFactor>1.0</progressionFactor>
+        </suspendOnFailure>
+        <markForSuspension>
+            <retriesBeforeSuspension>0</retriesBeforeSuspension>
+        </markForSuspension>
+    </address>
+</endpoint>

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/log-proxy.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/log-proxy.xml
@@ -16,11 +16,15 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-
-<task xmlns="http://ws.apache.org/ns/synapse" name="pinned-task" pinnedServers="pinnedServerCluster"
-      class="org.apache.synapse.startup.tasks.MessageInjector" group="synapse.simple.quartz">
-    <trigger interval="60"/>
-    <property name="message">
-        <test xmlns="">pinned-server-task</test>
-    </property>
-</task>
+<proxy name="log-proxy" startOnLoad="true" transports="http https" xmlns="http://ws.apache.org/ns/synapse">
+    <target>
+        <inSequence>
+            <log level="full">
+                <property name="where" value="log proxy"/>
+            </log>
+            <respond/>
+        </inSequence>
+        <outSequence/>
+        <faultSequence/>
+    </target>
+</proxy>

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/testng.xml
@@ -31,6 +31,7 @@
         <classes>
             <class name="org.wso2.micro.integrator.startup.StartupTests"/>
             <class name="org.wso2.micro.integrator.tasks.TaskTests"/>
+            <class name="org.wso2.micro.integrator.message.processor.MessageProcessorTests"/>
         </classes>
     </test>
 

--- a/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/LogReaderManager.java
+++ b/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/LogReaderManager.java
@@ -47,4 +47,8 @@ public class LogReaderManager {
         readerList.forEach(CarbonLogReader::stop);
         readerList.clear();
     }
+
+    public void clearAll() {
+        readerList.forEach(CarbonLogReader::clearLogs);
+    }
 }


### PR DESCRIPTION
#### Following test cases are added

- Check whether a message processor task gets scheduled in a single node.
- Check whether member count no. of tasks get scheduled for the message processor.
- Check whether the message processor gets executed when a message is added to the store.

