### PR TITLE
Add ManagementAPI support to create transaction count report

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -43,7 +43,8 @@ public class Constants {
     public static final String PREFIX_LOGOUT = "/logout";
     public static final String PREFIX_SERVER_DATA = "/server";
     public static final String PREFIX_LOG_FILES = "/logs";
-    public static final String PREFIX_REQ_COUNT = "/transactions";
+    public static final String PREFIX_TRANSACTION = "/transactions";
+    public static final String PATH_PARAM_TRANSACTION = "/" + "{param}";
 
     public static final String COUNT = "count";
     public static final String LIST = "list";

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementInternalApi.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementInternalApi.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIHandler;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_TRANSACTION;
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_USER;
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_APIS;
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_CARBON_APPS;
@@ -48,9 +49,9 @@ import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_SEQUENC
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_SERVER_DATA;
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_TASKS;
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_TEMPLATES;
+import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_TRANSACTION;
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_USERS;
 import static org.wso2.micro.integrator.management.apis.Constants.REST_API_CONTEXT;
-import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_REQ_COUNT;
 
 public class ManagementInternalApi implements InternalAPI {
 
@@ -85,7 +86,8 @@ public class ManagementInternalApi implements InternalAPI {
         resourcesList.add(new ApiResourceAdapter(PREFIX_LOGOUT, new LogoutResource()));
         resourcesList.add(new ApiResourceAdapter(PREFIX_SERVER_DATA, new MetaDataResource()));
         resourcesList.add(new LogFilesResource(PREFIX_LOG_FILES));
-        resourcesList.add(new ApiResourceAdapter(PREFIX_REQ_COUNT, new RequestCountResource()));
+        resourcesList.add(new ApiResourceAdapter(PREFIX_TRANSACTION + PATH_PARAM_TRANSACTION,
+                                                 new RequestCountResource()));
 
         resources = new APIResource[resourcesList.size()];
         resources = resourcesList.toArray(resources);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RequestCountResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RequestCountResource.java
@@ -23,16 +23,25 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.config.SynapseConfiguration;
+import org.json.JSONArray;
 import org.json.JSONObject;
+import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.micro.core.util.StringUtils;
 import org.wso2.micro.integrator.initializer.handler.DataHolder;
 import org.wso2.micro.integrator.initializer.handler.transaction.exception.TransactionCounterException;
 import org.wso2.micro.integrator.initializer.handler.transaction.store.TransactionStore;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.wso2.micro.integrator.management.apis.Constants.BAD_REQUEST;
@@ -41,9 +50,9 @@ import static org.wso2.micro.integrator.management.apis.Constants.INTERNAL_SERVE
 
 
 /**
- * Resource for a retrieving aggregated request count.
+ * Resource for a retrieving aggregated transaction count.
  * <p>
- * Handles resources in the form "management/transactions and management/transactions?year=2020&month=5"
+ * Handles resources in the form "management/transactions/{param}"
  */
 public class RequestCountResource implements MiApiResource {
 
@@ -61,15 +70,37 @@ public class RequestCountResource implements MiApiResource {
     public boolean invoke(MessageContext synCtx,
                           org.apache.axis2.context.MessageContext axis2MessageContext,
                           SynapseConfiguration synapseConfiguration) {
+
+        String pathParam = Utils.getPathParameter(synCtx, "param");
+
+        if ("count".equalsIgnoreCase(pathParam)) {
+            String yearParameter = Utils.getQueryParameter(synCtx, "year");
+            String monthParameter = Utils.getQueryParameter(synCtx, "month");
+
+            return handleTransactionCountCommand(axis2MessageContext, yearParameter, monthParameter);
+
+        } else if ("report".equalsIgnoreCase(pathParam)) {
+            String start = Utils.getQueryParameter(synCtx, "start");
+            String end = Utils.getQueryParameter(synCtx, "end");
+
+            return handleTransactionReportCommand(axis2MessageContext, start, end);
+
+        } else {
+            JSONObject response = Utils.createJsonError("No such resource as management/transactions/" + pathParam,
+                                                        axis2MessageContext, BAD_REQUEST);
+            Utils.setJsonPayLoad(axis2MessageContext, response);
+            return true;
+        }
+    }
+
+    private boolean handleTransactionCountCommand(org.apache.axis2.context.MessageContext axis2MessageContext,
+                                                  String yearParameter, String monthParameter) {
         String errorMessage;
-
-        String yearParameter = Utils.getQueryParameter(synCtx, "year");
-        String monthParameter = Utils.getQueryParameter(synCtx, "month");
-
         if (StringUtils.isEmpty(yearParameter) && StringUtils.isEmpty(monthParameter)) {
             Date date = new Date();
             LocalDate localDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-            return takeRequestCountOfTheMonth(axis2MessageContext, localDate.getYear(), localDate.getMonthValue());
+            return takeTransactionCountOfTheMonth(axis2MessageContext, localDate.getYear(),
+                                                  localDate.getMonthValue());
         } else if (StringUtils.isEmpty(yearParameter) || StringUtils.isEmpty(monthParameter)) {
             errorMessage = "Either both \"year\" and \"month\" arguments or none should be specified.";
         } else {
@@ -77,10 +108,10 @@ public class RequestCountResource implements MiApiResource {
             Integer month = tryParseInt(monthParameter);
 
             if (null != year && null != month) {
-                return takeRequestCountOfTheMonth(axis2MessageContext, year, month);
-            } else if (null == year && null == month){
+                return takeTransactionCountOfTheMonth(axis2MessageContext, year, month);
+            } else if (null == year && null == month) {
                 errorMessage = "Invalid inputs for arguments \"year\" and \"month\".";
-            } else if (null == year){
+            } else if (null == year) {
                 errorMessage = "Invalid input for argument \"year\".";
             } else {
                 errorMessage = "Invalid input for argument \"month\".";
@@ -92,8 +123,37 @@ public class RequestCountResource implements MiApiResource {
         return true;
     }
 
-    // Take aggregated request count for a given month.
-    private boolean takeRequestCountOfTheMonth(org.apache.axis2.context.MessageContext axisCtx, int year, int month) {
+    private boolean handleTransactionReportCommand(org.apache.axis2.context.MessageContext axis2MessageContext,
+                                                   String start, String end) {
+        String errorMessage;
+        if (StringUtils.isEmpty(start)) {
+            errorMessage = "Argument \"start\" cannot be empty";
+        } else {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            LocalDate startDate = tryParseDate(start + "-01", formatter);
+            if (null != startDate) {
+                LocalDate endDate;
+                if (StringUtils.isEmpty(end)) {
+                    endDate = new Date().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+                    return getReportContent(axis2MessageContext, startDate, endDate);
+                }
+                endDate = tryParseDate(end + "-01", formatter);
+                if (null != endDate) {
+                    return getReportContent(axis2MessageContext, startDate, endDate);
+                }
+                errorMessage = "Invalid input for argument \"end\"";
+            } else {
+                errorMessage = "Invalid input for argument \"start\"";
+            }
+        }
+        JSONObject response = Utils.createJsonError(errorMessage, axis2MessageContext, BAD_REQUEST);
+        Utils.setJsonPayLoad(axis2MessageContext, response);
+        return true;
+    }
+
+    // Take aggregated transaction count for a given month.
+    private boolean takeTransactionCountOfTheMonth(org.apache.axis2.context.MessageContext axisCtx, int year,
+                                                   int month) {
 
         JSONObject response;
         axisCtx.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE, "application/json");
@@ -101,30 +161,114 @@ public class RequestCountResource implements MiApiResource {
 
         TransactionStore transactionStore = DataHolder.getInstance().getTransactionStore();
         if (transactionStore != null) {
-            // Get request count of current Month
-            long requestCount;
+            // Get transaction count of current Month
+            long transactionCount;
             try {
-                requestCount = transactionStore.getTransactionCountOfMonth(year, month);
+                transactionCount = transactionStore.getTransactionCountOfMonth(year, month);
             } catch (TransactionCounterException e) {
-                response =
-                        Utils.createJsonError("Error occurred while retrieving data from the database ", e, axisCtx,
-                                              INTERNAL_SERVER_ERROR);
+                response = Utils.createJsonError("Error occurred while retrieving data from the database ", e,
+                                                 axisCtx, INTERNAL_SERVER_ERROR);
                 Utils.setJsonPayLoad(axisCtx, response);
+                LOG.error("Error occurred while getting the transaction count from the database", e);
                 return true;
             }
-            if (requestCount != -1L) {
-                response = new JSONObject(
-                        "{\"Year\" : " + year + ", \"Month\" : " + month + ", \"RequestCount\" : " + requestCount +
-                                "}");
+            if (transactionCount != -1L) {
+                response = new JSONObject("{\"Year\" : " + year + ", \"Month\" : " + month + ", "
+                                                  + "\"TransactionCount\" : " + transactionCount + "}");
             } else {
                 response = new JSONObject("{\"error\" : \"Did not find stats for " + year + "/" + month + "\"}");
             }
         } else {
-            response =
-                    Utils.createJsonError("TransactionStore is not initialized", axisCtx, FORBIDDEN);
+            response = Utils.createJsonError("Transaction Count Handler component is not initialized", axisCtx,
+                                             FORBIDDEN);
         }
         Utils.setJsonPayLoad(axisCtx, response);
         return true;
+    }
+
+    /**
+     * Create the content of the transaction count report and generate the report in <CARBON_HOME>/temp directory.
+     *
+     * @param axisCtx   axis message context
+     * @param startDate date from which the values in the report should starts
+     * @param endDate   date upto which the values in the report should includes
+     * @return true
+     */
+    private boolean getReportContent(org.apache.axis2.context.MessageContext axisCtx, LocalDate startDate,
+                                     LocalDate endDate) {
+        String filePath = System.getProperty(ServerConstants.CARBON_HOME) + File.separator + "tmp" + File.separator +
+                "transaction-count-summary-" + new Date().getTime() + ".csv";
+        JSONObject response;
+        axisCtx.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE, "application/json");
+        axisCtx.setProperty(Constants.Configuration.CONTENT_TYPE, "application/json");
+
+        TransactionStore transactionStore = DataHolder.getInstance().getTransactionStore();
+        if (null == transactionStore) {
+            response = Utils.createJsonError("Transaction Count Handler component is not initialized", axisCtx,
+                                             FORBIDDEN);
+            Utils.setJsonPayLoad(axisCtx, response);
+            return true;
+        } else {
+            String errorMessage;
+            try {
+                List<String[]> transactionCountData = transactionStore
+                        .getTransactionCountDataWithColumnNames(startDate.toString(),
+                                                                endDate.toString());
+                writeToCSVFile(filePath, transactionCountData);
+                response = new JSONObject();
+                response.put("TransactionCountData", populateReportContent(transactionCountData));
+                LOG.info("Transaction count report is created at " + filePath);
+            } catch (TransactionCounterException e) {
+                errorMessage = "Error occurred while retrieving the transaction count data from the database";
+                response = Utils.createJsonError(errorMessage, e, axisCtx, INTERNAL_SERVER_ERROR);
+                LOG.error(errorMessage, e);
+            } catch (IOException e) {
+                errorMessage = "Error occurred while writing the data to the output file: " + filePath;
+                response = Utils.createJsonError(errorMessage, e, axisCtx, INTERNAL_SERVER_ERROR);
+                LOG.error(errorMessage, e);
+            }
+        }
+        Utils.setJsonPayLoad(axisCtx, response);
+        return true;
+    }
+
+    /**
+     * Populate the report content.
+     *
+     * @param dataLines Data to be included in the report.
+     * @return a JSONArray with the report content
+     */
+    private JSONArray populateReportContent(List<String[]> dataLines) {
+        JSONArray arr = new JSONArray();
+        for (String[] line : dataLines) {
+            arr.put(line);
+        }
+        return arr;
+    }
+
+    /**
+     * Write data to the given CSV file.
+     *
+     * @param filePath  of the target csv file
+     * @param dataLines Data to be written to the report.
+     */
+    private void writeToCSVFile(String filePath, List<String[]> dataLines) throws IOException {
+        try (FileWriter csvOutputFile = new FileWriter(filePath, true);
+             PrintWriter writer = new PrintWriter(csvOutputFile)) {
+            dataLines.stream()
+                    .map(this::convertToCSV)
+                    .forEach(writer::println);
+        }
+    }
+
+    /**
+     * Convert a string array to a string separated by a ",".
+     *
+     * @param data to be converted to a comma separated string
+     * @return comma separated string
+     */
+    private String convertToCSV(String[] data) {
+        return String.join(",", data);
     }
 
     /**
@@ -139,6 +283,22 @@ public class RequestCountResource implements MiApiResource {
             return Integer.parseInt(someText);
         } catch (NumberFormatException ex) {
             LOG.error("Invalid input. Cannot parse the input '" + someText + "' as an Integer: ", ex);
+            return null;
+        }
+    }
+
+    /**
+     * Try to parse input string to a LocalDate.
+     *
+     * @param date      input string
+     * @param formatter date formatter
+     * @return parsed Date, null if failed
+     */
+    private static LocalDate tryParseDate(String date, DateTimeFormatter formatter) {
+        try {
+            return LocalDate.parse(date, formatter);
+        } catch (DateTimeParseException ex) {
+            LOG.error("Invalid Date format. Cannot parse the input '" + date + "' as a LocalDate: ", ex);
             return null;
         }
     }

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/store/TransactionStore.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/store/TransactionStore.java
@@ -22,7 +22,7 @@ import org.wso2.micro.integrator.initializer.handler.transaction.exception.Trans
 import org.wso2.micro.integrator.initializer.handler.transaction.exception.TransactionCounterInitializationException;
 import org.wso2.micro.integrator.initializer.handler.transaction.store.connector.RDBMSConnector;
 
-import java.sql.SQLException;
+import java.util.List;
 import java.util.UUID;
 import javax.crypto.Cipher;
 import javax.sql.DataSource;
@@ -55,21 +55,32 @@ public class TransactionStore {
      * @throws TransactionCounterException -
      */
     public void addTransaction() throws TransactionCounterException {
-        try {
-            this.rdbmsConnector.addTransaction();
-        } catch (SQLException e) {
-            throw new TransactionCounterException(
-                    "Error occurred while adding transaction count to the database", e);
-        }
+        this.rdbmsConnector.addTransaction();
     }
 
+    /**
+     * Get the transaction count for the given year and month.
+     *
+     * @param year        Year.
+     * @param monthNumber Month.
+     * @throws TransactionCounterException -
+     */
     public long getTransactionCountOfMonth(int year, int monthNumber) throws TransactionCounterException {
-        try {
-            return this.rdbmsConnector.getTransactionCountOfMonth(year, monthNumber);
-        } catch (SQLException e) {
-            throw new TransactionCounterException(
-                    "Error occurred while getting the transaction count from the database", e);
-        }
+        return this.rdbmsConnector.getTransactionCountOfMonth(year, monthNumber);
+
+    }
+
+    /**
+     * Get transaction count data for a given period of time.
+     *
+     * @param startDate Start date.
+     * @param endDate   End date.
+     * @return a list of string arrays with information of the column names and row data
+     * @throws TransactionCounterException -
+     */
+    public List<String[]> getTransactionCountDataWithColumnNames(String startDate, String endDate)
+            throws TransactionCounterException {
+        return this.rdbmsConnector.getTransactionCountDataWithColumnNames(startDate, endDate);
     }
 
     /**

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/store/connector/TransactionQueryHelper.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/store/connector/TransactionQueryHelper.java
@@ -21,14 +21,16 @@ package org.wso2.micro.integrator.initializer.handler.transaction.store.connecto
 /**
  * This class contains all the data base queries related to transaction counting.
  */
-public class TransactionQueryHelper {
+class TransactionQueryHelper {
 
-    public final static String INSERT_RAW = "INSERT INTO CURRENT_STATS (TIME_STAMP, NODE_ID, TRANSACTION_COUNT," +
+    static final String INSERT_RAW = "INSERT INTO CURRENT_STATS (TIME_STAMP, NODE_ID, TRANSACTION_COUNT," +
             "TRANSACTION_COUNT_ENCRYPTED) VALUES (?,?,?,?)";
-    public final static String GET_TRAN_COUNT = "SELECT TRANSACTION_COUNT FROM CURRENT_STATS WHERE TIME_STAMP=?" +
+    static final String GET_TRAN_COUNT = "SELECT TRANSACTION_COUNT FROM CURRENT_STATS WHERE TIME_STAMP=?" +
             " AND NODE_ID=?";
-    public final static String UPDATE_TRAN_COUNT = "UPDATE CURRENT_STATS SET TRANSACTION_COUNT=?, " +
+    static final String UPDATE_TRAN_COUNT = "UPDATE CURRENT_STATS SET TRANSACTION_COUNT=?, " +
             "TRANSACTION_COUNT_ENCRYPTED=? WHERE NODE_ID=? AND TIME_STAMP=?";
-    public final static String TRAN_COUNT_OF_MONTH =
+    static final String TRAN_COUNT_OF_MONTH =
             "SELECT SUM(TRANSACTION_COUNT) FROM CURRENT_STATS WHERE TIME_STAMP =?";
+    static final String GET_TRAN_COUNT_DATA_FOR_A_TIME_PERIOD =
+            "SELECT * FROM CURRENT_STATS WHERE TIME_STAMP BETWEEN ? AND ?";
 }


### PR DESCRIPTION
## Purpose
Implement the following Management APIs for the transaction count component.

| API  | Description | Response |
| ------------- | ------------- | ------------- | 
| /management/transactions/count  | Get the transaction count for the current month | {"Year" : 2020, "Month" : 05, "TransactionCount" : 239347}|
| /management/transactions/count?year=[year]&month=[month]  | Get the transaction count for the given date | {"Year" : 2020, "Month" : 06, "TransactionCount" : 1232347}|
| /management/transactions/report?start=[start]&end=[end]  | Get the report content for the period between start and end date. Generate a report inside <CARBON_HOME>/temp directory  | {"TransactionCountData" : [[date, nodeId, count, encryptedCount], [val1, val2, val3, val4]]}|
| /management/transactions/report?start=[start]  | Get the report content for the period between start and current date. Generate a report inside <CARBON_HOME>/temp directory  | {"TransactionCountData" : [[date, nodeId, count, encryptedCount], [val1, val2, val3, val4]]}|
