### PR TITLE
Fix appending new line character to last line, for single line texts

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -1011,6 +1011,11 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                         strBuilder.append(line);
                         strBuilder.append(NEW_LINE_CHAR);
                     }
+                    // need to remove new_line_charater from the last line, for single line texts
+                    int length = strBuilder.length();
+                    if (length != 0) {
+                        strBuilder.setLength(length - NEW_LINE_CHAR.length());
+                    }
                 }
                 return OMAbstractFactory.getOMFactory().createOMText(strBuilder.toString());
             } else {


### PR DESCRIPTION
## Purpose
With the fix done in [1] we append a new line after each line read. We need to handle the scenarios where we have only a single line text.

Related issue https://github.com/wso2/micro-integrator/issues/1952

[1] https://github.com/wso2/micro-integrator/pull/1908