### PR TITLE
Fix log duplication in carbon-log-file

### DIFF
--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -309,24 +309,19 @@ logger.Owasp-CsrfGuard.level = WARN
 # Following are to log HTTP headers and messages
 logger.synapse-transport-http-headers.name=org.apache.synapse.transport.http.headers
 logger.synapse-transport-http-headers.level=OFF
-logger.synapse-transport-http-headers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.synapse-transport-http-wire.name=org.apache.synapse.transport.http.wire
 logger.synapse-transport-http-wire.level=OFF
-logger.synapse-transport-http-wire.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 # Following entries are to see HTTP headers and messages of Callout mediator/MessageProcessor
 logger.httpclient-wire-header.name=httpclient.wire.header
 logger.httpclient-wire-header.level=OFF
-logger.httpclient-wire-header.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.httpclient-wire-content.name=httpclient.wire.content
 logger.httpclient-wire-content.level=OFF
-logger.httpclient-wire-content.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.name = org.apache.axis2.wsdl.codegen.writer.PrettyPrinter
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.level = ERROR
-logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-axis2-clustering.name = org.apache.axis2.clustering
 logger.org-apache-axis2-clustering.level = INFO
@@ -335,7 +330,6 @@ logger.org-apache-axis2-clustering.additivity = false
 logger.org-apache.name = org.apache
 logger.org-apache.level = INFO
 logger.org-apache.additivity = false
-logger.org-apache.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-catalina.name = org.apache.catalina
 logger.org-apache-catalina.level = ERROR
@@ -401,40 +395,31 @@ logger.org-wso2.level = ERROR
 
 logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
 logger.org-apache-axis-enterprise.level = FATAL
-logger.org-apache-axis-enterprise.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-directory-shared-ldap.name = org.apache.directory.shared.ldap
 logger.org-apache-directory-shared-ldap.level = WARN
-logger.org-apache-directory-shared-ldap.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-directory-server-ldap-handlers.name = org.apache.directory.server.ldap.handlers
 logger.org-apache-directory-server-ldap-handlers.level = WARN
-logger.org-apache-directory-server-ldap-handlers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 #Following are to remove false error messages from startup (IS)
 logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.name = org.apache.directory.shared.ldap.entry.DefaultServerAttribute
 logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.level = FATAL
-logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-directory-server-core-DefaultDirectoryService.name = org.apache.directory.server.core.DefaultDirectoryService
 logger.org-apache-directory-server-core-DefaultDirectoryService.level = ERROR
-logger.org-apache-directory-server-core-DefaultDirectoryService.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-directory-shared-ldap-ldif-LdifReader.name = org.apache.directory.shared.ldap.ldif.LdifReader
 logger.org-apache-directory-shared-ldap-ldif-LdifReader.level = ERROR
-logger.org-apache-directory-shared-ldap-ldif-LdifReader.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-directory-server-ldap-LdapProtocolHandler.name = org.apache.directory.server.ldap.LdapProtocolHandler
 logger.org-apache-directory-server-ldap-LdapProtocolHandler.level = ERROR
-logger.org-apache-directory-server-ldap-LdapProtocolHandler.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-directory-server-core.name = org.apache.directory.server.core
 logger.org-apache-directory-server-core.level = ERROR
-logger.org-apache-directory-server-core.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.org-apache-directory-server-ldap-LdapSession.name = org.apache.directory.server.ldap.LdapSession
 logger.org-apache-directory-server-ldap-LdapSession.level = Error
-logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 
 logger.correlation.name = correlation
 logger.correlation.level = INFO


### PR DESCRIPTION
## Purpose
Fix log duplication in wso2carbon.log file
Removing appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE from individual loggers. Because rootLogger will append logs to CARBON_LOGFILE,
`rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE`

Fixes https://github.com/wso2/micro-integrator/issues/1832