### PR TITLE
Iterate the appDeploymentHandlers list in reverse order when undeploying CApps

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -561,7 +561,8 @@ public class CappDeployer extends AbstractDeployer {
         log.info("Undeploying Carbon Application : " + carbonApp.getAppNameWithVersion() + "...");
         // Call the undeployer handler chain
         try {
-            for (AppDeploymentHandler handler : appDeploymentHandlers) {
+            for (int handlerIndex = appDeploymentHandlers.size() - 1; handlerIndex >= 0; handlerIndex--) {
+                AppDeploymentHandler handler = appDeploymentHandlers.get(handlerIndex);
                 handler.undeployArtifacts(carbonApp, axisConfig);
             }
             // Remove the app from cAppMap list


### PR DESCRIPTION
## Purpose
When undeploying CApps, the appDeploymentHandlers list was traversed in the same order as when we are deploying CApps.
Fixes wso2/micro-integrator#2175

## Approach
Iterate the appDeploymentHandlers list in reverse order