### PR TITLE
Introduce the replace_pattern and replacer to log masking

### DIFF
--- a/components/org.wso2.micro.integrator.log4j2.plugins/src/main/java/org/wso2/micro/integrator/log4j/plugins/LogMaskConverter.java
+++ b/components/org.wso2.micro.integrator.log4j2.plugins/src/main/java/org/wso2/micro/integrator/log4j/plugins/LogMaskConverter.java
@@ -16,6 +16,8 @@
 
 package org.wso2.micro.integrator.log4j.plugins;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;
@@ -31,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,12 +46,15 @@ import java.util.regex.Pattern;
  */
 public class LogMaskConverter extends LogEventPatternConverter {
 
+    private static final Log log = LogFactory.getLog(LogMaskConverter.class);
+
     private static final LogMaskConverter INSTANCE = new LogMaskConverter();
     private static final String DEFAULT_MASKING_PATTERNS_FILE_NAME = "wso2-log-masking.properties";
-    private static final String REPLACEMENT_STRING = "*****";
     private static final String MASK_PATTERN = "mm";
+    private static final String REPLACE_PATTERN = ".replace_pattern";
+    private static final String REPLACER = ".replacer";
 
-    private final List<Pattern> logMaskingPatterns;
+    private List<LogMaskInfoProvider> logMaskInfoProvider;
     private boolean isMaskAvailable = false;
 
     public static LogMaskConverter newInstance(String[] options) {
@@ -58,7 +64,7 @@ public class LogMaskConverter extends LogEventPatternConverter {
     protected LogMaskConverter() {
 
         super(MASK_PATTERN, MASK_PATTERN);
-        logMaskingPatterns = new ArrayList<>();
+        logMaskInfoProvider = new ArrayList<>();
         loadMaskingPatterns();
     }
 
@@ -70,13 +76,22 @@ public class LogMaskConverter extends LogEventPatternConverter {
         // Check whether there are any masking patterns defined.
         if (this.isMaskAvailable) {
             Matcher matcher;
+            Matcher replaceMatcher;
 
-            for (Pattern pattern : logMaskingPatterns) {
+            for (LogMaskInfoProvider maskingInfo : logMaskInfoProvider) {
+                Pattern pattern = maskingInfo.logMaskingPattern;
                 matcher = pattern.matcher(message);
                 StringBuffer stringBuffer = new StringBuffer();
-
+                Pattern replacementPattern = maskingInfo.logReplacementPattern;
                 while (matcher.find()) {
-                    matcher.appendReplacement(stringBuffer, REPLACEMENT_STRING);
+                    if (Objects.isNull(replacementPattern)) {
+                        matcher.appendReplacement(stringBuffer, maskingInfo.logReplacementString);
+                    } else {
+                        String subStringToMask = message.substring(matcher.start(), matcher.end());
+                        replaceMatcher = replacementPattern.matcher(subStringToMask);
+                        subStringToMask = replaceMatcher.replaceAll(maskingInfo.logReplacementString);
+                        matcher.appendReplacement(stringBuffer, subStringToMask);
+                    }
                 }
                 matcher.appendTail(stringBuffer);
                 message = stringBuffer.toString();
@@ -90,8 +105,8 @@ public class LogMaskConverter extends LogEventPatternConverter {
      */
     private void loadMaskingPatterns() {
 
-        String defaultFile = MicroIntegratorBaseUtils.getCarbonConfigDirPath() + File.separatorChar +
-                             DEFAULT_MASKING_PATTERNS_FILE_NAME;
+        String defaultFile = MicroIntegratorBaseUtils.getCarbonConfigDirPath() + File.separatorChar
+                + DEFAULT_MASKING_PATTERNS_FILE_NAME;
         Properties properties = new Properties();
         InputStream propsStream = null;
         try {
@@ -99,21 +114,48 @@ public class LogMaskConverter extends LogEventPatternConverter {
             if (Files.exists(Paths.get(defaultFile))) {
                 propsStream = new FileInputStream(defaultFile);
                 properties.load(propsStream);
+
                 for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-                    Pattern maskingPattern = Pattern.compile((String) entry.getValue());
-                    logMaskingPatterns.add(maskingPattern);
+                    if (((String) entry.getKey()).endsWith(REPLACE_PATTERN) || ((String) entry.getKey()).endsWith(
+                            REPLACER)) {
+                        continue;
+                    }
+                    String pattern = (String) entry.getValue();
+                    String replacePattern = properties.getProperty(entry.getKey() + REPLACE_PATTERN);
+                    String replacerPattern = properties.getProperty(entry.getKey() + REPLACER);
+                    logMaskInfoProvider.add(new LogMaskInfoProvider(pattern, replacePattern, replacerPattern));
                     this.isMaskAvailable = true;
                 }
             }
         } catch (IOException e) {
             // If the masking patterns cannot be loaded print an error message.
-            System.err.println("Error loading the masking patterns, due to : " + e.getMessage());
+            log.error("Error loading the masking patterns, due to : " + e.getMessage(), e);
         } finally {
             if (propsStream != null) {
                 try {
                     propsStream.close();
                 } catch (IOException ignore) {
                 }
+            }
+        }
+    }
+
+    /**
+     * This class represents the masking information.
+     */
+    public class LogMaskInfoProvider {
+
+        private Pattern logMaskingPattern;
+        private Pattern logReplacementPattern;
+        private String logReplacementString = "*****";
+
+        LogMaskInfoProvider(String logMaskingPattern, String logReplacementPattern, String logReplacementString) {
+            this.logMaskingPattern = Pattern.compile(logMaskingPattern);
+            if (Objects.nonNull(logReplacementPattern)) {
+                this.logReplacementPattern = Pattern.compile(logReplacementPattern);
+            }
+            if (Objects.nonNull(logReplacementString)) {
+                this.logReplacementString = logReplacementString;
             }
         }
     }


### PR DESCRIPTION
## Purpose
Previously, log masking functionality checks for the configured pattern and if any match found, it masks it with defined ‘*****’.
But configuration does not provide a way to mask only a specified part in a selected pattern. For instance, if someone needs to mask only the username part in an email address, the current implementation does not provide that level of customizability to the user.

This pr addresses this limitation by adding two other configurations to the deployment.toml as below.

```
[masking_pattern.properties]
"email"="(?<=email\":)(.*)([a-zA-Z0-9._-]+@)"
"email.replace_pattern"="(?<=.{1}).(?=.*@)"
"email.replacer"="*"
```

The first regex chooses the pattern we want to mask, say "email: username@gmail.com"
The replace_pattern regex specifies which part from the above one we need to actually mask, say only the string until the @ sign
The replacer specifies the symbol used to mask with.

result: email: ********@gmail.com

Related issue: https://github.com/wso2/micro-integrator/issues/2007