### PR TITLE
Fix VFS testcase failure

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/vfsTransport/ESBJAVA4770/deployment.toml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/vfsTransport/ESBJAVA4770/deployment.toml
@@ -13,7 +13,7 @@ type = "database"
 [transport.vfs] # enable by default
 
 listener.enable = true
-listener.keystore.file_name = "repository/resources/security/vfsKeystore.jks"
+listener.keystore.location = "repository/resources/security/vfsKeystore.jks"
 listener.keystore.type = "JKS"
 listener.keystore.password = "edcrfv"
 listener.keystore.key_password = "qazwsx"


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

With this PR https://github.com/wso2/micro-integrator/pull/1053, `transport.vfs.listener.keystore.file_name` has been renamed to `transport.vfs.listener.keystore.location`. This PR will address the testcase failure associated with that.