### PR TITLE
Fix transaction counter key factory algorithm

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/security/CryptoUtil.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/security/CryptoUtil.java
@@ -105,7 +105,7 @@ public class CryptoUtil {
         // decode to get the binary DER representation.
         byte[] publicKeyDER = Base64.getDecoder().decode(publicKeyPEM);
 
-        KeyFactory keyFactory = KeyFactory.getInstance(TransactionConstants.ENCRYPTION_ALGORITHM);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         return keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyDER));
     }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Fix transaction counter key factory algorithm

Currently when you start Micro-Integrator with transaction counter enabled, the following error will be printed.  This PR will fix it.

```
[2020-06-25 15:55:24,535] FATAL {ServiceBusInitializer} - Couldn't initialize the ESB... org.wso2.micro.integrator.initializer.handler.transaction.exception.TransactionCounterInitializationException: Error initializing Cipher
	at org.wso2.micro.integrator.initializer.handler.transaction.security.CryptoUtil.initializeCipher(CryptoUtil.java:71)
	at org.wso2.micro.integrator.initializer.handler.transaction.TransactionCountHandlerComponent.start(TransactionCountHandlerComponent.java:62)
	at org.wso2.micro.integrator.initializer.ServiceBusInitializer.activate(ServiceBusInitializer.java:201)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.internal.ds.model.ServiceComponent.activate(ServiceComponent.java:235)
	at org.eclipse.equinox.internal.ds.model.ServiceComponentProp.activate(ServiceComponentProp.java:146)
	at org.eclipse.equinox.internal.ds.model.ServiceComponentProp.build(ServiceComponentProp.java:345)
	at org.eclipse.equinox.internal.ds.InstanceProcess.buildComponent(InstanceProcess.java:620)
	at org.eclipse.equinox.internal.ds.InstanceProcess.buildComponents(InstanceProcess.java:197)
	at org.eclipse.equinox.internal.ds.Resolver.getEligible(Resolver.java:343)
	at org.eclipse.equinox.internal.ds.SCRManager.serviceChanged(SCRManager.java:222)
	at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:113)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:985)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:234)
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:151)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:866)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:804)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.register(ServiceRegistrationImpl.java:130)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.registerService(ServiceRegistry.java:228)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:525)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:544)
	at org.wso2.micro.integrator.ntask.core.internal.TasksDSComponent.activate(TasksDSComponent.java:147)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.internal.ds.model.ServiceComponent.activate(ServiceComponent.java:260)
	at org.eclipse.equinox.internal.ds.model.ServiceComponentProp.activate(ServiceComponentProp.java:146)
	at org.eclipse.equinox.internal.ds.model.ServiceComponentProp.build(ServiceComponentProp.java:345)
	at org.eclipse.equinox.internal.ds.InstanceProcess.buildComponent(InstanceProcess.java:620)
	at org.eclipse.equinox.internal.ds.InstanceProcess.buildComponents(InstanceProcess.java:197)
	at org.eclipse.equinox.internal.ds.Resolver.buildNewlySatisfied(Resolver.java:473)
	at org.eclipse.equinox.internal.ds.Resolver.enableComponents(Resolver.java:217)
	at org.eclipse.equinox.internal.ds.SCRManager.performWork(SCRManager.java:816)
	at org.eclipse.equinox.internal.ds.SCRManager$QueuedJob.dispatch(SCRManager.java:783)
	at org.eclipse.equinox.internal.ds.WorkThread.run(WorkThread.java:89)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.security.NoSuchAlgorithmException: RSA/ECB/OAEPwithSHA1andMGF1Padding KeyFactory not available
	at java.security.KeyFactory.<init>(KeyFactory.java:138)
	at java.security.KeyFactory.getInstance(KeyFactory.java:172)
	at org.wso2.micro.integrator.initializer.handler.transaction.security.CryptoUtil.loadPublicKey(CryptoUtil.java:108)
	at org.wso2.micro.integrator.initializer.handler.transaction.security.CryptoUtil.initializeCipher(CryptoUtil.java:63)
	... 39 more

```