### PR TITLE
Correct default ConnectionDelay for LDAP

### DIFF
--- a/distribution/src/resources/config-tool/infer.json
+++ b/distribution/src/resources/config-tool/infer.json
@@ -54,7 +54,7 @@
       "user_store.properties.ConnectionPoolingEnabled": true,
       "user_store.properties.LDAPConnectionTimeout": "5000",
       "user_store.properties.ReplaceEscapeCharactersAtUserLogin": true,
-      "user_store.properties.ConnectionRetryDelay": "2",
+      "user_store.properties.ConnectionRetryDelay": "120000",
       "user_store.properties.EnableMaxUserLimitForSCIM": "false"
     },
     "read_write_ldap": {
@@ -94,7 +94,7 @@
       "user_store.properties.ConnectionPoolingEnabled": true,
       "user_store.properties.LDAPConnectionTimeout": "5000",
       "user_store.properties.ReplaceEscapeCharactersAtUserLogin": true,
-      "user_store.properties.ConnectionRetryDelay": "2",
+      "user_store.properties.ConnectionRetryDelay": "120000",
       "user_store.properties.EnableMaxUserLimitForSCIM": "false"
     }
   },


### PR DESCRIPTION
The default should be 2min where as it has been added as 2ms