### PR TITLE
Fix HTTP inbound endpoint creating new worker thread pool for each request

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpSourceHandler.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpSourceHandler.java
@@ -79,20 +79,21 @@ public class InboundHttpSourceHandler extends SourceHandler {
 
             Pattern dispatchPattern = null;
 
-            WorkerPoolConfiguration workerPoolConfiguration = HTTPEndpointManager.getInstance()
-                    .getWorkerPoolConfiguration(SUPER_TENANT_DOMAIN_NAME, port);
-            if (workerPoolConfiguration != null) {
-                workerPool = sourceConfiguration.getWorkerPool(workerPoolConfiguration.getWorkerPoolCoreSize(),
-                                                               workerPoolConfiguration.getWorkerPoolSizeMax(),
-                                                               workerPoolConfiguration
-                                                                       .getWorkerPoolThreadKeepAliveSec(),
-                                                               workerPoolConfiguration.getWorkerPoolQueuLength(),
-                                                               workerPoolConfiguration.getThreadGroupID(),
-                                                               workerPoolConfiguration.getThreadID());
-            }
-
+            // Need to initialize workerPool only once
             if (workerPool == null) {
-                workerPool = sourceConfiguration.getWorkerPool();
+                WorkerPoolConfiguration workerPoolConfiguration = HTTPEndpointManager.getInstance()
+                        .getWorkerPoolConfiguration(SUPER_TENANT_DOMAIN_NAME, port);
+                if (workerPoolConfiguration != null) {
+                    workerPool = sourceConfiguration.getWorkerPool(workerPoolConfiguration.getWorkerPoolCoreSize(),
+                            workerPoolConfiguration.getWorkerPoolSizeMax(),
+                            workerPoolConfiguration
+                                    .getWorkerPoolThreadKeepAliveSec(),
+                            workerPoolConfiguration.getWorkerPoolQueuLength(),
+                            workerPoolConfiguration.getThreadGroupID(),
+                            workerPoolConfiguration.getThreadID());
+                } else {
+                    workerPool = sourceConfiguration.getWorkerPool();
+                }
             }
 
             Object correlationId = conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID);
@@ -121,5 +122,4 @@ public class InboundHttpSourceHandler extends SourceHandler {
             sourceConfiguration.getSourceConnections().shutDownConnection(conn, true);
         }
     }
-
 }


### PR DESCRIPTION
This PR fixes the issue where HTTP inbound endpoint creating new worker thread pool for each request. The worker pool is only created if it is not available while handling request.

Fixes https://github.com/wso2/micro-integrator/issues/1575

