### PR TITLE
Fix Intermittent test failure

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/foreach/ForEachPropertiesTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/foreach/ForEachPropertiesTestCase.java
@@ -52,13 +52,13 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
     public void testSingleForEachProperties() throws Exception {
         carbonLogReader.clearLogs();
         String request =
-                "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:m0=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">\n"
-                        + "    <soap:Header/>\n" + "    <soap:Body>\n" + "        <m0:getQuote>\n"
-                        + "            <m0:group>Group1</m0:group>\n"
-                        + "            <m0:request><m0:code>IBM</m0:code></m0:request>\n"
-                        + "            <m0:request><m0:code>WSO2</m0:code></m0:request>\n"
-                        + "            <m0:request><m0:code>MSFT</m0:code></m0:request>\n" + "        </m0:getQuote>\n"
-                        + "    </soap:Body>\n" + "</soap:Envelope>\n";
+                "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:m0=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">"
+                        + "<soap:Header/><soap:Body><m0:getQuote>"
+                        + "<m0:group>Group1</m0:group>"
+                        + "<m0:request><m0:code>IBM</m0:code></m0:request>"
+                        + "<m0:request><m0:code>WSO2</m0:code></m0:request>"
+                        + "<m0:request><m0:code>MSFT</m0:code></m0:request></m0:getQuote>"
+                        + "</soap:Body></soap:Envelope>";
 
         simpleHttpClient = new SimpleHttpClient();
         simpleHttpClient.doPost(getProxyServiceURLHttp("foreachSinglePropertyTestProxy"),
@@ -81,11 +81,11 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
                 int end = matcher.end();
                 String quote = payload.substring(start, end);
 
-                assertTrue(carbonLogReader.getLogs().contains("<m0:getQuote>" + "            <m0:group>Group1</m0:group>"
-                                + "            <m0:request><m0:code>IBM</m0:code></m0:request>"
-                                + "            <m0:request><m0:code>WSO2</m0:code></m0:request>"
-                                + "            <m0:request><m0:code>MSFT</m0:code></m0:request>" + "        </m0:getQuote>"),
-                        "original payload is incorrect");
+                assertTrue(carbonLogReader.getLogs().contains(
+                        "<m0:getQuote><m0:group>Group1</m0:group>" + "<m0:request><m0:code>IBM</m0:code></m0:request>"
+                                + "<m0:request><m0:code>WSO2</m0:code></m0:request>"
+                                + "<m0:request><m0:code>MSFT</m0:code></m0:request></m0:getQuote>"),
+                           "original payload is incorrect");
             }
         }
 
@@ -115,11 +115,12 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
                 int start = matcher.start();
                 int end = matcher.end();
                 String quote = payload.substring(start, end);
-
-                assertTrue(quote.contains("<m0:group>Group1</m0:group>"), "Group Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_IBM</m0:symbol>"), "IBM Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_WSO2</m0:symbol>"), "WSO2 Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_MSFT</m0:symbol>"), "MSTF Element not found");
+                assertTrue(quote.contains("<m0:group>Group1</m0:group>"), "Group Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_IBM</m0:symbol>"), "IBM Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_WSO2</m0:symbol>"),
+                           "WSO2 Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_MSFT</m0:symbol>"),
+                           "MSTF Element not found in : " + quote);
             }
         }
     }
