### PR TITLE
Make startup interval zero for Transaction Counter

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RequestCountResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RequestCountResource.java
@@ -76,13 +76,11 @@ public class RequestCountResource implements MiApiResource {
         if ("count".equalsIgnoreCase(pathParam)) {
             String yearParameter = Utils.getQueryParameter(synCtx, "year");
             String monthParameter = Utils.getQueryParameter(synCtx, "month");
-
             return handleTransactionCountCommand(axis2MessageContext, yearParameter, monthParameter);
 
         } else if ("report".equalsIgnoreCase(pathParam)) {
             String start = Utils.getQueryParameter(synCtx, "start");
             String end = Utils.getQueryParameter(synCtx, "end");
-
             return handleTransactionReportCommand(axis2MessageContext, start, end);
 
         } else {
@@ -206,8 +204,6 @@ public class RequestCountResource implements MiApiResource {
         if (null == transactionStore) {
             response = Utils.createJsonError("Transaction Count Handler component is not initialized", axisCtx,
                                              FORBIDDEN);
-            Utils.setJsonPayLoad(axisCtx, response);
-            return true;
         } else {
             String errorMessage;
             try {

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/TransactionCountHandlerComponent.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/TransactionCountHandlerComponent.java
@@ -118,7 +118,7 @@ public class TransactionCountHandlerComponent {
             } catch (Throwable e) {
                 LOG.error("Could not persist the transaction count: ", e);
             }
-        }, updateInterval, updateInterval, TimeUnit.MINUTES);
+        }, 0, updateInterval, TimeUnit.MINUTES);
     }
 
     /**

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/store/TransactionStore.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/handler/transaction/store/TransactionStore.java
@@ -67,7 +67,6 @@ public class TransactionStore {
      */
     public long getTransactionCountOfMonth(int year, int monthNumber) throws TransactionCounterException {
         return this.rdbmsConnector.getTransactionCountOfMonth(year, monthNumber);
-
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Make startup interval zero for Transaction Counter. This will ensure that there will be an entry in the database after the Node is started.