### PR TITLE
Fix error in server shut down with RabbitMQ

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundOneTimeTriggerEventBasedProcessor.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundOneTimeTriggerEventBasedProcessor.java
@@ -41,7 +41,15 @@ public abstract class InboundOneTimeTriggerEventBasedProcessor extends InboundOn
      * undeployed/redeployed or when server stop
      */
     public void destroy() {
-        super.destroy();
+        destroy(true);
+    }
+
+    /**
+     * Stop the inbound polling processor This will be called when inbound is
+     * undeployed/redeployed or when server stop
+     */
+    public void destroy(boolean removeTask) {
+        super.destroy(removeTask);
         //Terminate waiting events
         eventBasedConsumer.destroy();
     }

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundOneTimeTriggerRequestProcessor.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundOneTimeTriggerRequestProcessor.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.inbound.InboundRequestProcessor;
+import org.apache.synapse.inbound.InboundTaskProcessor;
 import org.apache.synapse.startup.quartz.StartUpController;
 import org.apache.synapse.task.TaskDescription;
 import org.apache.synapse.task.TaskManager;
@@ -37,7 +38,7 @@ import static org.wso2.carbon.inbound.endpoint.common.Constants.SUPER_TENANT_DOM
  * One such requirement is loading the tenant when message is injected if at that moment tenant
  * is unloaded.
  */
-public abstract class InboundOneTimeTriggerRequestProcessor implements InboundRequestProcessor {
+public abstract class InboundOneTimeTriggerRequestProcessor implements InboundRequestProcessor, InboundTaskProcessor {
 
     protected StartUpController startUpController;
     protected SynapseEnvironment synapseEnvironment;
@@ -110,12 +111,17 @@ public abstract class InboundOneTimeTriggerRequestProcessor implements InboundRe
      * undeployed/redeployed or when server stop
      */
     public void destroy() {
+        destroy(true);
+    }
+
+    @Override
+    public void destroy(boolean removeTask) {
         log.info("Inbound endpoint " + name + " stopping.");
 
         dataStore.unregisterPollingEndpoint(SUPER_TENANT_DOMAIN_NAME, name);
 
         if (startUpController != null) {
-            startUpController.destroy();
+            startUpController.destroy(removeTask);
         } else if (runningThread != null) {
             try {
                 //this is introduced where the the thread is suspended due to external server is not

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/mqtt/MqttListener.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/mqtt/MqttListener.java
@@ -115,6 +115,11 @@ public class MqttListener extends InboundOneTimeTriggerRequestProcessor {
 
     @Override
     public void destroy() {
+        destroy(true);
+    }
+
+    @Override
+    public void destroy(boolean removeTask) {
         log.info("Mqtt Inbound endpoint: " + name + " Started destroying context.");
         MqttClientManager clientManager = MqttClientManager.getInstance();
         String inboundIdentifier = clientManager
@@ -143,7 +148,7 @@ public class MqttListener extends InboundOneTimeTriggerRequestProcessor {
                 log.error("Error while disconnecting from the remote server.");
             }
         }
-        super.destroy();
+        super.destroy(removeTask);
     }
 
     @Override

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQListener.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQListener.java
@@ -67,8 +67,13 @@ public class RabbitMQListener extends InboundOneTimeTriggerRequestProcessor {
 
     @Override
     public void destroy() {
+        destroy(true);
+    }
+
+    @Override
+    public void destroy(boolean removeTask) {
         rabbitMQConsumer.close();
-        super.destroy();
+        super.destroy(removeTask);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
The exception is thrown upon server shutdown while the task was being deleted. The fix is to prevent the task being deleted upon server shutdown just as for other inbound task implementations.

Resolves: https://github.com/wso2/micro-integrator/issues/1665