@@ -128,13 +129,12 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
     public void testMultipleForEachPropertiesWithoutID() throws Exception {
         carbonLogReader.clearLogs();
         String request =
-                "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:m0=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">\n"
-                        + "    <soap:Header/>\n" + "    <soap:Body>\n" + "        <m0:getQuote>\n"
-                        + "            <m0:group>Group1</m0:group>\n"
-                        + "            <m0:request><m0:code>IBM</m0:code></m0:request>\n"
-                        + "            <m0:request><m0:code>WSO2</m0:code></m0:request>\n"
-                        + "            <m0:request><m0:code>MSFT</m0:code></m0:request>\n" + "        </m0:getQuote>\n"
-                        + "    </soap:Body>\n" + "</soap:Envelope>\n";
+                "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:m0=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">"
+                        + "<soap:Header/><soap:Body><m0:getQuote>" + "<m0:group>Group1</m0:group>"
+                        + "<m0:request><m0:code>IBM</m0:code></m0:request>"
+                        + "<m0:request><m0:code>WSO2</m0:code></m0:request>"
+                        + "<m0:request><m0:code>MSFT</m0:code></m0:request></m0:getQuote>"
+                        + "</soap:Body></soap:Envelope>";
 
         simpleHttpClient = new SimpleHttpClient();
         simpleHttpClient.doPost(getProxyServiceURLHttp("foreachMultiplePropertyWithoutIDTestProxy"), headers,
@@ -157,11 +157,11 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
                 int end = matcher.end();
                 String quote = payload.substring(start, end);
 
-                assertTrue(quote.contains("<m0:getQuote>" + "            <m0:group>Group1</m0:group>"
-                                + "            <m0:request><m0:code>IBM</m0:code></m0:request>"
-                                + "            <m0:request><m0:code>WSO2</m0:code></m0:request>"
-                                + "            <m0:request><m0:code>MSFT</m0:code></m0:request>" + "        </m0:getQuote>"),
-                        "original payload is incorrect");
+                assertTrue(quote.contains(
+                        "<m0:getQuote><m0:group>Group1</m0:group>" + "<m0:request><m0:code>IBM</m0:code></m0:request>"
+                                + "<m0:request><m0:code>WSO2</m0:code></m0:request>"
+                                + "<m0:request><m0:code>MSFT</m0:code></m0:request></m0:getQuote>"),
+                           "original payload is incorrect");
             }
         }
 
@@ -191,11 +191,12 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
                 int start = matcher.start();
                 int end = matcher.end();
                 String quote = payload.substring(start, end);
-
-                assertTrue(quote.contains("<m0:group>Group1</m0:group>"), "Group Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_IBM</m0:symbol>"), "IBM Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_WSO2</m0:symbol>"), "WSO2 Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_MSFT</m0:symbol>"), "MSTF Element not found");
+                assertTrue(quote.contains("<m0:group>Group1</m0:group>"), "Group Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_IBM</m0:symbol>"), "IBM Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_WSO2</m0:symbol>"),
+                           "WSO2 Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_MSFT</m0:symbol>"),
+                           "MSTF Element not found in : " + quote);
             }
         }
 
@@ -214,13 +215,12 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
     public void testMultipleForEachPropertiesWithID() throws Exception {
         carbonLogReader.clearLogs();
         String request =
-                "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:m0=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">\n"
-                        + "    <soap:Header/>\n" + "    <soap:Body>\n" + "        <m0:getQuote>\n"
-                        + "            <m0:group>Group1</m0:group>\n"
-                        + "            <m0:request><m0:code>IBM</m0:code></m0:request>\n"
-                        + "            <m0:request><m0:code>WSO2</m0:code></m0:request>\n"
-                        + "            <m0:request><m0:code>MSFT</m0:code></m0:request>\n" + "        </m0:getQuote>\n"
-                        + "    </soap:Body>\n" + "</soap:Envelope>\n";
+                "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:m0=\"http://services.samples\" xmlns:xsd=\"http://services.samples/xsd\">"
+                        + "<soap:Header/><soap:Body><m0:getQuote>" + "<m0:group>Group1</m0:group>"
+                        + "<m0:request><m0:code>IBM</m0:code></m0:request>"
+                        + "<m0:request><m0:code>WSO2</m0:code></m0:request>"
+                        + "<m0:request><m0:code>MSFT</m0:code></m0:request></m0:getQuote>"
+                        + "</soap:Body></soap:Envelope>";
 
         simpleHttpClient = new SimpleHttpClient();
         simpleHttpClient.doPost(getProxyServiceURLHttp("foreachMultiplePropertyWithIDTestProxy"), headers,
@@ -244,11 +244,11 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
                 int end = matcher.end();
                 String quote = payload.substring(start, end);
 
-                assertTrue(quote.contains("<m0:getQuote>" + "            <m0:group>Group1</m0:group>"
-                                + "            <m0:request><m0:code>IBM</m0:code></m0:request>"
-                                + "            <m0:request><m0:code>WSO2</m0:code></m0:request>"
-                                + "            <m0:request><m0:code>MSFT</m0:code></m0:request>" + "        </m0:getQuote>"),
-                        "original payload is incorrect");
+                assertTrue(quote.contains(
+                        "<m0:getQuote><m0:group>Group1</m0:group>" + "<m0:request><m0:code>IBM</m0:code></m0:request>"
+                                + "<m0:request><m0:code>WSO2</m0:code></m0:request>"
+                                + "<m0:request><m0:code>MSFT</m0:code></m0:request></m0:getQuote>"),
+                           "original payload is incorrect");
             }
         }
 
