### PR TITLE
Update wrapper.conf to support log4j2 upgrade

### DIFF
--- a/distribution/src/conf/wrapper.conf
+++ b/distribution/src/conf/wrapper.conf
@@ -117,4 +117,6 @@ wrapper.java.additional.36 = -DavoidConfigHashRead=true
 wrapper.java.additional.37 = -Dproperties.file.path=default
 wrapper.java.additional.38 = -DenableReadinessProbe=true
 wrapper.java.additional.39 = -Dorg.apache.activemq.SERIALIZABLE_PACKAGES="*"
-wrapper.java.additional.40 = -Dserver.main.class=org.wso2.carbon.micro.integrator.server.Main
+wrapper.java.additional.40 = -Djava.util.logging.config.file=${wso2mi_home}\\conf\\etc\\logging-bridge.properties
+wrapper.java.additional.41 = -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
+wrapper.java.additional.42 = -Dserver.main.class=org.wso2.carbon.micro.integrator.server.Main


### PR DESCRIPTION
## Purpose
This PR adds the following configurations to wrapper.conf to support log4j2 upgrade. Without the following configurations, the existing carbon logs will get override after a restart of MI windows service.

```
wrapper.java.additional.14 = -Djava.util.logging.config.file=${wso2mi_home}\\conf\\etc\\logging-bridge.properties
wrapper.java.additional.40 = -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
```

Fixes: https://github.com/wso2/micro-integrator/issues/1468