### PR TITLE
Allow overriding default JDBC user store configs

### DIFF
--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -5,6 +5,18 @@
   "server.identity_server_username": "axis2_transport.parameter.identityServerUserName",
   "server.identity_server_password": "axis2_transport.parameter.identityServerPw",
 
+  "user_store.read_only":"user_store.properties.ReadOnly",
+  "user_store.write_groups":"user_store.properties.WriteGroups",
+  "user_store.username_javascript_regex":"user_store.properties.UsernameJavaScriptRegEx",
+  "user_store.username_java_regex_violation_error_msg":"user_store.properties.UsernameJavaRegExViolationErrorMsg",
+  "user_store.password_javascript_regex":"user_store.properties.PasswordJavaScriptRegEx",
+  "user_store.password_java_regex_violation_error_msg":"user_store.properties.PasswordJavaRegExViolationErrorMsg",
+  "user_store.rolename_javascript_regex":"user_store.properties.RolenameJavaScriptRegEx",
+  "user_store.case_insensitive_username":"user_store.properties.CaseInsensitiveUsername",
+  "user_store.is_bulk_import_supported":"user_store.properties.IsBulkImportSupported",
+  "user_store.password_digest":"user_store.properties.PasswordDigest",
+  "user_store.store_salted_password":"user_store.properties.StoreSaltedPassword",
+
   "user_store.connection_url":"user_store.properties.ConnectionURL",
   "user_store.connection_name":"user_store.properties.ConnectionName",
   "user_store.connection_password":"user_store.properties.ConnectionPassword",


### PR DESCRIPTION
## Purpose
This PR brings in the capability of configuring the JDBC user store by defining properties in the form of 
```
[user_store]
class = "org.wso2.micro.integrator.security.user.core.jdbc.JDBCUserStoreManager"
type = "database"
property_key = "value"
```
for the properties that are supported by the user store.

Resolves: https://github.com/wso2/micro-integrator/issues/1525