### PR TITLE
Template synapse-handler configurations in deployment.toml file

### DIFF
--- a/distribution/src/resources/config-tool/deployment-full.toml
+++ b/distribution/src/resources/config-tool/deployment-full.toml
@@ -921,3 +921,8 @@ order_before="before"
 order_after="after"
 order_phase_first="phasefirst"
 order_phase_last="phaselast"
+
+########################## Synapse handlers ###################################
+[[synapse_handlers]]
+name="IntegratorSynapseHandler"
+class="org.wso2.micro.integrator.dataservices.odata.endpoint.ODataPassThroughHandler"

--- a/distribution/src/resources/config-tool/templates/conf/synapse-handlers.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/synapse-handlers.xml.j2
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<handlers>
+    <handler name="IntegratorSynapseHandler" class="org.wso2.micro.integrator.dataservices.odata.endpoint.ODataPassThroughHandler"/>
+    {% for handler in synapse_handlers %}
+    <handler name="{{handler.name}}" class="{{handler.class}}"/>
+    {% endfor %}
+</handlers>


### PR DESCRIPTION
## Purpose
Template synapse-handler configurations in deployment.toml file as in the following example.

Ex:
[[synapse_handlers]]
name="IntegratorHandler"
class="org.wso2.micro.integrator.example.SynapseHandler"