### PR TITLE
Change default to false for JDBC Userstore ReadOnly property and fix typos in User store error messages

### DIFF
--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/common/AbstractUserStoreManager.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/common/AbstractUserStoreManager.java
@@ -3912,7 +3912,7 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
             UserStoreManager manager = entry.getValue();
             if (manager != null && ((AbstractUserStoreManager) manager).isSharedGroupEnabled()) {
                 if (sharedRoleManager != null) {
-                    throw new UserStoreException("There can not be more than one user store that support" +
+                    throw new UserStoreException("There cannot be more than one user store that support" +
                             "shared groups");
                 }
                 sharedRoleManager = manager;
@@ -5912,9 +5912,9 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
 
         if (!userExist) {
             if (isReadOnly()) {
-                String message = "Admin user can not be created in primary user store. " +
+                String message = "Admin user cannot be created in primary user store. " +
                         "User store is read only. " +
-                        "Please pick a user name which is exist in the primary user store as Admin user";
+                        "Please pick a user name which exists in the primary user store as Admin user";
                 if (initialSetup) {
                     throw new UserStoreException(message);
                 } else if (log.isDebugEnabled()) {
@@ -5941,9 +5941,9 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
                 }
             } else {
                 if (initialSetup) {
-                    String message = "Admin user can not be created in primary user store. " +
+                    String message = "Admin user cannot be created in primary user store. " +
                             "Add-Admin has been set to false. " +
-                            "Please pick a User name which is exist in the primary user store as Admin user";
+                            "Please pick a User name which exists in the primary user store as Admin user";
                     if (initialSetup) {
                         throw new UserStoreException(message);
                     } else if (log.isDebugEnabled()) {
@@ -5996,9 +5996,9 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
                     }
                 }
             } else {
-                String message = "Admin role can not be created in primary user store. " +
+                String message = "Admin role cannot be created in primary user store. " +
                         "Add-Admin has been set to false. " +
-                        "Please pick a Role name which is exist in the primary user store as Admin Role";
+                        "Please pick a Role name which exists in the primary user store as Admin Role";
                 if (initialSetup) {
                     throw new UserStoreException(message);
                 } else if (log.isDebugEnabled()) {
@@ -6040,7 +6040,7 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
                         }
                     }
                 } else {
-                    String message = "Admin user can not be assigned to Admin role " +
+                    String message = "Admin user cannot be assigned to Admin role " +
                             "Add-Admin has been set to false. Please do the assign it in user store level";
                     if (initialSetup) {
                         throw new UserStoreException(message);

--- a/distribution/src/resources/config-tool/deployment-full.toml
+++ b/distribution/src/resources/config-tool/deployment-full.toml
@@ -79,6 +79,7 @@ ldap_connection_timeout = 5000   #inferred          timeout in milliseconds
 read_timeout = '' # empty by default
 retry_attempts = '' # empty by default
 replace_escape_characters_at_user_login = true   #inferred
+read_only = false #inferred
 
 [authorization_manager]
 class = "org.wso2.micro.integrator.security.user.core.authorization.JDBCAuthorizationManager"   # inferred

--- a/distribution/src/resources/config-tool/infer.json
+++ b/distribution/src/resources/config-tool/infer.json
@@ -3,7 +3,7 @@
     "database": {
       "user_store.class": "org.wso2.micro.integrator.security.user.core.jdbc.JDBCUserStoreManager",
       "user_store.properties.TenantManager": "org.wso2.carbon.user.core.tenant.JDBCTenantManager",
-      "user_store.properties.ReadOnly": true,
+      "user_store.properties.ReadOnly": false,
       "user_store.properties.ReadGroups": true,
       "user_store.properties.WriteGroups": true,
       "user_store.properties.UsernameJavaRegEx": "^[\\S]{3,30}$",


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

- Change default to false for JDBC Userstore ReadOnly property. This will help creating default admin user when setting up a JDBC user store.
- Fix typos in User store error messages
