### PR TITLE
Create an RSA cipher using OAEP

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/TransactionConstants.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/TransactionConstants.java
@@ -28,5 +28,5 @@ public class TransactionConstants {
             + "repository" + File.separator + "resources" + File.separator + "security" + File.separator
             + "publickey.pem";
 
-    public static final String ENCRYPTION_ALGORITHM = "RSA";
+    public static final String ENCRYPTION_ALGORITHM = "RSA/ECB/OAEPwithSHA1andMGF1Padding";
 }


### PR DESCRIPTION
## Purpose
Without OAEP in RSA encryption, it will take less work for an attacker to decrypt the data or to infer patterns from the ciphertext. This PR fixes this issue by creating an RSA cipher using OAEP.