### PR TITLE
Fix Failure of UserManagementTests.testDeleteUser

### DIFF
--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/hybrid/HybridRoleManager.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/hybrid/HybridRoleManager.java
@@ -36,9 +36,9 @@ public class HybridRoleManager {
     private static Log log = LogFactory.getLog(JDBCUserStoreManager.class);
     protected UserRealm userRealm;
     protected UserRolesCache userRolesCache = null;
-    int tenantId;
-    private RealmConfiguration realmConfig;
-    private boolean userRolesCacheEnabled = true;
+    protected int tenantId;
+    protected RealmConfiguration realmConfig;
+    protected boolean userRolesCacheEnabled = true;
 
     public HybridRoleManager(int tenantId, RealmConfiguration realmConfig, UserRealm realm) {
         this.tenantId = tenantId;

--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/hybrid/JdbcHybridRoleManager.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/hybrid/JdbcHybridRoleManager.java
@@ -44,11 +44,8 @@ public class JdbcHybridRoleManager extends HybridRoleManager {
     private static Log log = LogFactory.getLog(JDBCUserStoreManager.class);
     private final int DEFAULT_MAX_ROLE_LIST_SIZE = 1000;
     private final int DEFAULT_MAX_SEARCH_TIME = 1000;
-    int tenantId;
     private DataSource dataSource;
-    private RealmConfiguration realmConfig;
     private String isCascadeDeleteEnabled;
-    private boolean userRolesCacheEnabled = true;
     private static final String APPLICATION_DOMAIN = "Application";
     private static final String WORKFLOW_DOMAIN = "Workflow";
 


### PR DESCRIPTION
## Purpose
UserManagementTests.testDeleteUser fails in jenkins with the following stack trace:
```
 [2020-07-16 05:22:49,326] ERROR {Utils} - Error initializing the user store. Please try again later org.wso2.micro.integrator.security.user.core.UserStoreException: Error occurred while accessing Java Security Manager Privilege Block when called by method deleteUser with 1 length of Objects and argTypes [class java.lang.String]
 	at org.wso2.micro.integrator.security.user.core.common.AbstractUserStoreManager.callSecure(AbstractUserStoreManager.java:193)
 	at org.wso2.micro.integrator.security.user.core.common.AbstractUserStoreManager.deleteUser(AbstractUserStoreManager.java:2188)
 	at org.wso2.micro.integrator.management.apis.UserResource.handleDelete(UserResource.java:139)
 	at org.wso2.micro.integrator.management.apis.UserResource.invoke(UserResource.java:86)
 	at org.wso2.micro.integrator.management.apis.ApiResourceAdapter.invoke(ApiResourceAdapter.java:55)
 	at org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIDispatcher.dispatch(InternalAPIDispatcher.java:86)
 	at org.wso2.carbon.inbound.endpoint.protocol.http.InboundHttpServerWorker.run(InboundHttpServerWorker.java:109)
 	at org.apache.axis2.transport.base.threads.NativeWorkerPool$1.run(NativeWorkerPool.java:172)
 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
 	at java.lang.Thread.run(Thread.java:748)
 Caused by: java.security.PrivilegedActionException: java.lang.reflect.InvocationTargetException
 	at java.security.AccessController.doPrivileged(Native Method)
 	at org.wso2.micro.integrator.security.user.core.common.AbstractUserStoreManager.callSecure(AbstractUserStoreManager.java:172)
 	... 10 more
 Caused by: java.lang.reflect.InvocationTargetException
 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.lang.reflect.Method.invoke(Method.java:498)
 	at org.wso2.micro.integrator.security.user.core.common.AbstractUserStoreManager$2.run(AbstractUserStoreManager.java:175)
 	... 12 more
 Caused by: java.lang.NullPointerException
 	at org.wso2.micro.integrator.security.user.core.util.UserCoreUtil.getDomainName(UserCoreUtil.java:552)
 	at org.wso2.micro.integrator.security.user.core.hybrid.JdbcHybridRoleManager.getMyDomainName(JdbcHybridRoleManager.java:891)
 	at org.wso2.micro.integrator.security.user.core.hybrid.JdbcHybridRoleManager.deleteUser(JdbcHybridRoleManager.java:822)
 	at org.wso2.micro.integrator.security.user.core.common.AbstractUserStoreManager.deleteUser(AbstractUserStoreManager.java:2255)
 	... 17 more
```

This is because the property realmConfig is set as a private field while it is initialized only in the super class HybridRoleManager. The resolution is to make the field protected.