### PR TITLE
Enable RabbitMQ tests for content-type

### DIFF
--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/java/org/wso2/carbon/esb/rabbitmq/transport/test/RabbitMQContentTypeTestCase.java
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/java/org/wso2/carbon/esb/rabbitmq/transport/test/RabbitMQContentTypeTestCase.java
@@ -14,7 +14,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/*
 package org.wso2.carbon.esb.rabbitmq.transport.test;
 
 import org.testng.Assert;
@@ -23,60 +22,40 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.esb.rabbitmq.utils.RabbitMQServerInstance;
 import org.wso2.carbon.esb.rabbitmq.utils.RabbitMQTestUtils;
-import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
-import org.wso2.carbon.logging.view.stub.types.carbon.LogEvent;
+import org.wso2.esb.integration.common.utils.CarbonLogReader;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.clients.rabbitmqclient.RabbitMQProducerClient;
 
-import java.io.File;*/
 
 /**
  * Test RabbitMQ receiver with different content-types and with content type service parameter
  */
-/*public class RabbitMQContentTypeTestCase extends ESBIntegrationTest {
+public class RabbitMQContentTypeTestCase extends ESBIntegrationTest {
 
-    private LogViewerClient logViewer;
+    private CarbonLogReader logReader;
     private RabbitMQProducerClient sender;
 
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
         super.init();
         sender = RabbitMQServerInstance.createProducerWithDeclaration("exchange2", "simple_consumer_test");
-        //The consumer proxy cannot be pre-deployed since the queue declaration(which is done in 'initRabbitMQBroker')
-        // must happen before deployment.
-        loadESBConfigurationFromClasspath(
-                File.separator + "artifacts" + File.separator + "ESB" + File.separator + "rabbitmq" + File.separator
-                        + "transport" + File.separator + "rabbitmq_consumer_proxy.xml");
-        logViewer = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
+        logReader = new CarbonLogReader();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test RabbitMQ consumer with no content type")
     public void testContentTypeEmpty() throws Exception {
-        int beforeLogSize = logViewer.getAllRemoteSystemLogs().length;
+        logReader.start();
         String message = "<ser:placeOrder xmlns:ser=\"http://services.samples\">\n" + "<ser:order>\n"
                 + "<ser:price>100</ser:price>\n" + "<ser:quantity>2000</ser:quantity>\n"
                 + "<ser:symbol>RMQ</ser:symbol>\n" + "</ser:order>\n" + "</ser:placeOrder>";
         sender.sendMessage(message, null);
         RabbitMQTestUtils.waitForLogToGetUpdated();
 
-        LogEvent[] logs = logViewer.getAllRemoteSystemLogs();
-        int afterLogSize = logs.length;
-        boolean setDefaultContentType = false;
-        int count = 0;
-
-        for (int i = (afterLogSize - beforeLogSize - 1); i >= 0; i--) {
-            String logMessage = logs[i].getMessage();
-            if (logMessage.contains("Unable to determine content type for message") && logMessage
-                    .contains("setting to text/plain")) {
-                setDefaultContentType = true;
-            }
-            if (logMessage.contains("received = true")) {
-                count++;
-            }
-        }
-
-        Assert.assertTrue(setDefaultContentType, "Default content type is not set to text/plain");
-        Assert.assertEquals(count, 1, "All messages are not received from queue");
+        logReader.stop();
+        Assert.assertTrue(logReader.checkForLog("Unable to determine content type for message", 5));
+        Assert.assertTrue(logReader.checkForLog("setting to text/plain", 5));
+        Assert.assertEquals(logReader.getNumberOfOccurencesForLog("received = true"),
+                            1, "All messages are not received from queue");
     }
 
     @AfterClass(alwaysRun = true)
@@ -84,4 +63,4 @@ import java.io.File;*/
         sender.disconnect();
         super.cleanup();
     }
