### PR TITLE
Fix Test Failure

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/foreach/ForEachPropertiesTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/foreach/ForEachPropertiesTestCase.java
@@ -101,28 +101,21 @@ public class ForEachPropertiesTestCase extends ESBIntegrationTest {
             assertTrue(carbonLogReader.getLogs().contains("in_count = " + 3),
                     "Final counter mismatch, expected 3 found = " + carbonLogReader.getLogs());
         }
+        //final payload in insequence
+        String payload = carbonLogReader.getLogs();
+        String search = "<m0:getQuote>(.*)</m0:getQuote>";
+        Pattern pattern = Pattern.compile(search, Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(payload);
+        boolean matchFound = matcher.find();
 
-        if (carbonLogReader.checkForLog("in_payload", DEFAULT_TIMEOUT)) {
-            //final payload in insequence
-            String payload = carbonLogReader.getLogs();
-            String search = "<m0:getQuote>(.*)</m0:getQuote>";
-            Pattern pattern = Pattern.compile(search, Pattern.DOTALL);
-            Matcher matcher = pattern.matcher(payload);
-            boolean matchFound = matcher.find();
-
-            assertTrue(matchFound, "getQuote element not found");
-            if (matchFound) {
-                int start = matcher.start();
-                int end = matcher.end();
-                String quote = payload.substring(start, end);
-                assertTrue(quote.contains("<m0:group>Group1</m0:group>"), "Group Element not found in : " + quote);
-                assertTrue(quote.contains("<m0:symbol>Group1_IBM</m0:symbol>"), "IBM Element not found in : " + quote);
-                assertTrue(quote.contains("<m0:symbol>Group1_WSO2</m0:symbol>"),
-                           "WSO2 Element not found in : " + quote);
-                assertTrue(quote.contains("<m0:symbol>Group1_MSFT</m0:symbol>"),
-                           "MSTF Element not found in : " + quote);
-            }
-        }
+        assertTrue(matchFound, "getQuote element not found");
+        int start = matcher.start();
+        int end = matcher.end();
+        String quote = payload.substring(start, end);
+        assertTrue(quote.contains("<m0:group>Group1</m0:group>"), "Group Element not found in : " + quote);
+        assertTrue(quote.contains("<m0:symbol>Group1_IBM</m0:symbol>"), "IBM Element not found in : " + quote);
+        assertTrue(quote.contains("<m0:symbol>Group1_WSO2</m0:symbol>"), "WSO2 Element not found in : " + quote);
+        assertTrue(quote.contains("<m0:symbol>Group1_MSFT</m0:symbol>"), "MSTF Element not found in : " + quote);
     }
 
     @Test(groups = "wso2.esb", description = "Test foreach properties in a multiple foreach constructs without id specified")

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/foreachSinglePropertyTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/foreachSinglePropertyTestProxy.xml
@@ -39,6 +39,7 @@
                 <property name="in_group"
                           expression="get-property('FOREACH_ORIGINAL_MESSAGE')//m0:group" xmlns:m0="http://services.samples" />
             </log>
+            <log level="full"/>
         </inSequence>
         <outSequence/>
 


### PR DESCRIPTION
$subject.

This test case looks for a log "**in_payload**" which is not printed by the proxy which being invoked in the test case. If by any chance, another test case executes in between, and prints the particular then this test case validates all the conditions inside that if block. Hence removed that if check. 

When it validate, since the modified payload by the for each mediator is not logged, all the if conditions fail. Hence added a log level full.
