### PR TITLE
Make user store common for all the internal Apis

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIHandler;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 public class ConfigurationLoaderTestCase {
 
@@ -74,6 +75,48 @@ public class ConfigurationLoaderTestCase {
         Assert.assertEquals("/resource1", handlerWithCustomResources.getResources().get(0));
         Assert.assertEquals("/resource2", handlerWithCustomResources.getResources().get(1));
 
+    }
+
+    /**
+     * Test loading of internal apis from the internal-apis.xml file.
+     */
+    @Test
+    public void testLoadUsers() {
+
+        // test configuration with users
+        URL url = getClass().getResource("internal-apis.xml");
+        Assert.assertNotNull("Configuration file not found", url);
+
+        ConfigurationLoader.loadInternalApis("internal/http/api/internal-apis.xml");
+        Map<String, char[]> userMap = ConfigurationLoader.getUserMap();
+
+        org.junit.Assert.assertEquals(3, userMap.size());
+        //Assert admin:admin
+        org.junit.Assert.assertNotNull(userMap.get("admin"));
+        org.junit.Assert.assertEquals("admin", String.valueOf(userMap.get("admin")));
+
+        //Assert user1:pwd1
+        org.junit.Assert.assertNotNull(userMap.get("user1"));
+        org.junit.Assert.assertEquals("pwd1", String.valueOf(userMap.get("user1")));
+
+        //Assert user2:pwd2
+        org.junit.Assert.assertNotNull(userMap.get("user2"));
+        org.junit.Assert.assertEquals("pwd2", String.valueOf(userMap.get("user2")));
+    }
+
+    /**
+     * Test loading of internal apis from the internal-apis.xml file.
+     */
+    @Test
+    public void testLoadInternalApisWithNoUserStore() {
+
+        // test configuration with users
+        URL url = getClass().getResource("internal-apis-without-user-store.xml");
+        Assert.assertNotNull("Configuration file not found", url);
+
+        ConfigurationLoader.loadInternalApis("internal/http/api/internal-apis-without-user-store.xml");
+        Assert.assertNull("User store is not defined in the file but it is not null",
+                          ConfigurationLoader.getUserMap());
     }
 
     private List<InternalAPI> getApis() {

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/resources/internal/http/api/internal-apis-without-user-store.xml
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/resources/internal/http/api/internal-apis-without-user-store.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<internalApis>
+    <apis>
+        <api name="SampleAPI" protocol="http https" class="internal.http.api.SampleInternalAPI">
+            <handlers>
+                <handler name="SampleInternalApiHandlerWithNoResources"
+                         class="internal.http.api.SampleInternalApiHandlerWithNoResources"/>
+                <handler name="SampleInternalApiHandlerWithAllResources"
+                         class="internal.http.api.SampleInternalApiHandlerWithAllResources">
+                    <resources>
+                        <resource>/</resource>
+                    </resources>
+                </handler>
+                <handler name="SampleInternalApiHandlerWithCustomResources"
+                         class="internal.http.api.SampleInternalApiHandlerWithCustomResources">
+                    <resources>
+                        <resource>/resource1</resource>
+                        <resource>/resource2</resource>
+                    </resources>
+                </handler>
+            </handlers>
+        </api>
+    </apis>
+</internalApis>

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/resources/internal/http/api/internal-apis.xml
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/resources/internal/http/api/internal-apis.xml
@@ -38,6 +38,22 @@
             </handlers>
         </api>
     </apis>
+    <userStore>
+        <users>
+            <user>
+                <username>admin</username>
+                <password>admin</password>
+            </user>
+            <user>
+                <username>user1</username>
+                <password>pwd1</password>
+            </user>
+            <user>
+                <username>user2</username>
+                <password>pwd2</password>
+            </user>
+        </users>
+    </userStore>
     <sslConfig>
         <parameter name="keystore">
             <KeyStore>

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/pom.xml
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/pom.xml
@@ -16,6 +16,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.ei</groupId>
             <artifactId>org.wso2.micro.integrator.inbound.endpoint</artifactId>
             <scope>compile</scope>

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementApiParser.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementApiParser.java
@@ -21,17 +21,16 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.micro.core.util.CarbonException;
 import org.wso2.micro.integrator.core.util.MicroIntegratorBaseUtils;
 import org.wso2.securevault.SecretResolverFactory;
 
-import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -40,8 +39,6 @@ import static org.wso2.micro.integrator.management.apis.Constants.APIS_Q;
 import static org.wso2.micro.integrator.management.apis.Constants.API_Q;
 import static org.wso2.micro.integrator.management.apis.Constants.MGT_API_NAME;
 import static org.wso2.micro.integrator.management.apis.Constants.NAME_ATTR;
-import static org.wso2.micro.integrator.management.apis.Constants.USERS_Q;
-import static org.wso2.micro.integrator.management.apis.Constants.USER_STORE_Q;
 
 /**
  * This class reads through internal-apis.xml and parses the values.
@@ -50,7 +47,6 @@ public class ManagementApiParser {
 
     private static final Log LOG = LogFactory.getLog(ManagementApiParser.class);
     private static OMElement managementApiElement;
-    private Map<String, char[]> usersList;
 
     /**
      * Method to get the File object representation of the internal-apis.xml file.
@@ -72,13 +68,15 @@ public class ManagementApiParser {
 
     public static OMElement getManagementApiElement() throws IOException, CarbonException, XMLStreamException,
             ManagementApiUndefinedException {
+
         if (Objects.nonNull(managementApiElement)) {
             return managementApiElement;
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Parsing the ManagementApi element from " + getConfigurationFilePath());
         }
-        Iterator<OMElement> internalApis = getInternalApisElement();
+        @SuppressWarnings("unchecked") Iterator<OMElement> internalApis =
+                getInternalApisElement().getFirstChildWithName(APIS_Q).getChildrenWithName(API_Q);
         while (internalApis.hasNext()) {
             OMElement apiOM = internalApis.next();
             String apiName = apiOM.getAttributeValue(NAME_ATTR);
@@ -90,31 +88,27 @@ public class ManagementApiParser {
         throw new ManagementApiUndefinedException("Management API not defined in " + getConfigurationFilePath());
     }
 
-    public Map<String, char[]> getUserList() throws CarbonException, XMLStreamException, IOException,
-            UserStoreUndefinedException, ManagementApiUndefinedException {
-        if (Objects.nonNull(usersList)) {
-            return usersList;
-        }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Parsing the UserStore element from " + getConfigurationFilePath());
-        }
-        OMElement userStoreOM = getManagementApiElement().getFirstChildWithName(USER_STORE_Q);
-        if (Objects.nonNull(userStoreOM)) {
-            usersList = populateUserList(userStoreOM.getFirstChildWithName(USERS_Q));
-            return usersList;
+    /**
+     * Method to get the user store define in internal-apis.xml
+     *
+     * @return a non null map if the user store is defined.
+     * @throws UserStoreUndefinedException if the user store is not defined in internal-apis.xml
+     */
+    public Map<String, char[]> getUserMap() throws UserStoreUndefinedException {
+        Map<String, char[]> usersMap = ConfigurationLoader.getUserMap();
+        if (Objects.nonNull(usersMap)) {
+            return usersMap;
         } else {
             throw new UserStoreUndefinedException("UserStore tag not defined inside the Management API");
         }
     }
 
-    private static Iterator<OMElement> getInternalApisElement() throws IOException, CarbonException,
-            XMLStreamException {
+    private static OMElement getInternalApisElement() throws IOException, CarbonException, XMLStreamException {
         File mgtApiUserConfig = getConfigurationFile();
         try (InputStream fileInputStream = new FileInputStream(mgtApiUserConfig)) {
             OMElement documentElement = getOMElementFromFile(fileInputStream);
             createSecretResolver(documentElement);
-
-            return documentElement.getFirstChildWithName(APIS_Q).getChildrenWithName(API_Q);
+            return documentElement;
         }
     }
 
@@ -129,34 +123,6 @@ public class ManagementApiParser {
         InputStream inputStream = MicroIntegratorBaseUtils.replaceSystemVariablesInXml(fileInputStream);
         StAXOMBuilder builder = new StAXOMBuilder(inputStream);
         return builder.getDocumentElement();
-    }
-
-    /**
-     * Populates the userList hashMap by user store OM element
-     *
-     * @return HashMap<String, char [ ]> Map of credential pairs
-     */
-    private Map<String, char[]> populateUserList(OMElement users) throws XMLStreamException {
-        HashMap<String, char[]> userList = new HashMap<>();
-        if (users != null) {
-            Iterator usersIterator = users.getChildrenWithName(new QName("user"));
-            if (usersIterator != null) {
-                while (usersIterator.hasNext()) {
-                    OMElement userElement = (OMElement) usersIterator.next();
-                    OMElement userNameElement = userElement.getFirstChildWithName(new QName("username"));
-                    OMElement passwordElement = userElement.getFirstChildWithName(new QName("password"));
-                    if (userNameElement != null && passwordElement != null) {
-                        String userName = userNameElement.getText();
-                        if (userList.containsKey(userName)) {
-                            throw new XMLStreamException("Error parsing the file based user store. User: " + userName
-                                                         + " defined more than once. ");
-                        }
-                        userList.put(userName, passwordElement.getText().toCharArray());
-                    }
-                }
-            }
-        }
-        return userList;
     }
 
     /**

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityHandlerAdapter.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityHandlerAdapter.java
@@ -71,7 +71,7 @@ public abstract class SecurityHandlerAdapter implements InternalAPIHandler {
         if (!isInitialized) {
             ManagementApiParser mgtParser = new ManagementApiParser();
             try {
-                usersList = mgtParser.getUserList();
+                usersList = mgtParser.getUserMap();
             } catch (UserStoreUndefinedException e) {
                 useCarbonUserStore = true;
                 LOG.info("User store config has not been defined in file "

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/test/java/org/wso2/micro/integrator/management/apis/ManagementApiParserTest.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/test/java/org/wso2/micro/integrator/management/apis/ManagementApiParserTest.java
@@ -21,16 +21,26 @@ package org.wso2.micro.integrator.management.apis;
 import org.apache.axiom.om.OMElement;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.micro.core.util.CarbonException;
 import org.wso2.micro.integrator.core.internal.MicroIntegratorBaseConstants;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.wso2.micro.integrator.management.apis.Constants.MGT_API_NAME;
 import static org.wso2.micro.integrator.management.apis.Constants.NAME_ATTR;
 
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ConfigurationLoader.class)
 public class ManagementApiParserTest {
 
     private void initializeConfDirectory() {
@@ -47,22 +57,22 @@ public class ManagementApiParserTest {
     }
 
     @Test
-    public void getUserList() throws CarbonException, IOException, UserStoreUndefinedException, ManagementApiUndefinedException, XMLStreamException {
-        initializeConfDirectory();
+    public void testGetUserList() throws UserStoreUndefinedException {
+        Map<String, char[]> userMap = new HashMap<>();
+        userMap.put("user1", "pwd1".toCharArray());
+        PowerMockito.mockStatic(ConfigurationLoader.class);
+        Mockito.when(ConfigurationLoader.getUserMap()).thenReturn(userMap);
         ManagementApiParser managementApiParser = new ManagementApiParser();
-        Map<String, char[]> userList = managementApiParser.getUserList();
+        Map<String, char[]> retrievedUserMap = managementApiParser.getUserMap();
+        Assert.assertNotNull(retrievedUserMap);
+        Assert.assertEquals("pwd1", new String(retrievedUserMap.get("user1")));
+    }
 
-        Assert.assertEquals(3, userList.size());
-        //Assert admin:admin
-        Assert.assertNotNull(userList.get("admin"));
-        Assert.assertEquals("admin", String.valueOf(userList.get("admin")));
-
-        //Assert user1:pwd1
-        Assert.assertNotNull(userList.get("user1"));
-        Assert.assertEquals("pwd1", String.valueOf(userList.get("user1")));
-
-        //Assert user2:pwd2
-        Assert.assertNotNull(userList.get("user2"));
-        Assert.assertEquals("pwd2", String.valueOf(userList.get("user2")));
+    @Test(expected = UserStoreUndefinedException.class)
+    public void testGetNullUserStore() throws UserStoreUndefinedException {
+        PowerMockito.mockStatic(ConfigurationLoader.class);
+        Mockito.when(ConfigurationLoader.getUserMap()).thenReturn(null);
+        ManagementApiParser managementApiParser = new ManagementApiParser();
+        managementApiParser.getUserMap();
     }
 }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/test/resources/org/wso2/micro/integrator/management/apis/internal-apis.xml
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/test/resources/org/wso2/micro/integrator/management/apis/internal-apis.xml
@@ -21,22 +21,22 @@
         <api name="SampleAPI" protocol="http https" class="internal.http.api.SampleInternalAPI"/>
         <api class="org.wso2.micro.integrator.management.apis.ManagementInternalApi" name="ManagementApi"
              protocol="https">
-            <UserStore>
-                <users>
-                    <user>
-                        <username>admin</username>
-                        <password>admin</password>
-                    </user>
-                    <user>
-                        <username>user1</username>
-                        <password>pwd1</password>
-                    </user>
-                    <user>
-                        <username>user2</username>
-                        <password>pwd2</password>
-                    </user>
-                </users>
-            </UserStore>
         </api>
     </apis>
+    <userStore>
+        <users>
+            <user>
+                <username>admin</username>
+                <password>admin</password>
+            </user>
+            <user>
+                <username>user1</username>
+                <password>pwd1</password>
+            </user>
+            <user>
+                <username>user2</username>
+                <password>pwd2</password>
+            </user>
+        </users>
+    </userStore>
 </internalApis>

--- a/distribution/src/conf/internal-apis.xml
+++ b/distribution/src/conf/internal-apis.xml
@@ -23,14 +23,6 @@
         <api name="ReadinessProbe" protocol="http" class="org.wso2.micro.integrator.probes.ReadinessProbe"/>
         <api class="org.wso2.micro.integrator.management.apis.ManagementInternalApi" name="ManagementApi"
              protocol="https">
-            <UserStore>
-                <users>
-                    <user>
-                        <username>admin</username>
-                        <password>admin</password>
-                    </user>
-                </users>
-            </UserStore>
             <handlers>
                 <handler class="org.wso2.micro.integrator.management.apis.security.handler.JWTTokenSecurityHandler"
                          name="JWTTokenSecurityHandler">
@@ -58,6 +50,14 @@
             </cors>
         </api>
     </apis>
+    <userStore>
+        <users>
+            <user>
+                <username>admin</username>
+                <password>admin</password>
+            </user>
+        </users>
+    </userStore>
     <sslConfig>
         <parameter name="keystore">
             <KeyStore>

--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -430,8 +430,8 @@
   "management_api.handler.token_store_config.remove_oldest_token_on_overflow": "true",
   "management_api.handler.token_config.expiry": "3600",
   "management_api.handler.token_config.size": "2048",
-  "management_api.file_user_store.enable": true,
-  "management_api.user_store.users": [
+  "internal_apis.file_user_store.enable": true,
+  "internal_apis.users": [
     {
       "user.name": "admin",
       "user.password": "admin"

--- a/distribution/src/resources/config-tool/templates/conf/internal-apis.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/internal-apis.xml.j2
@@ -24,18 +24,6 @@
         <api name="{{api.api_name}}" protocol="{{api.protocols}}" class="{{api.class}}"/>
         {% endfor %}
         <api name="{{management_api.name}}" protocol="{{management_api.protocols}}" class="{{management_api.class}}">
-            {% if management_api.file_user_store.enable == true %}
-            <UserStore>
-                <users>
-                    {% for user in management_api.user_store.users %}
-                        <user>
-                            <username>{{user.user.name}}</username>
-                            <password>{{user.user.password}}</password>
-                        </user>
-                    {% endfor %}
-                </users>
-            </UserStore>
-            {% endif %}
             <handlers>
                 {% if management_api_token_handler.enable == true %}
                 <handler name="{{management_api.handler.name}}" class="{{management_api.handler.class}}">
@@ -68,6 +56,18 @@
             </cors>
         </api>
     </apis>
+    {% if internal_apis.file_user_store.enable == true %}
+    <userStore>
+        <users>
+            {% for user in internal_apis.users %}
+            <user>
+                <username>{{user.user.name}}</username>
+                <password>{{user.user.password}}</password>
+            </user>
+            {% endfor %}
+        </users>
+    </userStore>
+    {% endif %}
     <sslConfig>
         {% for parameter_key,parameter_value in internal_api_ssl_config.parameter.items() %}
         <parameter name="{{parameter_key}}">{{parameter_value}}</parameter>

--- a/pom.xml
+++ b/pom.xml
@@ -1201,6 +1201,18 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito2</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1266,6 +1278,7 @@
     <!--This include only the dependencies for product build. Please define the integration test dependencies
     in integration test parent pom if they are not needed for product build.-->
     <properties>
+        <powermock.version>2.0.7</powermock.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/micro-integrator/issues/1450

A user store can be configured by adding the following to the deployment.toml
```
[[internal_apis.users]]
user.name = "user1"
password = "pwd1"
```
The user store can be disabled by adding the following parameter to to the deplyoment.toml
```
[internal_apis.file_user_store]
enable = false
```