-}*/
+}

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/java/org/wso2/carbon/esb/rabbitmq/transport/test/RabbitMQJSONConsumerTestCase.java
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/java/org/wso2/carbon/esb/rabbitmq/transport/test/RabbitMQJSONConsumerTestCase.java
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-/*package org.wso2.carbon.esb.rabbitmq.transport.test;
+package org.wso2.carbon.esb.rabbitmq.transport.test;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -23,39 +23,31 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.esb.rabbitmq.utils.RabbitMQServerInstance;
 import org.wso2.carbon.esb.rabbitmq.utils.RabbitMQTestUtils;
-import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
-import org.wso2.carbon.logging.view.stub.types.carbon.LogEvent;
+import org.wso2.esb.integration.common.utils.CarbonLogReader;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.clients.rabbitmqclient.RabbitMQProducerClient;
 
-import java.io.File;
-import java.io.IOException;*/
+import java.io.IOException;
 
 /**
  * RabbitMQJSONConsumerTestCase tests EI as a rabbitmq consumer using a proxy service where the payload is a JSON
  * object.
  */
-/*
 public class RabbitMQJSONConsumerTestCase extends ESBIntegrationTest {
 
-    private LogViewerClient logViewer;
+    private CarbonLogReader logReader;
     private RabbitMQProducerClient sender;
 
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
         super.init();
         sender = RabbitMQServerInstance.createProducerWithDeclaration("exchange2", "consumer_json");
-        //The consumer proxy cannot be pre-deployed since the queue declaration(which is done in 'initRabbitMQBroker')
-        // must happen before deployment.
-        loadESBConfigurationFromClasspath(
-                File.separator + "artifacts" + File.separator + "ESB" + File.separator + "rabbitmq" + File.separator
-                        + "transport" + File.separator + "rabbitmq_consumer_json.xml");
-        logViewer = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
+        logReader = new CarbonLogReader();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test ESB as a RabbitMQ consumer for JSON messages ")
     public void testRabbitMQJSONConsumer() throws Exception {
-        int beforeLogSize = logViewer.getAllRemoteSystemLogs().length;
+        logReader.start();
 
         try {
             String message = "{\"name\":\"device1\"}";
@@ -65,20 +57,9 @@ public class RabbitMQJSONConsumerTestCase extends ESBIntegrationTest {
         }
 
         RabbitMQTestUtils.waitForLogToGetUpdated();
-
-        LogEvent[] logs = logViewer.getAllRemoteSystemLogs();
-        int afterLogSize = logs.length;
-        int count = 0;
-
-        for (int i = (afterLogSize - beforeLogSize - 1); i >= 0; i--) {
-            String message = logs[i].getMessage();
-            if (message.contains("received = true")) {
-                count++;
-                System.out.println("message = " + message);
-            }
-        }
-
-        Assert.assertEquals(count, 1, "All messages are not received from queue");
+        logReader.stop();
+        Assert.assertEquals(logReader.getNumberOfOccurencesForLog("received = true"),
+                            1, "All messages are not received from queue");
     }
 
     @AfterClass(alwaysRun = true)
@@ -86,7 +67,5 @@ public class RabbitMQJSONConsumerTestCase extends ESBIntegrationTest {
         super.cleanup();
         sender.disconnect();
         sender = null;
-        logViewer = null;
     }
 }
-*/

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/java/org/wso2/carbon/esb/rabbitmq/utils/RabbitMQTestUtils.java
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/java/org/wso2/carbon/esb/rabbitmq/utils/RabbitMQTestUtils.java
@@ -162,7 +162,7 @@ public class RabbitMQTestUtils {
         }
 
         int exitCode = process.waitFor();
-        log.info("Command execution exited with error code : " + exitCode);
+        log.info("Command execution exited with code: " + exitCode);
     }
 
 }

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/RabbitMQJsonProxy.xml
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/RabbitMQJsonProxy.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~  
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="RabbitMQJsonProxy"
+       transports="rabbitmq"
+       startOnLoad="true"
+       trace="disable">
+    <description/>
+    <target>
+        <inSequence>
+            <property name="FORCE_SC_ACCEPTED" value="true" scope="axis2"/>
+            <log level="full">
+                <property name="received" value="true"/>
+            </log>
+        </inSequence>
+    </target>
+    <parameter name="rabbitmq.message.content.type">application/json</parameter>
+    <parameter name="rabbitmq.queue.name">consumer_json</parameter>
+    <parameter name="rabbitmq.connection.factory">AMQPConnectionFactory</parameter>
+</proxy>


### PR DESCRIPTION
## Purpose
Enables RabbitMQ tests written for default and JSON content types.