### PR TITLE
Exclude transitive poi dependency

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/pom.xml
@@ -54,6 +54,14 @@
                     <groupId>org.wso2.carbon.mediation</groupId>
                     <artifactId>org.wso2.carbon.mediation.initializer</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.poi.wso2</groupId>
+                    <artifactId>poi-scratchpad</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.poi.wso2</groupId>
+                    <artifactId>poi-ooxml</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Purpose
Exclude transitive poi dependency since it introduces a lower version of poi-ooxml(3.9.0.wso2v1) which causes unit test failures of org.wso2.micro.integrator.dataservices.core.test.excel.ExcelServiceTest