### PR TITLE
Add test to check JSON to XML conversion with Unicode characters

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/json/TestJSONtoXMLwithUnicodeCharacters.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/json/TestJSONtoXMLwithUnicodeCharacters.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.esb.json;
+
+import org.apache.http.HttpResponse;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.clients.SimpleHttpClient;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * This tests the JSON to XML conversion when JSON payload has unicode characters.
+ */
+public class TestJSONtoXMLwithUnicodeCharacters extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+        verifyProxyServiceExistence("JSONtoXMLProxy");
+    }
+
+    @Test(groups = {"wso2.esb"}, description = "Test JSON to XML conversion when JSON has unicode characters")
+    public void testJSONtoXMLwithUnicodeCharacters() throws IOException {
+        SimpleHttpClient simpleHttpClient = new SimpleHttpClient();
+        String request = "{\n" +
+                "    \"response\":\"\u0011\u0012Test With UTF-8 char at the beginning\"\n" +
+                "  }";
+
+        HttpResponse response = simpleHttpClient.doPost(getProxyServiceURLHttp("JSONtoXMLProxy"),
+                null, request, "application/json");
+        String responsePayload = simpleHttpClient.getResponsePayload(response);
+        assertTrue(responsePayload.equals("<jsonObject><response>\\u0011\\u0012Test With UTF-8 char at the" +
+                " beginning</response></jsonObject>"), "Error transforming JSON payload with unicode characters to XML.");
+    }
+}

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/JSONtoXMLProxy.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/JSONtoXMLProxy.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="JSONtoXMLProxy"
+       transports="https http"
+       startOnLoad="true"
+       trace="disable">
+    <description/>
+    <target>
+        <inSequence>
+            <property name="messageType" scope="axis2" type="STRING" value="application/xml"/>
+            <respond/>
+        </inSequence>
+    </target>
+</proxy>


### PR DESCRIPTION
## Purpose
This PR adds a test to check JSON to XML conversion when the JSON payload has UTF-8 Unicode characters
Related PR: https://github.com/wso2/wso2-axiom/pull/57