### PR TITLE
Add integration tests for message processor in cluster

### DIFF
--- a/integration/automation-extensions/src/main/java/org/wso2/esb/integration/common/extensions/carbonserver/MultipleServersManager.java
+++ b/integration/automation-extensions/src/main/java/org/wso2/esb/integration/common/extensions/carbonserver/MultipleServersManager.java
@@ -42,7 +42,7 @@ public class MultipleServersManager {
 
         int noOfServers = serverManagers.length;
         for (int index = 0; index < noOfServers; ++index) {
-            log.info("============================== Configuring server " + (index + 1)
+            log.info("============================== Configuring server " + (servers.size() + 1)
                              + " ==============================");
             TestServerManager testServerManager = serverManagers[index];
             try {
@@ -59,7 +59,7 @@ public class MultipleServersManager {
 
         int noOfServers = serverManagers.length;
         for (int index = 0; index < noOfServers; ++index) {
-            log.info("============================== Configuring server " + (index + 1)
+            log.info("============================== Configuring server " + (servers.size() + 1)
                              + " ==============================");
             TestServerManager testServerManager = serverManagers[index];
             try {

--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-processors/ScheduleMessageForwardingProcessor-3.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/resources/artifacts/ESB/message-processors/ScheduleMessageForwardingProcessor-3.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<messageProcessor xmlns="http://ws.apache.org/ns/synapse"
+                  class="org.apache.synapse.message.processor.impl.forwarder.ScheduledMessageForwardingProcessor"
+                  name="ScheduleMessageForwardingProcessor-3" targetEndpoint="log-endpoint"
+                  messageStore="InMemoryStore-1">
+    <parameter name="client.retry.interval">1000</parameter>
+    <parameter name="throttle">false</parameter>
+    <parameter name="max.delivery.attempts">4</parameter>
+    <parameter name="member.count">1</parameter>
+    <parameter name="store.connection.retry.interval">1000</parameter>
+    <parameter name="max.store.connection.attempts">-1</parameter>
+    <parameter name="max.delivery.drop">Disabled</parameter>
+    <parameter name="interval">1000</parameter>
+    <parameter name="message.processor.failMessagesStore">InMemoryStore-1</parameter>
+    <parameter name="is.active">false</parameter>
+    <parameter name="target.endpoint">log-endpoint</parameter>
+    <parameter name="message.processor.reply.sequence">main</parameter>
+</messageProcessor>


### PR DESCRIPTION
#### Following tests are added

- Check whether the message processor deployed in in-active state gets paused upon deployment.
- Check whether the running message processor deployed in an in-active state does not get paused upon a member join

