### PR TITLE
Move duplicate node detection before deleting assigned tasks

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/internal/TasksDSComponent.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/internal/TasksDSComponent.java
@@ -34,6 +34,7 @@ import org.wso2.config.mapper.ConfigParser;
 import org.wso2.micro.core.ServerStartupObserver;
 import org.wso2.micro.integrator.coordination.ClusterCoordinator;
 import org.wso2.micro.integrator.coordination.ClusterEventListener;
+import org.wso2.micro.integrator.coordination.exception.ClusterCoordinationException;
 import org.wso2.micro.integrator.coordination.util.RDBMSConstantUtils;
 import org.wso2.micro.integrator.core.util.MicroIntegratorBaseUtils;
 import org.wso2.micro.integrator.ndatasource.common.DataSourceException;
@@ -115,6 +116,13 @@ public class TasksDSComponent {
                 log.info("Initializing task coordination.");
                 DataSource coordinationDataSource = (DataSource) coordinationDatasourceObject;
                 clusterCoordinator = new ClusterCoordinator(coordinationDataSource);
+                if (clusterCoordinator.checkDuplicateNodeExistence()) {
+                    throw new ClusterCoordinationException(
+                            "Node with id " + clusterCoordinator.getThisNodeId() + " already "
+                                    + "exists in cluster or the previous shutdown of this node "
+                                    + "hasn't elapsed the heart beat expiry time of " + clusterCoordinator
+                                    .getHeartbeatMaxRetryInterval() + " milli seconds.");
+                }
                 dataHolder.setClusterCoordinator(clusterCoordinator);
                 // initialize task data base.
                 taskStore = new TaskStore(coordinationDataSource);

--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/ClusterCoordinator.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/ClusterCoordinator.java
@@ -48,6 +48,14 @@ public class ClusterCoordinator {
         allNodeIds.forEach(id -> log.info("Connected with node [" + id + "]"));
     }
 
+    public boolean checkDuplicateNodeExistence() {
+        return rdbmsCoordinationStrategy.isDuplicatedNode();
+    }
+
+    public int getHeartbeatMaxRetryInterval() {
+        return rdbmsCoordinationStrategy.getHeartbeatMaxRetryInterval();
+    }
+
     /**
      * Registers an event listener to listen to cluster events.
      *


### PR DESCRIPTION
Before a node joins a cluster, it deletes all the tasks assigned to it as that can be due to previous execution. However when a node with duplicate id joins the cluster, it removes the tasks of the existing node. Hence moved the duplicate detection logic prior to task deletion.