### PR TITLE
Clear logs in tests when starting log reader

### DIFF
--- a/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/CarbonLogReader.java
+++ b/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/CarbonLogReader.java
@@ -71,7 +71,7 @@ public class CarbonLogReader {
      * Start tailer thread.
      */
     public void start() {
-
+        clearLogs();
         tailer = new Tailer(carbonLogFile, carbonLogTailer, 1000, startReadingFromEndOfFile);
         Thread thread = new Thread(tailer);
         thread.setDaemon(true);


### PR DESCRIPTION
## Purpose
This is to avoid having logs of a previous run of the log tailer.