### PR TITLE
Fix admin role being assigned to all users

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/UsersResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/UsersResource.java
@@ -149,7 +149,7 @@ public class UsersResource extends UserResource {
         JsonObject payload = Utils.getJsonPayload(axis2MessageContext);
         if (payload.has(USER_ID) && payload.has(PASSWORD)) {
             String[] roleList = null;
-            if (payload.has(IS_ADMIN)) {
+            if (payload.has(IS_ADMIN) && payload.get(IS_ADMIN).getAsBoolean()) {
                 String adminRole = getRealmConfiguration().getAdminRoleName();
                 roleList = new String[]{adminRole};
             }


### PR DESCRIPTION
## Purpose
The role 'admin' gets assigned to users added via the management api even with the following payload:
```
{ 
   "userId":"user5",
   "password":"pwd123",
   "isAdmin":"false"
}
```
The issue was cause by the fact that the actual value of isAdmin was not read but only the existence of it.