### PR TITLE
Improve Registry Migration Client

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/AppDeployerUtils.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/AppDeployerUtils.java
@@ -72,7 +72,9 @@ public final class AppDeployerUtils {
 	private static final String GOV_REGISTRY_PREFIX = "gov:";
 	private static final String CONFIG_REGISTRY_PATH = "/_system/config";
 	private static final String CONFIG_REGISTRY_PREFIX = "conf:";
-	
+	private static final String LOCAL_REGISTRY_PATH = "/_system/local";
+	private static final String LOCAL_REGISTRY_PREFIX = "local:";
+
 	private AppDeployerUtils() {
 		// hide utility class
 		
@@ -735,6 +737,8 @@ public final class AppDeployerUtils {
             updatedPath = GOV_REGISTRY_PREFIX + path.substring(19);
         } else if (path.startsWith(CONFIG_REGISTRY_PATH)) {
             updatedPath = CONFIG_REGISTRY_PREFIX + path.substring(15);
+        } else if (path.startsWith(LOCAL_REGISTRY_PATH)) {
+            updatedPath = LOCAL_REGISTRY_PREFIX + path.substring(14);
         } else {
             //Consider default as governance registry
             updatedPath = GOV_REGISTRY_PREFIX + path;

--- a/migration/registry-migration-service/pom.xml
+++ b/migration/registry-migration-service/pom.xml
@@ -73,7 +73,7 @@
             <groupId>org.wso2.carbon.registry</groupId>
             <artifactId>org.wso2.carbon.registry.resource.stub</artifactId>
             <scope>compile</scope>
-            <version>4.7.24</version>
+            <version>4.7.38</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.simpleframework/simple-xml -->
         <dependency>
@@ -96,6 +96,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.registry</groupId>
+            <artifactId>org.wso2.carbon.registry.properties.stub</artifactId>
+            <version>4.7.38</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/migration/registry-migration-service/src/main/java/org/wso2/mi/registry/migration/PropertiesAdminServiceClient.java
+++ b/migration/registry-migration-service/src/main/java/org/wso2/mi/registry/migration/PropertiesAdminServiceClient.java
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.mi.registry.migration;
+
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.client.Options;
+import org.apache.axis2.client.ServiceClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.wso2.carbon.registry.properties.stub.PropertiesAdminServiceRegistryExceptionException;
+import org.wso2.carbon.registry.properties.stub.PropertiesAdminServiceStub;
+import org.wso2.carbon.registry.properties.stub.beans.xsd.PropertiesBean;
+import org.wso2.mi.registry.migration.exception.RegistryMigrationException;
+import org.wso2.mi.registry.migration.utils.MigrationClientUtils;
+
+import java.rmi.RemoteException;
+
+public class PropertiesAdminServiceClient {
+
+    private static final Logger LOGGER = LogManager.getLogger(ResourceAdminServiceClient.class);
+    private PropertiesAdminServiceStub propertiesAdminServiceStub;
+
+    PropertiesAdminServiceClient(String backEndUrl, String sessionCookie) throws RegistryMigrationException {
+        String endPoint = backEndUrl + "/services/PropertiesAdminService";
+        try {
+            propertiesAdminServiceStub = new PropertiesAdminServiceStub(endPoint);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Successfully initialized the PropertiesAdminServiceClient");
+            }
+        } catch (AxisFault e) {
+            throw new RegistryMigrationException("Error occurred while initializing the PropertiesAdminServiceClient. ", e);
+        }
+        //Authenticate the stub from sessionCooke
+        ServiceClient serviceClient;
+        Options option;
+
+        serviceClient = propertiesAdminServiceStub._getServiceClient();
+        option = serviceClient.getOptions();
+        option.setManageSession(true);
+        option.setTimeOutInMilliSeconds(MigrationClientUtils.SESSION_TIMEOUT_IN_MILLIS);
+        option.setProperty(org.apache.axis2.transport.http.HTTPConstants.COOKIE_STRING, sessionCookie);
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "Successfully authenticated the PropertiesAdminServiceClient from the sessionCookie: {}",
+                    sessionCookie);
+        }
+    }
+
+    /**
+     * Get registry properties given the registry path.
+     *
+     * @param path - registry path
+     * @return - all the properties defined at the registry resource
+     * @throws RegistryMigrationException if error occurs while getting properties using the propertiesAdminServiceStub
+     */
+    PropertiesBean getProperties(String path) throws RegistryMigrationException {
+        try {
+            return propertiesAdminServiceStub.getProperties(path, "yes");
+        } catch (RemoteException | PropertiesAdminServiceRegistryExceptionException e) {
+            throw new RegistryMigrationException("Error when getting the registry properties from " + path, e);
+        }
+    }
+}

