### PR TITLE
Change deployment.toml keystore table name.

### DIFF
--- a/distribution/src/conf/deployment.toml
+++ b/distribution/src/conf/deployment.toml
@@ -5,7 +5,7 @@ hostname = "localhost"
 [user_store]
 type = "read_only_ldap"
 
-[keystore.tls]
+[keystore.primary]
 file_name = "wso2carbon.jks"
 password = "wso2carbon"
 alias = "wso2carbon"

--- a/distribution/src/conf/deployment.toml.container
+++ b/distribution/src/conf/deployment.toml.container
@@ -5,7 +5,7 @@ hot_deployment = false
 [user_store]
 type = "read_only_ldap"
 
-[keystore.tls]
+[keystore.primary]
 file_name = "wso2carbon.jks"
 password = "wso2carbon"
 alias = "wso2carbon"


### PR DESCRIPTION
## Purpose
> Related to: https://github.com/wso2/micro-integrator/pull/1053
> Changes made to the deployment.toml keystore section will not take effect due to inconsistent table names.
