### PR TITLE
Add properties while creating a new non empty resource

### DIFF
--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/message/processor/MessageProcessorTests.java
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/message/processor/MessageProcessorTests.java
@@ -231,9 +231,7 @@ public class MessageProcessorTests extends ESBIntegrationTest {
         }
     }
 
-    @Test(dependsOnMethods = { "testMpActivationViaPassiveNode" },
-            // due to https://github.com/wso2/micro-integrator/issues/1071
-            enabled = false)
+    @Test(dependsOnMethods = { "testMpActivationViaPassiveNode" })
     void testMpStateUponRedeployment() throws Exception {
 
         logManager.clearAll();


### PR DESCRIPTION
Fixes https://github.com/wso2/micro-integrator/issues/1071

When a new non empty resource is added, the properties are not considered and only the resource is created with the content of the property. If the property name and content is specified, it should be added as property content and not resource content.

This PR improves the newNonEmptyResource method of Micro Integrator to match with https://github.com/wso2/carbon-mediation/blob/master/components/mediation-registry/org.wso2.carbon.mediation.registry/src/main/java/org/wso2/carbon/mediation/registry/WSO2Registry.java#L337.

