### PR TITLE
Add fail over retry TOML config support

### DIFF
--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -87,6 +87,8 @@
   "mediation.synapse.build_valid_nc_name": "synapse_properties.'synapse.commons.json.buildValidNCNames'",
   "mediation.synapse.enable_auto_primitive": "synapse_properties.'synapse.commons.json.output.autoPrimitive'",
   "mediation.synapse.json_out_auto_array": "synapse_properties.'synapse.commons.json.output.jsonoutAutoArray'",
+  "mediation.synapse.maximum_failover_retries":"synapse_properties.'maximum.failover.retries'",
+  "mediation.synapse.suspend_duration_on_maximum_failover":"synapse_properties.'suspend.duration.on.maximum.failover'",
 
   "mediation.flow.statistics.enable": "synapse_properties.'mediation.flow.statistics.enable'",
   "mediation.flow.statistics.capture_all": "synapse_properties.'mediation.flow.statistics.collect.all'",


### PR DESCRIPTION
## Purpose
Add TOML support for fail over retry implementation. These properties limit the number of retries for an endpoint to prevent unlimited retry attempts. The two configs are as follows.
[mediation]
synapse.maximum_failover_retries = 100
synapse.suspend_duration_on_maximum_failover = 100

maximum_failover_retries is unlimited by default. To make it unlimited, remove this configuration from the TOML file. This property enforces the maximum number of retry attempts for a particular failing endpoint before marking it as "Suspended".

suspend_duration_on_maximum_failover is 30000ms by default. This property specifies the timeout in milliseconds for a particular suspended endpoint to become "Active".