### PR TITLE
Fix concurrency issues in Transaction Count Handler

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/store/connector/RDBMSConnector.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/store/connector/RDBMSConnector.java
@@ -85,7 +85,7 @@ public class RDBMSConnector {
     /**
      * Add transaction count to the database.
      */
-    public void addTransaction() throws SQLException {
+    public synchronized void addTransaction() throws SQLException {
         // if raw exists - update else and a new raw.
         if (checkDataExists()) {
             updateStats();


### PR DESCRIPTION
## Purpose
The workload of the transaction counting part should be handled asynchronously to have the least performance impact on the main request flow due to this functionality. In order to achieve this, this PR has moved the transaction count handling part to a separate thread to make it asynchronous.

Also, the handleRequestInFlow method in the TransactionCountHandler will definitely be called concurrently and therefore, the variable transaction count will be modified by different threads. Hence, this PR has made the counter updating functionality synchronized. 

Fix: https://github.com/wso2/micro-integrator/issues/1558