--- a/migration/registry-migration-service/src/main/java/org/wso2/mi/registry/migration/RegistryResource.java
+++ b/migration/registry-migration-service/src/main/java/org/wso2/mi/registry/migration/RegistryResource.java
@@ -18,7 +18,7 @@ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 
 package org.wso2.mi.registry.migration;
 
-import org.wso2.carbon.registry.resource.stub.beans.xsd.Property;
+import org.wso2.carbon.registry.properties.stub.utils.xsd.Property;
 import org.wso2.mi.registry.migration.utils.resources.ResourceProperty;
 
 import java.util.ArrayList;

--- a/migration/registry-migration-service/src/main/java/org/wso2/mi/registry/migration/RegistryResourceProjectExporter.java
+++ b/migration/registry-migration-service/src/main/java/org/wso2/mi/registry/migration/RegistryResourceProjectExporter.java
@@ -232,6 +232,9 @@ public class RegistryResourceProjectExporter extends RegistryExporter {
             throws ProjectCreationException {
         List<ResourceProjectArtifact> artifacts = new ArrayList<>();
         for (RegistryResource registryResource : registryResources) {
+            if (!registryResource.canExport()) {
+                continue;
+            }
             if (registryResource instanceof RegistryCollection) {
                 addRegistryCollection((RegistryCollection) registryResource, registryResourceModulePath, artifacts);
             } else {
@@ -297,22 +300,20 @@ public class RegistryResourceProjectExporter extends RegistryExporter {
         }
 
         //update the artifact.xml file
-        if (registryCollection.canExport()) {
-            String resourceFQN = registryCollection.getFullQualifiedResourceName();
-            List<ResourceProperty> resourcePropertyList = registryCollection.getProperties();
+        String resourceFQN = registryCollection.getFullQualifiedResourceName();
+        List<ResourceProperty> resourcePropertyList = registryCollection.getProperties();
 
-            ResourceProperties resourceProperties = new ResourceProperties(resourcePropertyList);
-            Collection resourceCollection = new Collection(directory, resourcePath, resourceProperties);
-            ResourceProjectArtifact artifact = new ResourceProjectArtifact(resourceFQN, groupId, version,
-                                                                           resourceCollection);
-            artifacts.add(artifact);
+        ResourceProperties resourceProperties = new ResourceProperties(resourcePropertyList);
+        Collection resourceCollection = new Collection(directory, resourcePath, resourceProperties);
+        ResourceProjectArtifact artifact = new ResourceProjectArtifact(resourceFQN, groupId, version,
+                                                                       resourceCollection);
+        artifacts.add(artifact);
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Successfully created the registry resource at {}", collection.getAbsolutePath());
-            }
-            // Update the summary report and return the next index
-            summaryTable.add(new String[]{resourcePath, MigrationClientUtils.EXPORT_SUCCESS_MESSAGE, "-"});
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Successfully created the registry resource at {}", collection.getAbsolutePath());
         }
+        // Update the summary report and return the next index
+        summaryTable.add(new String[]{resourcePath, MigrationClientUtils.EXPORT_SUCCESS_MESSAGE, "-"});
     }
 
     /**

--- a/migration/registry-migration-service/src/main/java/org/wso2/mi/registry/migration/ResourceAdminServiceClient.java
+++ b/migration/registry-migration-service/src/main/java/org/wso2/mi/registry/migration/ResourceAdminServiceClient.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.registry.resource.stub.ResourceAdminServiceExceptionException;
 import org.wso2.carbon.registry.resource.stub.ResourceAdminServiceStub;
 import org.wso2.carbon.registry.resource.stub.beans.xsd.MetadataBean;
-import org.wso2.carbon.registry.resource.stub.beans.xsd.PropertiesBean;
 import org.wso2.carbon.registry.resource.stub.beans.xsd.ResourceTreeEntryBean;
 import org.wso2.mi.registry.migration.exception.RegistryMigrationException;
 import org.wso2.mi.registry.migration.utils.MigrationClientUtils;
@@ -75,14 +74,6 @@ public class ResourceAdminServiceClient {
     String getTextContent(String path) throws RegistryMigrationException {
         try {
             return resourceAdminServiceStub.getTextContent(path);
-        } catch (RemoteException | ResourceAdminServiceExceptionException e) {
-            throw new RegistryMigrationException("Error when getting the text content from " + path, e);
-        }
-    }
-
-    PropertiesBean getProperties(String path) throws RegistryMigrationException {
-        try {
-            return resourceAdminServiceStub.getProperties(path);
         } catch (RemoteException | ResourceAdminServiceExceptionException e) {
             throw new RegistryMigrationException("Error when getting the text content from " + path, e);
         }


### PR DESCRIPTION
## Purpose
This PR makes use of the existing properties admin service ("/services/PropertiesAdminService") to get all the registry resources properties during the execution of the registry migration client. 

Also, allows creating registry resources in the "registry/local" directory.