@@ -278,11 +278,12 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
                 int start = matcher.start();
                 int end = matcher.end();
                 String quote = payload.substring(start, end);
-
-                assertTrue(quote.contains("<m0:group>Group1</m0:group>"), "Group Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_IBM</m0:symbol>"), "IBM Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_WSO2</m0:symbol>"), "WSO2 Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_MSFT</m0:symbol>"), "MSTF Element not found");
+                assertTrue(quote.contains("<m0:group>Group1</m0:group>"), "Group Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_IBM</m0:symbol>"), "IBM Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_WSO2</m0:symbol>"),
+                           "WSO2 Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_MSFT</m0:symbol>"),
+                           "MSTF Element not found in : " + quote);
             }
         }
 
@@ -313,12 +314,15 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
                 int start = matcher.start();
                 int end = matcher.end();
                 String quote = payload.substring(start, end);
-
-                assertTrue(quote.contains("<m0:group>Group2</m0:group>"), "Group Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_Group2_IBM</m0:symbol>"), "IBM Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_Group2_WSO2</m0:symbol>"), "WSO2 Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_Group2_MSFT</m0:symbol>"), "MSTF Element not found");
-                assertTrue(quote.contains("<m0:symbol>Group1_Group2_SUN</m0:symbol>"), "SUN Element not found");
+                assertTrue(quote.contains("<m0:group>Group2</m0:group>"), "Group Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_Group2_IBM</m0:symbol>"),
+                           "IBM Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_Group2_WSO2</m0:symbol>"),
+                           "WSO2 Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_Group2_MSFT</m0:symbol>"),
+                           "MSTF Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:symbol>Group1_Group2_SUN</m0:symbol>"),
+                           "SUN Element not found in : " + quote);
             }
         }
     }
@@ -347,12 +351,11 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
                 int start = matcher.start();
                 int end = matcher.end();
                 String quote = payload.substring(start, end);
-
-                assertTrue(quote.contains("<m0:group>Group2</m0:group>"), "Group Element not found");
-                assertTrue(quote.contains("<m0:code>IBM</m0:code>"), "IBM Element not found");
-                assertTrue(quote.contains("<m0:code>WSO2</m0:code>"), "WSO2 Element not found");
-                assertTrue(quote.contains("<m0:code>MSFT</m0:code>"), "MSTF Element not found");
-                assertTrue(quote.contains("<m0:code>SUN</m0:code>"), "SUN Element not found");
+                assertTrue(quote.contains("<m0:group>Group2</m0:group>"), "Group Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:code>IBM</m0:code>"), "IBM Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:code>WSO2</m0:code>"), "WSO2 Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:code>MSFT</m0:code>"), "MSTF Element not found in : " + quote);
+                assertTrue(quote.contains("<m0:code>SUN</m0:code>"), "SUN Element not found in : " + quote);
             }
         }
     }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/foreach/ForEachSequentialExecutionTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/foreach/ForEachSequentialExecutionTestCase.java
