### PR TITLE
Fix https://github.com/wso2/micro-integrator/issues/1591

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -84,6 +84,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -611,6 +611,11 @@
                 ( needs javax.jms.JMSException )
                 -->
                 <include>javax.jms:javax.jms-api:jar</include>
+                <!--
+                javax jaxb-api need to be in class path for ciphertool
+                to run in jdk 11
+                -->
+                <include>javax.xml.bind:jaxb-api:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -991,6 +991,11 @@
                 <version>${org.wso2.orbit.javax.xml.bind.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${version.jaxb.api}</version>
+            </dependency>
+            <dependency>
                 <groupId>au.com.bytecode.opencsv.wso2</groupId>
                 <artifactId>opencsv</artifactId>
                 <version>${opencsv.orbit.version}</version>
@@ -1299,6 +1304,7 @@
         <!-- Carbon kernel version-->
         <carbon.kernel.version>4.5.3</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
+        <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
 
         <synapse.version>2.1.7-wso2v164</synapse.version>
         <carbon.mediation.version>4.7.45</carbon.mediation.version>


### PR DESCRIPTION
## Purpose
When running the cipher tool in JDK 11 it requires having JAXB-API in the classpath.
## Goals
Fixes: https://github.com/wso2/micro-integrator/issues/1591