### PR TITLE
Remove PrometheusStatisticsTest Test Case

### DIFF
--- a/integration/mediation-tests/tests-other/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/testng.xml
@@ -118,6 +118,11 @@
                     <exclude name=".*"/>
                 </methods>
             </class>
+            <class name="org.wso2.carbon.esb.statistics.PrometheusStatisticsTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
         </classes>
     </test>
 


### PR DESCRIPTION
Remove PrometheusStatisticsTest Test Case because it's changed in the with the new observability implementation.

