### PR TITLE
Add test case for server restart

### DIFF
--- a/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/startup/StartupTests.java
+++ b/integration/mediation-tests/tests-platform/tests-coordination/src/test/java/org/wso2/micro/integrator/startup/StartupTests.java
@@ -114,6 +114,16 @@ public class StartupTests extends ESBIntegrationTest {
         }
     }
 
+    @Test(dependsOnMethods = { "testCoordinator" })
+    public void testReStart() throws Exception {
+        node3.stopServer();
+        node3.startServer();
+        CarbonLogReader logReader3 = new CarbonLogReader(false, node3.getCarbonHome());
+        if (logReader3.checkForLog("ERROR", 30)) {
+            Assert.fail("Node 3 re-started with errors");
+        }
+    }
+
     @AfterClass
     public void clean() throws Exception {
         readerManager.stopAll();


### PR DESCRIPTION
Since we are depending on the parsed configs, there can be issues if the toml is not parsed for the second time if there is no change. Hence adding this test case.

Related issue: https://github.com/wso2/micro-integrator/issues/1435