### PR TITLE
Remove unused deprecated method from UserCoreUtil

### DIFF
--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/util/UserCoreUtil.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/util/UserCoreUtil.java
@@ -172,45 +172,6 @@ public final class UserCoreUtil {
     }
 
     /**
-     * @param password
-     * @param passwordHashMethod
-     * @param isKdcEnabled
-     * @return
-     * @throws UserStoreException
-     */
-    @Deprecated
-    public static String getPasswordToStore(String password, String passwordHashMethod,
-                                            boolean isKdcEnabled) throws UserStoreException {
-
-        if (isKdcEnabled) {
-            // If KDC is enabled we will always use plain text passwords.
-            // Cause - KDC cannot operate with hashed passwords.
-
-            return password;
-        }
-
-        String passwordToStore = password;
-
-        if (passwordHashMethod != null) {
-
-            if (passwordHashMethod
-                    .equals(UserCoreConstants.RealmConfig.PASSWORD_HASH_METHOD_PLAIN_TEXT)) {
-                return passwordToStore;
-            }
-
-            try {
-                MessageDigest messageDigest = MessageDigest.getInstance(passwordHashMethod);
-                byte[] digestValue = messageDigest.digest(password.getBytes());
-                passwordToStore = "{" + passwordHashMethod + "}" + Base64.encode(digestValue);
-//				passwordToStore = Base64.encode(digestValue);
-            } catch (NoSuchAlgorithmException e) {
-                throw new UserStoreException("Invalid hashMethod", e);
-            }
-        }
-        return passwordToStore;
-    }
-
-    /**
      * process the original password to be stored as per the given hash method and the status of Kerberos Key
      * Distribution Center (KDC).
      * If KDC is enabled plain text password is returned in a byte array since it cannot operate with hashed passwords.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Remove unused deprecated method `getPasswordToStore()` from UserCoreUtil 