### PR TITLE
Fix MI-1735: Registry resources are not getting removed upon the capp undeployment

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -838,7 +838,7 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
         String metadataDirPath = parent.getPath() + File.separator + METADATA_DIR_NAME;
         File metadataDir = new File(metadataDirPath);
         if (!metadataDir.exists()) {
-            handleException("Unable to delete metadata directory: " + metadataDir.getPath());
+            return;
         }
         File metadataFile = new File(metadataDir, resourceFileName + METADATA_FILE_SUFFIX);
         deleteFile(metadataFile);

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -837,7 +837,7 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
 
         String metadataDirPath = parent.getPath() + File.separator + METADATA_DIR_NAME;
         File metadataDir = new File(metadataDirPath);
-        if (!metadataDir.exists() && !metadataDir.mkdirs()) {
+        if (!metadataDir.exists()) {
             handleException("Unable to delete metadata directory: " + metadataDir.getPath());
         }
         File metadataFile = new File(metadataDir, resourceFileName + METADATA_FILE_SUFFIX);

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -486,7 +486,7 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                     deleteDirectory(parentFile);
                 }
             } catch (URISyntaxException e) {
-                handleException("Error while deleting the registry path " + path);
+                handleException("Error while deleting the registry path " + path, e);
             }
         } else {
             // Warn the user that unable to delete remote registry resources

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -58,6 +58,8 @@ import javax.xml.stream.XMLStreamReader;
 import static org.wso2.micro.integrator.registry.MicroIntegratorRegistryConstants.DEFAULT_MEDIA_TYPE;
 import static org.wso2.micro.integrator.registry.MicroIntegratorRegistryConstants.PROPERTY_EXTENTION;
 import static org.wso2.micro.integrator.registry.MicroIntegratorRegistryConstants.URL_SEPARATOR;
+import static org.wso2.micro.integrator.registry.MicroIntegratorRegistryConstants.CONFIG_DIRECTORY_NAME;
+import static org.wso2.micro.integrator.registry.MicroIntegratorRegistryConstants.GOVERNANCE_DIRECTORY_NAME;
 
 public class MicroIntegratorRegistry extends AbstractRegistry {
 
@@ -473,7 +475,19 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
     @Override
     public void delete(String path) {
         if (registryType == MicroIntegratorRegistryConstants.LOCAL_HOST_REGISTRY) {
-            removeResource(path);
+            try {
+                String targetPath = resolveRegistryURI(path);
+                File parentFile = new File(new URI(getParentPath(targetPath, false)));
+                String fileName = getResourceName(targetPath);
+                removeResource(path);
+                deleteMetadata(parentFile, fileName);
+                if (RegistryHelper.isDirectoryEmpty(parentFile.getPath()) && !CONFIG_DIRECTORY_NAME.equals
+                        (parentFile.getName()) && !GOVERNANCE_DIRECTORY_NAME.equals(parentFile.getName())) {
+                    deleteDirectory(parentFile);
+                }
+            } catch (URISyntaxException e) {
+                handleException("Error while deleting the registry path " + path);
+            }
         } else {
             // Warn the user that unable to delete remote registry resources
             log.warn("Deleting remote resources NOT SUPPORTED. Unable to delete: " + path);
@@ -810,6 +824,29 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
             }
         } catch (IOException e) {
             handleException("Couldn't write to metadata file: " + newMetadataFile.getPath(), e);
+        }
+    }
+
+    /**
+     * Delete metadata related to the given resource.
+     *
+     * @param parent           parent dir of the resource
+     * @param resourceFileName filename of the resource
+     */
+    private void deleteMetadata(File parent, String resourceFileName) {
+
+        String metadataDirPath = parent.getPath() + File.separator + METADATA_DIR_NAME;
+        File metadataDir = new File(metadataDirPath);
+        if (!metadataDir.exists() && !metadataDir.mkdirs()) {
+            handleException("Unable to delete metadata directory: " + metadataDir.getPath());
+        }
+        File metadataFile = new File(metadataDir, resourceFileName + METADATA_FILE_SUFFIX);
+        deleteFile(metadataFile);
+        if (RegistryHelper.isDirectoryEmpty(metadataDirPath)) {
+            deleteDirectory(metadataDir);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully deleted metadata file: " + metadataFile.getPath());
         }
     }
 

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
@@ -46,6 +46,9 @@ public class MicroIntegratorRegistryConstants {
     public static final String GOVERNANCE_REGISTRY_PREFIX = "gov:";
     public static final String LOCAL_REGISTRY_PREFIX = "local:";
 
+    public static final String CONFIG_DIRECTORY_NAME = "config";
+    public static final String GOVERNANCE_DIRECTORY_NAME = "governance";
+
     public static final char URL_SEPARATOR_CHAR = '/';
     public static final String URL_SEPARATOR = "/";
     public static final String PROPERTY_EXTENTION = ".properties";

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/RegistryHelper.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/RegistryHelper.java
@@ -69,4 +69,18 @@ public class RegistryHelper {
         return path.replace(URL_SEPARATOR_CHAR, File.separatorChar);
     }
 
+    /**
+     * Check whether the directory is empty
+     *
+     * @param directory  directory path
+     */
+    public static boolean isDirectoryEmpty (String directory) {
+        File file = new File(directory);
+        if (file.isDirectory()) {
+            return file.list().length == 0;
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
@@ -220,7 +220,7 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
             // check whether the file exists
             File file = new File(filePath);
             if (!file.exists()) {
-                log.error("Specified file to be removed as a resource is " + "not found at : " + filePath);
+                // the file is already deleted.
                 continue;
             }
             String resourcePath = AppDeployerUtils.computeResourcePath(createRegistryKey(resource),resource.getFileName());

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
@@ -78,7 +78,16 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
 
     @Override
     public void undeployArtifacts(CarbonApplication carbonApplication, AxisConfiguration axisConfiguration) throws DeploymentException {
+        ApplicationConfiguration appConfig = carbonApplication.getAppConfig();
+        List<Artifact.Dependency> deps = appConfig.getApplicationArtifact().getDependencies();
 
+        List<Artifact> artifacts = new ArrayList<Artifact>();
+        for (Artifact.Dependency dep : deps) {
+            if (dep.getArtifact() != null) {
+                artifacts.add(dep.getArtifact());
+            }
+        }
+        undeployRegistryArtifacts(artifacts, carbonApplication.getAppNameWithVersion());
     }
 
     /**
@@ -95,6 +104,23 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
             }
             RegistryConfig regConfig = buildRegistryConfig(artifact, parentAppName);
             writeArtifactToRegistry(regConfig);
+        });
+    }
+
+    /**
+     * Deploys registry artifacts recursively. A Registry artifact can exist as a sub artifact in
+     * any type of artifact. Therefore, have to search recursively
+     *
+     * @param artifacts     - list of artifacts to be deployed
+     * @param parentAppName - name of the parent cApp
+     */
+    private void undeployRegistryArtifacts(List<Artifact> artifacts, String parentAppName) {
+        artifacts.stream().filter(artifact -> REGISTRY_RESOURCE_TYPE.equals(artifact.getType())).forEach(artifact -> {
+            if (log.isDebugEnabled()) {
+                log.debug("Undeploying registry artifact: " + artifact.getName());
+            }
+            RegistryConfig regConfig = buildRegistryConfig(artifact, parentAppName);
+            removeArtifactFromRegistry(regConfig);
         });
     }
 
@@ -176,6 +202,29 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
             String resourcePath = AppDeployerUtils.computeResourcePath(createRegistryKey(resource),resource.getFileName());
             String mediaType = resource.getMediaType();
             lightweightRegistry.newNonEmptyResource(resourcePath, false, mediaType, readResourceContent(file), null);
+        }
+    }
+
+    /**
+     * Remove all registry contents (resources) of the given artifact from the registry.
+     *
+     * @param registryConfig - Artifact instance
+     */
+    private void removeArtifactFromRegistry(RegistryConfig registryConfig){
+
+        // get resources
+        List<RegistryConfig.Resourse> resources = registryConfig.getResources();
+        for (RegistryConfig.Resourse resource : resources) {
+            String filePath = registryConfig.getExtractedPath() + File.separator + AppDeployerConstants.RESOURCES_DIR
+                    + File.separator + resource.getFileName();
+            // check whether the file exists
+            File file = new File(filePath);
+            if (!file.exists()) {
+                log.error("Specified file to be removed as a resource is " + "not found at : " + filePath);
+                continue;
+            }
+            String resourcePath = AppDeployerUtils.computeResourcePath(createRegistryKey(resource),resource.getFileName());
+            lightweightRegistry.delete(resourcePath);
         }
     }
 


### PR DESCRIPTION
This is to add the logic to remove registry resources when the capp is getting undeployed

To fix : https://github.com/wso2/micro-integrator/issues/1735

