### PR TITLE
Update correlation id constants from synapse-commons

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundCorrelationEnabledHttpServerWorker.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundCorrelationEnabledHttpServerWorker.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.inbound.endpoint.protocol.http;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.MDC;
+import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.SourceRequest;
 import org.apache.synapse.transport.passthru.config.SourceConfiguration;
@@ -49,8 +50,8 @@ public class InboundCorrelationEnabledHttpServerWorker extends InboundHttpServer
     @Override
     public void run() {
         // Reset the correlation id MDC thread local value.
-        MDC.remove(PassThroughConstants.CORRELATION_MDC_PROPERTY);
-        MDC.put(PassThroughConstants.CORRELATION_MDC_PROPERTY, correlationId);
+        MDC.remove(CorrelationConstants.CORRELATION_MDC_PROPERTY);
+        MDC.put(CorrelationConstants.CORRELATION_MDC_PROPERTY, correlationId);
         // Log the time taken to switch from the previous thread to this thread
         correlationLog.info((System.currentTimeMillis() - initiationTimestamp) + "|Thread switch latency");
         super.run();

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpSourceHandler.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpSourceHandler.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpException;
 import org.apache.http.nio.NHttpServerConnection;
+import org.apache.synapse.commons.CorrelationConstants;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
 import org.apache.synapse.transport.passthru.ProtocolState;
 import org.apache.synapse.transport.passthru.SourceContext;
@@ -96,7 +97,7 @@ public class InboundHttpSourceHandler extends SourceHandler {
                 }
             }
 
-            Object correlationId = conn.getContext().getAttribute(PassThroughConstants.CORRELATION_ID);
+            Object correlationId = conn.getContext().getAttribute(CorrelationConstants.CORRELATION_ID);
             if (correlationId != null) {
                 workerPool.execute(
                         new InboundCorrelationEnabledHttpServerWorker(port, SUPER_TENANT_DOMAIN_NAME, request,

--- a/pom.xml
+++ b/pom.xml
@@ -1333,7 +1333,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
 
-        <synapse.version>2.1.7-wso2v172</synapse.version>
+        <synapse.version>2.1.7-wso2v173</synapse.version>
         <carbon.mediation.version>4.7.50</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>
         <carbon.crypto.api.imp.pkg.version.range>[1.1.0,1.2.0)</carbon.crypto.api.imp.pkg.version.range>


### PR DESCRIPTION
## Purpose
Add changes related to moving CORRELATION_ID and CORRELATION_ID_MDC constants to CorrelationConstant in synapse-commons (introduced by https://github.com/wso2/wso2-synapse/pull/1568).

Upgrade synapse version.