### PR TITLE
Upgrade pax-logging dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1388,8 +1388,8 @@
         <axis2.mar.maven.plugin>1.5.2</axis2.mar.maven.plugin>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>1.11.0</pax.logging.api.version>
-        <pax.logging.log4j2.version>1.11.0</pax.logging.log4j2.version>
+        <pax.logging.api.version>1.11.2</pax.logging.api.version>
+        <pax.logging.log4j2.version>1.11.2</pax.logging.log4j2.version>
         <org.apache.commons.logging.version>1.1.1</org.apache.commons.logging.version>
         <version.eclipse.equinox.cm>1.3.100</version.eclipse.equinox.cm>
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Upgrade pax-logging dependency from 1.11.0 to 1.11.2