### PR TITLE
Fix EI-5133: Introduce a property to hide current params in the DSFault msg

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.common/src/main/java/org/wso2/micro/integrator/dataservices/common/DBConstants.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.common/src/main/java/org/wso2/micro/integrator/dataservices/common/DBConstants.java
@@ -84,6 +84,7 @@ public final class DBConstants {
     public static final String DATA_SERVICE_REQUEST_BOX_RESPONSE_WRAPPER_ELEMENT = "DATA_SERVICE_REQUEST_BOX_RESPONSE";
     public static final String SECURITY_MODULE_NAME = "rampart";
     public static final String TENANT_IN_ONLY_MESSAGE = "TENANT_IN_ONLY_MESSAGE";
+    public static final String DISABLE_CURRENT_PARAMS_IN_LOG = "dss.disable.current.params";
         
     /**
      * Codes to be used as fault codes.

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
@@ -257,6 +257,10 @@ public class DBUtils {
         }
     }
 
+    public static boolean isCurrentParamsDisabled () {
+        return Boolean.parseBoolean(System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG));
+    }
+
     private static OMFactory omFactory;
 
     /** pre-fetch the OMFactory */

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
@@ -126,7 +126,7 @@ public class DBUtils {
 
     private static HashMap<String, String> xsdSqlTypeMap = null;
 
-    private static String currentParamsDisabled;
+    private static String currentParamsDisabledProperty;
 
     /* initialize the conversion types */
 
@@ -260,11 +260,11 @@ public class DBUtils {
     }
 
     static {
-        currentParamsDisabled = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
+        currentParamsDisabledProperty = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
     }
 
-    public static String getCurrentParamsDisabled() {
-        return currentParamsDisabled;
+    public static String getCurrentParamsDisabledProperty() {
+        return currentParamsDisabledProperty;
     }
 
     private static OMFactory omFactory;

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
@@ -126,6 +126,8 @@ public class DBUtils {
 
     private static HashMap<String, String> xsdSqlTypeMap = null;
 
+    private static String currentParamsDisabled;
+
     /* initialize the conversion types */
 
     static {
@@ -257,14 +259,11 @@ public class DBUtils {
         }
     }
 
-    private static boolean currentParamsDisabled;
-
     static {
-        currentParamsDisabled = Boolean.parseBoolean(System.getProperty(DBConstants.
-                DISABLE_CURRENT_PARAMS_IN_LOG));
+        currentParamsDisabled = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
     }
 
-    public static boolean isCurrentParamsDisabled() {
+    public static String getCurrentParamsDisabled() {
         return currentParamsDisabled;
     }
 

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
@@ -257,8 +257,15 @@ public class DBUtils {
         }
     }
 
-    public static boolean isCurrentParamsDisabled () {
-        return Boolean.parseBoolean(System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG));
+    private static boolean currentParamsDisabled;
+
+    static {
+        currentParamsDisabled = Boolean.parseBoolean(System.getProperty(DBConstants.
+                DISABLE_CURRENT_PARAMS_IN_LOG));
+    }
+
+    public static boolean isCurrentParamsDisabled() {
+        return currentParamsDisabled;
     }
 
     private static OMFactory omFactory;

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
@@ -602,7 +602,7 @@ public class DataServiceDocLitWrappedSchemaGenerator {
         XmlSchemaComplexType type = createComplexType(cparams, DBConstants.WSO2_DS_NAMESPACE,
                 DBConstants.DS_FAULT_ELEMENT, false);
         element.setType(type);
-		if ("true".equalsIgnoreCase(DBUtils.getCurrentParamsDisabled())) {
+		if ("true".equalsIgnoreCase(DBUtils.getCurrentParamsDisabledProperty())) {
 			createAndAddSimpleStringElements(cparams, element,
 					DBConstants.FaultParams.CURRENT_REQUEST_NAME, DBConstants.FaultParams.NESTED_EXCEPTION);
 		} else {

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
@@ -602,7 +602,7 @@ public class DataServiceDocLitWrappedSchemaGenerator {
         XmlSchemaComplexType type = createComplexType(cparams, DBConstants.WSO2_DS_NAMESPACE,
                 DBConstants.DS_FAULT_ELEMENT, false);
         element.setType(type);
-		if (DBUtils.isCurrentParamsDisabled()) {
+		if ("true".equalsIgnoreCase(DBUtils.getCurrentParamsDisabled())) {
 			createAndAddSimpleStringElements(cparams, element,
 					DBConstants.FaultParams.CURRENT_REQUEST_NAME, DBConstants.FaultParams.NESTED_EXCEPTION);
 		} else {

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
@@ -602,8 +602,7 @@ public class DataServiceDocLitWrappedSchemaGenerator {
         XmlSchemaComplexType type = createComplexType(cparams, DBConstants.WSO2_DS_NAMESPACE,
                 DBConstants.DS_FAULT_ELEMENT, false);
         element.setType(type);
-		String isCurrentParamsDisabled = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
-		if ("true".equalsIgnoreCase(isCurrentParamsDisabled)) {
+		if (DBUtils.isCurrentParamsDisabled()) {
 			createAndAddSimpleStringElements(cparams, element,
 					DBConstants.FaultParams.CURRENT_REQUEST_NAME, DBConstants.FaultParams.NESTED_EXCEPTION);
 		} else {

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceDocLitWrappedSchemaGenerator.java
@@ -602,9 +602,15 @@ public class DataServiceDocLitWrappedSchemaGenerator {
         XmlSchemaComplexType type = createComplexType(cparams, DBConstants.WSO2_DS_NAMESPACE,
                 DBConstants.DS_FAULT_ELEMENT, false);
         element.setType(type);
-        createAndAddSimpleStringElements(cparams, element,
-                DBConstants.FaultParams.CURRENT_PARAMS, DBConstants.FaultParams.CURRENT_REQUEST_NAME,
-                DBConstants.FaultParams.NESTED_EXCEPTION);
+		String isCurrentParamsDisabled = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
+		if ("true".equalsIgnoreCase(isCurrentParamsDisabled)) {
+			createAndAddSimpleStringElements(cparams, element,
+					DBConstants.FaultParams.CURRENT_REQUEST_NAME, DBConstants.FaultParams.NESTED_EXCEPTION);
+		} else {
+			createAndAddSimpleStringElements(cparams, element,
+					DBConstants.FaultParams.CURRENT_PARAMS, DBConstants.FaultParams.CURRENT_REQUEST_NAME,
+					DBConstants.FaultParams.NESTED_EXCEPTION);
+		}
         XmlSchemaElement dataServiceElement = createElement(cparams, DBConstants.WSO2_DS_NAMESPACE,
                 DBConstants.FaultParams.SOURCE_DATA_SERVICE, false);
         XmlSchemaComplexType dataServiceComplexType = createComplexType(cparams, DBConstants.WSO2_DS_NAMESPACE,

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceFault.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceFault.java
@@ -197,7 +197,7 @@ public class DataServiceFault extends Exception {
 			buff.append("Current Request Name: " + this.getCurrentRequestName() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_REQUEST_NAME, this.getCurrentRequestName());
 		}
-		if (this.getCurrentParams() != null && !("true".equalsIgnoreCase(DBUtils.getCurrentParamsDisabled()))) {
+		if (this.getCurrentParams() != null && !("true".equalsIgnoreCase(DBUtils.getCurrentParamsDisabledProperty()))) {
 			buff.append("Current Params: " + this.getCurrentParams() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_PARAMS, this.getCurrentParams().toString());
 		}

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceFault.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceFault.java
@@ -197,7 +197,7 @@ public class DataServiceFault extends Exception {
 			buff.append("Current Request Name: " + this.getCurrentRequestName() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_REQUEST_NAME, this.getCurrentRequestName());
 		}
-		if (this.getCurrentParams() != null && !DBUtils.isCurrentParamsDisabled()) {
+		if (this.getCurrentParams() != null && !("true".equalsIgnoreCase(DBUtils.getCurrentParamsDisabled()))) {
 			buff.append("Current Params: " + this.getCurrentParams() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_PARAMS, this.getCurrentParams().toString());
 		}

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceFault.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceFault.java
@@ -197,8 +197,7 @@ public class DataServiceFault extends Exception {
 			buff.append("Current Request Name: " + this.getCurrentRequestName() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_REQUEST_NAME, this.getCurrentRequestName());
 		}
-		String isCurrentParamsDisabled = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
-		if (this.getCurrentParams() != null && !("true".equalsIgnoreCase(isCurrentParamsDisabled))) {
+		if (this.getCurrentParams() != null && !DBUtils.isCurrentParamsDisabled()) {
 			buff.append("Current Params: " + this.getCurrentParams() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_PARAMS, this.getCurrentParams().toString());
 		}

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceFault.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DataServiceFault.java
@@ -197,7 +197,8 @@ public class DataServiceFault extends Exception {
 			buff.append("Current Request Name: " + this.getCurrentRequestName() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_REQUEST_NAME, this.getCurrentRequestName());
 		}
-		if (this.getCurrentParams() != null) {
+		String isCurrentParamsDisabled = System.getProperty(DBConstants.DISABLE_CURRENT_PARAMS_IN_LOG);
+		if (this.getCurrentParams() != null && !("true".equalsIgnoreCase(isCurrentParamsDisabled))) {
 			buff.append("Current Params: " + this.getCurrentParams() + "\n");
             getPropertyMap().put(DBConstants.FaultParams.CURRENT_PARAMS, this.getCurrentParams().toString());
 		}


### PR DESCRIPTION
## Purpose

This is to fix wso2/product-ei#5133

If the current params should be hidden in the log file and then in the wsdl, the following system property should be enabled.
dss.disable.current.params=true