### PR TITLE
Synchronize JMSPollingConsumer destroy to avoid deadlocks

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSPollingConsumer.java
@@ -420,14 +420,16 @@ public class JMSPollingConsumer {
     }
 
     public void destroy() {
-        if (messageConsumer != null) {
-            jmsConnectionFactory.closeConsumer(messageConsumer, true);
-        }
-        if (session != null) {
-            jmsConnectionFactory.closeSession(session, true);
-        }
-        if (connection != null) {
-            jmsConnectionFactory.closeConnection(connection, true);
+        synchronized (jmsConnectionFactory) {
+            if (messageConsumer != null) {
+                jmsConnectionFactory.closeConsumer(messageConsumer, true);
+            }
+            if (session != null) {
+                jmsConnectionFactory.closeSession(session, true);
+            }
+            if (connection != null) {
+                jmsConnectionFactory.closeConnection(connection, true);
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Port fix https://github.com/wso2/carbon-mediation/pull/1334
Relates to https://github.com/wso2/product-ei/issues/4735
Resolves https://github.com/wso2/micro-integrator/issues/1675