@@ -55,13 +55,13 @@ public class ForEachSequentialExecutionTestCase extends ESBIntegrationTest {
         // Verify logs to check that the order of symbols is same as in the payload. The symbols should be as SYM[1-10]
         // as in payload. Since loop iterates from the last log onwards, verifying whether the symbols are in SYM[10-1] order
         for (int i = 0; i < 10; i++) {
-            if (carbonLogReader.checkForLog("foreach = in", DEFAULT_TIMEOUT)) {
+            if (carbonLogReader.checkForLog("foreachSequentialExecutionTestProxy = in", DEFAULT_TIMEOUT)) {
                 if (!carbonLogReader.getLogs().contains("SYM" + i)) {
                     Assert.fail("Incorrect message entered ForEach scope. Could not find symbol SYM" + i);
                 }
             }
         }
-        Assert.assertTrue(carbonLogReader.checkForLog("foreach = in", DEFAULT_TIMEOUT, 10), "Count of messages entered ForEach scope is incorrect");
+        Assert.assertTrue(carbonLogReader.checkForLog("foreachSequentialExecutionTestProxy = in", DEFAULT_TIMEOUT, 10), "Count of messages entered ForEach scope is incorrect");
         carbonLogReader.stop();
     }
 

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/foreach/ForEachWithIterateTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/foreach/ForEachWithIterateTestCase.java
@@ -49,17 +49,16 @@ public class ForEachWithIterateTestCase extends ESBIntegrationTest {
     @Test(groups = "wso2.esb", description = "Test foreach inline sequence to transform payload, passed to endpoint using iterate and aggregate mediators")
     public void testForEachInlineSequenceWithIterateEndpoint() throws Exception {
         carbonLogReader.clearLogs();
-        String response = client
-                .getMultipleCustomResponse(getProxyServiceURLHttp("foreachSequentialExecutionTestProxy"), "IBM", 2);
+        String response = client.getMultipleCustomResponse(getProxyServiceURLHttp("foreachWithIteration"), "IBM", 2);
         Assert.assertNotNull(response);
 
-        if (carbonLogReader.checkForLog("foreach = in", DEFAULT_TIMEOUT)) {
+        if (carbonLogReader.checkForLog("foreachWithIteration = in", DEFAULT_TIMEOUT)) {
             if (!carbonLogReader.getLogs().contains("IBM")) {
                 Assert.fail("Incorrect message entered ForEach scope");
             }
         }
-        Assert.assertTrue(carbonLogReader.checkForLog("foreach = in", DEFAULT_TIMEOUT, 2),
-                "Count of messages entered ForEach scope is incorrect");
+        Assert.assertTrue(carbonLogReader.checkForLog("foreachWithIteration = in", DEFAULT_TIMEOUT, 2),
+                          "Count of messages entered ForEach scope is incorrect");
         OMElement envelope = client.toOMElement(response);
         OMElement soapBody = envelope.getFirstElement();
         Iterator iterator = soapBody.getChildrenWithName(new QName("http://services.samples", "getQuoteResponse"));

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/foreachWithIteration.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/foreachWithIteration.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="foreachWithIteration" transports="https http" startOnLoad="true"
+       trace="disable">
+    <description/>
+    <target>
+        <inSequence>
+            <sequence key="iterateMessagesSeq560"/>
+        </inSequence>
+        <outSequence>
+            <sequence key="aggregateMessagesSeq567"/>
+        </outSequence>
+    </target>
+</proxy>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/sequences/iterateMessagesSeq560.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/sequences/iterateMessagesSeq560.xml
@@ -1,0 +1,49 @@
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<sequence xmlns="http://ws.apache.org/ns/synapse" name="iterateMessagesSeq560">
+    <foreach xmlns:ns="http://services.samples" expression="//ns:CheckPriceRequest">
+        <sequence>
+            <payloadFactory media-type="xml">
+                <format>
+                    <ns:request>
+                        <ns:symbol>$1</ns:symbol>
+                    </ns:request>
+                </format>
+                <args>
+                    <arg evaluator="xml" expression="//ns:Code"/>
+                </args>
+            </payloadFactory>
+            <log level="full">
+                <property name="foreachWithIteration" value="in"/>
+            </log>
+        </sequence>
+    </foreach>
+    <iterate xmlns:m0="http://services.samples" id="iterate1" expression="//m0:getQuote/m0:request"
+             preservePayload="true" attachPath="//m0:getQuote">
+        <target>
+            <sequence>
+                <send>
+                    <endpoint>
+                        <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
+                    </endpoint>
+                </send>
+            </sequence>
+        </target>
+    </iterate>
+</sequence>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/sequences/iterateMessagesSeq567.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/sequences/iterateMessagesSeq567.xml
@@ -12,7 +12,7 @@
                     </args>
                 </payloadFactory>
                 <log level="full">
-                    <property name="foreach" value="in"/>
+                    <property name="foreachSequentialExecutionTestProxy" value="in"/>
                 </log>
             </sequence>
         </foreach>


### PR DESCRIPTION
$subject. The tests were failing since same seq is used in more than single test case and when the order changed, it lead to failures. Hence separated them out. Also the \n character and spaces in payload was causing un expected results when checking string contains and etc.

In case of Message Processor tests, we were asserting a generic string which is not common to this test case, Hence modified the assert message specific to this test case so that it don't conflict with others. Also in an assert, three conditions were tested. So break them into three so that we can identify the failures more clearly if it fails in future.