### PR TITLE
Avoid processor deactivation

### DIFF
--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/testng.xml
@@ -9,6 +9,13 @@
         <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestTransformerListener"/>
     </listeners>
 
+    <!--Leave message processor tests at the beginning to avoid processor being deactivated due to subsequent tests -->
+    <test name="RabbitMQ-Store-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.rabbitmq.store"/>
+        </packages>
+    </test>
+
     <test name="RabbitMQ-Transport-Test" preserve-order="true" verbose="2">
         <packages>
             <!--Add basic tests that do not require to restart/stop or initialize rabbitmq server here.
@@ -55,12 +62,6 @@
         <classes>
             <class name="org.wso2.carbon.esb.rabbitmq.inbound.RabbitMQInboundTestCase"/>
         </classes>
-    </test>
-
-    <test name="RabbitMQ-Store-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.rabbitmq.store"/>
-        </packages>
     </test>
 
 </suite>


### PR DESCRIPTION
## Purpose
Move message processor tests to the beginning to avoid the processors becoming deactivated due to other tests.