### PR TITLE
Refactor dataServicesCallMediator to dataServiceCallMediator

### DIFF
--- a/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediatorConstants.java
+++ b/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediatorConstants.java
@@ -28,7 +28,7 @@ public class DataServiceCallMediatorConstants {
     public static final String TARGET_BODY_TYPE = "body";
     public static final String JSON_TYPE = "json";
     public static final String XML_TYPE = "xml";
-    public static final String DATA_SERVICES_CALL = "dataServicesCall";
+    public static final String DATA_SERVICE_CALL = "dataServiceCall";
     public static final String SERVICE_NAME = "serviceName";
     public static final String OPERATIONS = "operations";
     public static final String OPERATION = "operation";

--- a/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediatorFactory.java
+++ b/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediatorFactory.java
@@ -69,7 +69,7 @@ public class DataServiceCallMediatorFactory extends AbstractMediatorFactory {
     private static final Log log = LogFactory.getLog(DataServiceCallMediatorFactory.class);
 
     private static final QName DSSCALL_Q =
-            new QName(SynapseConstants.SYNAPSE_NAMESPACE, DataServiceCallMediatorConstants.DATA_SERVICES_CALL);
+            new QName(SynapseConstants.SYNAPSE_NAMESPACE, DataServiceCallMediatorConstants.DATA_SERVICE_CALL);
     private static final QName SOURCE_Q = new QName(
             XMLConfigConstants.SYNAPSE_NAMESPACE, DataServiceCallMediatorConstants.SOURCE);
     private static final QName TARGET_Q = new QName(

--- a/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediatorSerializer.java
+++ b/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediatorSerializer.java
@@ -44,7 +44,7 @@ public class DataServiceCallMediatorSerializer extends AbstractMediatorSerialize
         }
 
         DataServiceCallMediator mediator = (DataServiceCallMediator) m;
-        OMElement dsCallEle = fac.createOMElement(DataServiceCallMediatorConstants.DATA_SERVICES_CALL, synNS);
+        OMElement dsCallEle = fac.createOMElement(DataServiceCallMediatorConstants.DATA_SERVICE_CALL, synNS);
         OMElement sourceEle = fac.createOMElement(DataServiceCallMediatorConstants.SOURCE, synNS);
         OMElement targetEle = fac.createOMElement(DataServiceCallMediatorConstants.TARGET, synNS);
         OMAttribute serviceName = fac.createOMAttribute(DataServiceCallMediatorConstants.SERVICE_NAME, nullNS,

--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorInlineBatchRequestProxy.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorInlineBatchRequestProxy.xml
@@ -23,7 +23,7 @@
     <description/>
     <target>
         <inSequence>
-            <dataServicesCall serviceName="DSSCallMediatorTest">
+            <dataServiceCall serviceName="DSSCallMediatorTest">
                 <source type="inline"/>
                 <operations type="batch_req">
                     <operation name="addEmployee">
@@ -42,7 +42,7 @@
                     </operation>
                 </operations>
                 <target type="body"/>
-            </dataServicesCall>
+            </dataServiceCall>
             <respond/>
         </inSequence>
     </target>

--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorInlineRequestBoxProxy.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorInlineRequestBoxProxy.xml
@@ -23,7 +23,7 @@
     <description/>
     <target>
         <inSequence>
-            <dataServicesCall serviceName="DSSCallMediatorTest">
+            <dataServiceCall serviceName="DSSCallMediatorTest">
                 <source type="inline"/>
                 <operations type="request_box">
                     <operation name="addEmployee">
@@ -38,7 +38,7 @@
                     </operation>
                 </operations>
                 <target type="body"/>
-            </dataServicesCall>
+            </dataServiceCall>
             <respond/>
         </inSequence>
     </target>

--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorInlineSingleRequestProxy.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorInlineSingleRequestProxy.xml
@@ -23,7 +23,7 @@
     <description/>
     <target>
         <inSequence>
-            <dataServicesCall serviceName="DSSCallMediatorTest">
+            <dataServiceCall serviceName="DSSCallMediatorTest">
                 <source type="inline"/>
                 <operations type="single_req">
                     <operation name="addEmployee">
@@ -35,7 +35,7 @@
                     </operation>
                 </operations>
                 <target type="body"/>
-            </dataServicesCall>
+            </dataServiceCall>
             <respond/>
         </inSequence>
     </target>

--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorSourceTypeBodyProxy.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorSourceTypeBodyProxy.xml
@@ -23,10 +23,10 @@
     <description/>
     <target>
         <inSequence>
-            <dataServicesCall serviceName="DSSCallMediatorTest">
+            <dataServiceCall serviceName="DSSCallMediatorTest">
                 <source type="body"/>
                 <target type="body"/>
-            </dataServicesCall>
+            </dataServiceCall>
             <respond/>
         </inSequence>
     </target>

--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorTargetTypePropertyProxy.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/server/repository/deployment/server/synapse-configs/default/proxy-services/dssCallMediatorTargetTypePropertyProxy.xml
@@ -23,7 +23,7 @@
     <description/>
     <target>
         <inSequence>
-            <dataServicesCall serviceName="DSSCallMediatorTest">
+            <dataServiceCall serviceName="DSSCallMediatorTest">
                 <source type="inline"/>
                 <operations type="single_req">
                     <operation name="addEmployee">
@@ -35,7 +35,7 @@
                     </operation>
                 </operations>
                 <target type="property" name="responseProperty"/>
-            </dataServicesCall>
+            </dataServiceCall>
             <log level="custom">
                 <property name="responsePayload" expression="$ctx:responseProperty"/>
             </log>


### PR DESCRIPTION
## Purpose
Refactor **dataServicesCallMediator** syntax to **dataServiceCallMediator** as shown below and update test case artifacts.
```
<dataServiceCall serviceName=" ">
<source [type="inline" | “body”] />
   <operations [type="single_req" | “batch_req” | “request_box”] >
      <operation name=" " >
         <param name=" " type=" " value=" " />
      </operation>
   </operations>
<target [type="body" | “property”] name=” ” />
</dataServiceCall>
```

Related PR https://github.com/wso2/micro-integrator/pull/1714