### PR TITLE
Improve error message when try to retrieve non existing message store/processor

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/MessageProcessorResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/MessageProcessorResource.java
@@ -144,7 +144,7 @@ public class MessageProcessorResource extends APIResource {
         if (Objects.nonNull(messageProcessor)) {
             Utils.setJsonPayLoad(axis2MessageContext, getMessageProcessorAsJson(messageProcessor));
         } else {
-            Utils.setJsonPayLoad(axis2MessageContext, Utils.createJsonErrorObject("Message processor does not exist"));
+            Utils.setJsonPayLoad(axis2MessageContext, Utils.createJsonError("Specified message processor ('" + name + "') not found", axis2MessageContext, Constants.NOT_FOUND));
         }
     }
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/MessageStoreResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/MessageStoreResource.java
@@ -117,7 +117,7 @@ public class MessageStoreResource implements MiApiResource {
             Utils.setJsonPayLoad(axis2MessageContext, getMessageStoreAsJson(messageStore));
         } else {
             LOG.warn("Message store " + messageStoreName + " does not exist");
-            Utils.setJsonPayLoad(axis2MessageContext, Utils.createJsonErrorObject("Message store does not exist"));
+            Utils.setJsonPayLoad(axis2MessageContext, Utils.createJsonError("Specified message store ('" + messageStoreName + "') not found", axis2MessageContext, Constants.NOT_FOUND));
         }
     }
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/micro-integrator/issues/973

When trying to retrieve the details of non-existing message store/message processor using the CLI, it returns empty keys. This PR fixes the issue by printing a consistent message as of other resources.
![image](https://user-images.githubusercontent.com/29911181/87520682-f07cd000-c6a0-11ea-8c17-29f68ce375b0.png)
