### PR TITLE
Fix CLI Tests

### DIFF
--- a/integration/cli-tests/src/test/java/org/wso2/micro/integrator/cli/CliEndpointTestCase.java
+++ b/integration/cli-tests/src/test/java/org/wso2/micro/integrator/cli/CliEndpointTestCase.java
@@ -47,9 +47,9 @@ public class CliEndpointTestCase extends AbstractCliTest {
         Assert.assertEquals(outputForCLICommand.size(), 3);
         // 3: Table heading, SimpleEP, SimpleStockQuoteServiceEndpoint
 
-        final String TABLE_HEADING = "NAME                              TYPE      METHOD   URL";
-        final String SIMPLE_EP_TABLE_ROW = "SimpleEP                          address";
-        final String STOCK_EP_TABLE_ROW = "SimpleStockQuoteServiceEndpoint   address";
+        final String TABLE_HEADING = "NAME                              TYPE      Active";
+        final String SIMPLE_EP_TABLE_ROW = "SimpleEP                          address   true";
+        final String STOCK_EP_TABLE_ROW = "SimpleStockQuoteServiceEndpoint   address   true";
 
         Assert.assertEquals(outputForCLICommand.get(0), TABLE_HEADING);
         Assert.assertTrue(outputForCLICommand.contains(SIMPLE_EP_TABLE_ROW));


### PR DESCRIPTION
Since empty fields are skipped with
https://github.com/wso2/product-mi-tooling/pull/77/commits/fa4d5bc707ac9a5aa4a9f27d6d91b2d12ffeca0e
and Active param is included in the output