### PR TITLE
Fix Data Mapper failure in MI when DMC file contains single line comments

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -77,6 +77,8 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
     private static final String METADATA_FILE_SUFFIX = ".meta";
     private static final String METADATA_KEY_MEDIA_TYPE = "mediaType";
 
+    private static final String NEW_LINE_CHAR = System.getProperty("line.separator");
+
     private static final int FILE = 1;
     private static final int HTTP = 2;
     private static final int HTTPS = 3;
@@ -1007,6 +1009,7 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                     String line;
                     while ((line = bReader.readLine()) != null) {
                         strBuilder.append(line);
+                        strBuilder.append(NEW_LINE_CHAR);
                     }
                 }
                 return OMAbstractFactory.getOMFactory().createOMText(strBuilder.toString());

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/test/java/org/wso2/micro/integrator/registry/TestMicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/test/java/org/wso2/micro/integrator/registry/TestMicroIntegratorRegistry.java
@@ -120,7 +120,7 @@ public class TestMicroIntegratorRegistry {
     @Test
     public void testRegistryResourceReadWithEmptyMediaType() {
         OMNode omNode = microIntegratorRegistry.lookup("conf:/custom/QueueName");
-        Assert.assertEquals("File content should be as expected","ordersQueue", ((OMTextImpl) omNode).getText());
+        Assert.assertEquals("File content should be as expected","ordersQueue", ((OMTextImpl) omNode).getText().trim());
     }
 
     @AfterClass


### PR DESCRIPTION
Fix wso2/micro-integrator#1903
When there is a single line comment MI identifies the rest of the content after the comment section as well as a comment. Therefore appended a new line after each line reads.