### PR TITLE
[Observability] [OpenTracing] Stop finding analytics server when only OpenTracing is enabled

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/main/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/internal/MediationStatisticsComponent.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/main/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/internal/MediationStatisticsComponent.java
@@ -304,8 +304,7 @@ public class MediationStatisticsComponent {
     }
 
     private void checkPublishingEnabled() {
-
-        flowStatisticsEnabled = RuntimeStatisticCollector.isStatisticsEnabled();
+        flowStatisticsEnabled = RuntimeStatisticCollector.isMediationFlowStatisticsEnabled();
         MessageFlowDataPublisherDataHolder.getInstance().setGlobalStatisticsEnabled(flowStatisticsEnabled);
         if (!flowStatisticsEnabled) {
             log.info("Global Message-Flow Statistic Reporting is Disabled");


### PR DESCRIPTION
**NOTE: Merge this PR only after merging https://github.com/wso2/wso2-synapse/pull/1567 and doing a wso2-synapse release**

## Purpose
> We set the `isStatisticsEnabled` property of `RuntimeStatisticCollector` if either OpenTracing, or Analytics Profile statistics is enabled. Therefore, when we enable only OpenTracing, Micro Integrator will still try to search for an Analytics Worker, and produce error logs on the console. This PR fixes this to enable publishing to Analytics Worker only when mediation statistics flow is enabled.

## Goals
> Preventing publishing to analytics worker, when only OpenTracing is enabled.

## Related PRs
> - Adding `isMediationFlowStatisticsEnabled()` method to `RuntimeStatisticCollector`: https://github.com/wso2/wso2-synapse/pull/1567