### PR TITLE
Add service component for ESB to MI password migration.

### DIFF
--- a/migration/migration-service/pom.xml
+++ b/migration/migration-service/pom.xml
@@ -56,6 +56,16 @@
             <artifactId>org.wso2.micro.integrator.mediation.security</artifactId>
             <version>${migration.from.mi.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.registry</groupId>
+            <artifactId>org.wso2.carbon.registry.properties</artifactId>
+            <version>${carbon.registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.mediation</groupId>
+            <artifactId>org.wso2.carbon.mediation.security</artifactId>
+            <version>4.7.33</version>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -64,6 +74,7 @@
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <migration.from.mi.version>1.1.0</migration.from.mi.version>
         <org.osgi.version>1.3.0</org.osgi.version>
+        <carbon.registry.version>4.7.24</carbon.registry.version>
     </properties>
 
     <build>
@@ -98,8 +109,9 @@
                             org.wso2.mi.migration.internal
                         </Private-Package>
                         <Import-Package>
+                            org.wso2.carbon.mediation.security.vault; resolution:=optional,
                             org.wso2.securevault,
-                            org.wso2.micro.integrator.mediation.security.vault; version="${migration.from.mi.version}",
+                            org.wso2.micro.integrator.mediation.security.vault; version="${migration.from.mi.version}"; resolution:=optional,
                             org.apache.commons.logging; version="${commons.logging.version}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                         </Import-Package>

--- a/migration/migration-service/src/main/java/org/wso2/mi/migration/internal/EIMigrationServiceComponent.java
+++ b/migration/migration-service/src/main/java/org/wso2/mi/migration/internal/EIMigrationServiceComponent.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.mi.migration.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.mi.migration.migrate.ei.EIPasswordMigrationClient;
+
+/**
+ * This class implements the secret migration service component for EI and ESB.
+ */
+
+@Component(
+        name = "org.wso2.ei.migration.client",
+        immediate = true)
+public class EIMigrationServiceComponent {
+
+    private static final Log log = LogFactory.getLog(EIMigrationServiceComponent.class);
+
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        log.info("WSO2 EI to MI migration bundle is activated");
+        String product = System.getProperty("migrate.from.product.version");
+        // Supports both EI and ESB. If changes need to be done with specific versions,
+        // include an inner if block as needed.
+        if (product.contains("esb")) {
+            migrateSecrets(true);
+        } else if (product.contains("ei")){
+           migrateSecrets(false);
+        } else {
+            log.error("Provided product version is invalid");
+        }
+        System.exit(0);
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext context) {
+        log.info("WSO2 EI to MI migration bundle is deactivated");
+    }
+
+    @Reference(
+            name = "registry.service",
+            service = org.wso2.carbon.registry.core.service.RegistryService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRegistryService")
+    protected void setRegistryService(RegistryService registryService) {
+        EIRegistryDataHolder.setRegistryService(registryService);
+    }
+
+    protected void unsetRegistryService(RegistryService registryService) {
+        EIRegistryDataHolder.setRegistryService(null);
+    }
+
+    /**
+     * Migrate passwords
+     */
+    private void migrateSecrets(Boolean isESB) {
+        log.info("Initiating WSO2 EI password migration");
+        try {
+            EIPasswordMigrationClient eiMigrationClient = new EIPasswordMigrationClient();
+            eiMigrationClient.migratePasswords(isESB);
+            log.info("Successfully completed password migration");
+        } catch (Throwable e) {
+            log.error("Error while migrating secure vault passwords", e);
+        }
+    }
+}

--- a/migration/migration-service/src/main/java/org/wso2/mi/migration/internal/EIRegistryDataHolder.java
+++ b/migration/migration-service/src/main/java/org/wso2/mi/migration/internal/EIRegistryDataHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.mi.migration.internal;
+
+import org.wso2.carbon.registry.core.service.RegistryService;
+
+public class EIRegistryDataHolder {
+
+    private static RegistryService registryService;
+
+    /**
+     * Method to get RegistryService.
+     *
+     * @return registryService.
+     */
+    public static RegistryService getRegistryService() {
+        return registryService;
+    }
+
+    /**
+     * Method to set registry RegistryService.
+     *
+     * @param service registryService.
+     */
+    public static void setRegistryService(RegistryService service) {
+        registryService = service;
+    }
+}

--- a/migration/migration-service/src/main/java/org/wso2/mi/migration/internal/MIMigrationServiceComponent.java
+++ b/migration/migration-service/src/main/java/org/wso2/mi/migration/internal/MIMigrationServiceComponent.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.wso2.mi.migration.migrate.PasswordMigrationClient;
+import org.wso2.mi.migration.migrate.mi.MIPasswordMigrationClient;
 
 @Component(
         name = "org.wso2.mi.migration.client",
@@ -38,7 +38,7 @@ public class MIMigrationServiceComponent {
 
         log.info("WSO2 MI migration bundle is activated");
         // current support is only for mi110 -> mi120
-        if (System.getProperty("migrate.from.product.version").startsWith("110")) {
+        if (System.getProperty("migrate.from.product.version").startsWith("mi110")) {
             migratePasswords();
         } else {
             log.error("Provided product version is invalid");
@@ -57,7 +57,7 @@ public class MIMigrationServiceComponent {
     private void migratePasswords() {
         log.info("Initiating WSO2 MI password migration");
         try {
-            PasswordMigrationClient passwordMigrationClient = new PasswordMigrationClient();
+            MIPasswordMigrationClient passwordMigrationClient = new MIPasswordMigrationClient();
             passwordMigrationClient.migratePasswords();
             log.info("Successfully completed password migration");
         } catch (Throwable e) {

--- a/migration/migration-service/src/main/java/org/wso2/mi/migration/migrate/MigrationConstants.java
+++ b/migration/migration-service/src/main/java/org/wso2/mi/migration/migrate/MigrationConstants.java
@@ -28,4 +28,8 @@ public class MigrationConstants {
     public static final String MIGRATION_CONF = "migration-conf.properties";
     public static final String KEYSTORE_PASSWORD = "keystore.identity.key.password";
     public static final String KEYSTORE_LOCATION = "keystore.identity.location";
+    public static final String SECURE_VAULT_PATH = "/_system/config/repository/components/secure-vault";
+    public static final String ADMIN_USERNAME = "admin.user.name";
+    public static final String RSA = "RSA";
+    public static final String CIPHER_TRANSFORMATION_SYSTEM_PROPERTY = "org.wso2.CipherTransformation";
 }

--- a/migration/migration-service/src/main/java/org/wso2/mi/migration/migrate/ei/EIPasswordMigrationClient.java
+++ b/migration/migration-service/src/main/java/org/wso2/mi/migration/migrate/ei/EIPasswordMigrationClient.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.mi.migration.migrate.ei;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.mediation.security.vault.CipherInitializer;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.mi.migration.internal.EIRegistryDataHolder;
+import org.wso2.mi.migration.migrate.MigrationClientConfig;
+import org.wso2.mi.migration.migrate.MigrationClientException;
+import org.wso2.mi.migration.migrate.MigrationConstants;
+import org.wso2.mi.migration.utils.MigrationIOUtils;
+import org.wso2.securevault.DecryptionProvider;
+import org.wso2.securevault.secret.SecretManager;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Decrypts secure vault entries in the registry and entries in the cipher-text.properties
+ */
+public class EIPasswordMigrationClient {
+
+    private static final String SECURE_VAULT_PATH = MigrationConstants.SECURE_VAULT_PATH;
+    private UserRegistry userRegistry;
+    private Resource userRegistryResource;
+    private String carbonHome = System.getProperty(MigrationConstants.CARBON_HOME);
+    private String ESB_CIPHER_TEXT_PATH = Paths.get(carbonHome, "repository","conf", "security",
+            "cipher-text.properties").toString();
+    private String EI_CIPHER_TEXT_PATH = Paths.get(carbonHome, "conf", "security",
+            "cipher-text.properties").toString();
+
+    private static final Log log = LogFactory.getLog(EIPasswordMigrationClient.class);
+
+    public EIPasswordMigrationClient() throws RegistryException {
+        String adminUserName = MigrationClientConfig.getInstance()
+                .getMigrationConfiguration()
+                .getProperty(MigrationConstants.ADMIN_USERNAME);
+        if (adminUserName.isEmpty()) {
+            throw new MigrationClientException("Invalid admin username");
+        }
+
+        this.userRegistry = EIRegistryDataHolder.getRegistryService().getRegistry(adminUserName);
+        this.userRegistryResource = userRegistry.get(SECURE_VAULT_PATH);
+    }
+
+
+    /**
+     * filter registry properties and extract only system properties
+     *
+     * @param userRegistryResourceProperties resource properties
+     * @return secure vault properties
+     */
+    private Map<String, String> getSecureVaultProperties(Properties userRegistryResourceProperties) {
+        Map<String, String> systemProperties = new HashMap<>();
+
+        Set<Object> keys = userRegistryResourceProperties.keySet();
+        for (Object key: keys){
+            if (!key.toString().startsWith("registry")) {
+                systemProperties.put(key.toString(), userRegistryResource.getProperty(key.toString()));
+            }
+        }
+        return systemProperties;
+    }
+
+    /**
+     * decrypt  passwords using RSA algorithm
+     *
+     * @param secureVaultProperties secure vault property-value map
+     * @return decrypted passwords
+     */
+    private Map<String, String> getDecryptedPasswords(Map<String, String> secureVaultProperties) {
+        Map<String, String> decryptedPasswords = new HashMap<>();
+        DecryptionProvider decryptionProvider = CipherInitializer.getInstance().getDecryptionProvider();
+        if (decryptionProvider == null) {
+            // This cannot happen unless someone mess with OSGI references
+            throw new MigrationClientException("Secret repository has not been initialized.");
+        }
+
+        secureVaultProperties.forEach((alias, password) -> {
+            String decryptedPassword = new String(decryptionProvider.decrypt(password.getBytes()));
+            decryptedPasswords.put(alias, decryptedPassword);
+        });
+        return decryptedPasswords;
+    }
+
+    /**
+     * Decrypt passwords using RSA and encrypt passwords and migrate passwords
+     */
+    public void migratePasswords(Boolean isESB) {
+        MigrationIOUtils.createMigrationDirectoryIfNotExists();
+        migrateSecureVaultPasswords();
+        migrateCipherTextProperties(isESB);
+    }
+
+    /**
+     * Writes decrypted secure-vault registry entries to a file.
+     */
+    private void migrateSecureVaultPasswords() {
+        Properties userRegistryResourceProperties = userRegistryResource.getProperties();
+        Map<String, String> secureVaultProperties = getSecureVaultProperties(userRegistryResourceProperties);
+        Map<String, String> decryptedPasswords = getDecryptedPasswords(secureVaultProperties);
+        MigrationIOUtils.writePropertiesFile("secure-vault-decrypted.properties", decryptedPasswords);
+    }
+
+
+    /**
+     * Writes decrypted cipher-text.properties entries to a file.
+     */
+    private void migrateCipherTextProperties(Boolean isESB) {
+
+        String cipherTextPath = ESB_CIPHER_TEXT_PATH;
+        if (!isESB){
+            cipherTextPath = EI_CIPHER_TEXT_PATH;
+        }
+        Map<String, String> cipherTextProperties =  MigrationIOUtils.getProperties(cipherTextPath);
+        Map<String, String> decryptedPasswords = new HashMap<>();
+        SecretManager manager = SecretManager.getInstance();
+        cipherTextProperties.forEach((alias, encryptedValue) -> {
+            String decyptedValue = manager.getSecret(alias);
+            decryptedPasswords.put(alias, decyptedValue);
+        });
+        MigrationIOUtils.writePropertiesFile("cipher-text-decrypted.properties", decryptedPasswords);
+    }
+}

--- a/migration/migration-service/src/main/java/org/wso2/mi/migration/utils/MigrationIOUtils.java
+++ b/migration/migration-service/src/main/java/org/wso2/mi/migration/utils/MigrationIOUtils.java
@@ -20,12 +20,15 @@ package org.wso2.mi.migration.utils;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.mi.migration.migrate.MigrationClientException;
 import org.wso2.mi.migration.migrate.MigrationConstants;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -73,5 +76,21 @@ public class MigrationIOUtils {
             map.put(name, properties.getProperty(name));
         }
         return map;
+    }
+
+    public static void writePropertiesFile(String fileName, Map<String, String> propertyMap) {
+
+        String filePath = Paths.get(carbonHome, MigrationConstants.MIGRATION_DIR, fileName).toString();
+        Properties properties = new Properties();
+        propertyMap.forEach((alias, decryptedValue) -> {
+            properties.setProperty(alias, decryptedValue);
+        });
+
+        try (OutputStream outputStream = new FileOutputStream(filePath)) {
+            properties.store(outputStream, null);
+        } catch (IOException e) {
+            log.error("Error while writing file " + filePath, e);
+            throw new MigrationClientException("Error while writing file " + filePath, e);
+        }
     }
 }


### PR DESCRIPTION
## Purpose
> Add a separate service component for secret migration from ESB to MI-1.2.0.

> For EI and ESB follows the steps as follows
- Create a directory in CARBON_HOME named, **migration**.
- Add migration-conf.properties file with admin user name.
```
admin.user.name=admin
```
 > Start the server with following param.
-Dmigrate.from.product.version=ei
-Dmigrate.from.product.version=esb



