### PR TITLE
Throw exception when target property name is empty in DSS Call Mediator

### DIFF
--- a/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediator.java
+++ b/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediator.java
@@ -222,7 +222,8 @@ public class DataServiceCallMediator extends AbstractMediator {
                 if (targetDynamicName != null) {
                     targetPropertyName = targetDynamicName.evaluateValue(messageContext);
                     if (StringUtils.isEmpty(targetPropertyName)) {
-                        log.warn("Evaluated value for " + targetPropertyName + " is empty");
+                        handleException("Target type is set to property. Evaluated value for target " +
+                                "property name is null or empty", messageContext);
                     }
                 }
                 messageContext.setProperty(targetPropertyName, omElement);


### PR DESCRIPTION
## Purpose
In DSS Call Mediator, when the target type is set to property, we need to configure the property name. With dynamic property name support, the name of the configured target property may result in null. In that case, we print a warning log and continue the mediation.

From this PR we throw an exception if the configured dynamic property name becomes null.