### PR TITLE
Introduce a synapse property to manage port offset for Inbound Endpoints

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpConstants.java
@@ -38,6 +38,7 @@ public class InboundHttpConstants {
     public static final String CLIENT_REVOCATION = "CertificateRevocationVerifier";
     public static final String HTTP = "http";
     public static final String HTTPS = "https";
+    public static final String ENABLE_PORT_OFFSET_FOR_INBOUND_ENDPOINT = "inbound.port.offset.enable";
     /**
      * Defines the core size (number of threads) of the worker thread pool.
      */

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpListener.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpListener.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.inbound.endpoint.protocol.http;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.inbound.InboundEndpoint;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.inbound.InboundRequestProcessor;
@@ -46,10 +47,13 @@ public class InboundHttpListener implements InboundRequestProcessor {
 
     public InboundHttpListener(InboundProcessorParams params) {
         processorParams = params;
+        boolean enableInboundPortOffset = SynapsePropertiesLoader.
+                getBooleanProperty(InboundHttpConstants.ENABLE_PORT_OFFSET_FOR_INBOUND_ENDPOINT, false);
         String portParam = params.getProperties()
                 .getProperty(InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
         try {
-            port = Integer.parseInt(portParam) + PersistenceUtils.getPortOffset();
+            port = enableInboundPortOffset ? Integer.parseInt(portParam) +
+                    PersistenceUtils.getPortOffset() : Integer.parseInt(portParam);
         } catch (NumberFormatException e) {
             handleException("Please provide port number as integer  instead of  port  " + portParam, e);
         }

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/https/InboundHttpsListener.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/https/InboundHttpsListener.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.inbound.endpoint.protocol.https;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.SynapsePropertiesLoader;
 import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.transport.passthru.core.ssl.SSLConfiguration;
 import org.wso2.carbon.inbound.endpoint.persistence.PersistenceUtils;
@@ -40,10 +41,13 @@ public class InboundHttpsListener extends InboundHttpListener {
     public InboundHttpsListener(InboundProcessorParams params) {
         super(params);
         processorParams = params;
+        boolean enableInboundPortOffset = SynapsePropertiesLoader.
+                getBooleanProperty(InboundHttpConstants.ENABLE_PORT_OFFSET_FOR_INBOUND_ENDPOINT, false);
         String portParam = params.getProperties()
                 .getProperty(InboundHttpConstants.INBOUND_ENDPOINT_PARAMETER_HTTP_PORT);
         try {
-            port = Integer.parseInt(portParam) + PersistenceUtils.getPortOffset();
+            port = enableInboundPortOffset ? Integer.parseInt(portParam) +
+                    PersistenceUtils.getPortOffset() : Integer.parseInt(portParam);
         } catch (NumberFormatException e) {
             handleException("Please provide port number as integer  instead of  port  " + portParam, e);
         }

--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -41,6 +41,7 @@
   "synapse_properties.'statistics.clean.interval'": "1000",
   "synapse_properties.'inbound.threads.core'": "20",
   "synapse_properties.'inbound.threads.max'": "100",
+  "synapse_properties.'inbound.port.offset.enable'": false,
 
   "synapse_properties.'opentracing.enable'": false,
   "synapse_properties.'jaeger.sampler.manager.host'": "localhost",

--- a/distribution/src/resources/config-tool/deployment-full.toml
+++ b/distribution/src/resources/config-tool/deployment-full.toml
@@ -864,6 +864,7 @@ stat.tracer.collect_mediation_properties=false
 
 inbound.core_threads = 20
 inbound.max_threads = 100
+inbound.port_offset_enable = false
 
 internal_http_api_enable = true     # inferred  true by default
 internal_http_api_port = 9191       # inferred 9191 by default

--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -98,6 +98,7 @@
   "mediation.statistics.clean_interval" : "synapse_properties.'statistics.clean.interval'",
   "mediation.inbound.core_threads": "synapse_properties.'inbound.threads.core'",
   "mediation.inbound.max_threads": "synapse_properties.'inbound.threads.max'",
+  "mediation.inbound.port_offset_enable": "synapse_properties.'inbound.port.offset.enable'",
   "mediation.internal_http_api_enable": "synapse_properties.'internal.http.api.enabled'",
   "mediation.internal_http_api_port": "synapse_properties.'internal.http.api.port'",
   "mediation.internal_https_api_port": "synapse_properties.'internal.https.api.port'",

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/http/inbound/transport/test/HttpInboundDispatchTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/http/inbound/transport/test/HttpInboundDispatchTestCase.java
@@ -57,7 +57,7 @@ public class HttpInboundDispatchTestCase extends ESBIntegrationTest {
                 + File.separator + "http.inbound.transport" + File.separator + "inbound2.xml")));
         Utils.deploySynapseConfiguration(inbound2, "inbound2", "inbound-endpoints", true);
 
-        urlContext = "http://" + getHostname() + ":" + "9290" + "/";
+        urlContext = "http://" + getHostname() + ":" + "9090" + "/";
         carbonLogReader = new CarbonLogReader();
         carbonLogReader.start();
 
@@ -92,7 +92,7 @@ public class HttpInboundDispatchTestCase extends ESBIntegrationTest {
 
     @Test(groups = "wso2.esb", description = "Inbound HTTP Super Tenant Default Main Sequence Dispatch")
     public void inboundHttpSuperDefaultMainTest() throws Exception {
-        HttpRequestUtil.doPost(new URL("http://" + getHostname() + ":9291/"), REQUEST_PAYLOAD, new HashMap<>());
+        HttpRequestUtil.doPost(new URL("http://" + getHostname() + ":9091/"), REQUEST_PAYLOAD, new HashMap<>());
         Assert.assertTrue(carbonLogReader.checkForLog("main sequence executed for call to non-existent = /", DEFAULT_TIMEOUT));
         carbonLogReader.clearLogs();
     }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/http/inbound/transport/test/HttpInboundTransportTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/http/inbound/transport/test/HttpInboundTransportTestCase.java
@@ -34,7 +34,7 @@ public class HttpInboundTransportTestCase extends ESBIntegrationTest {
     @Test(groups = "wso2.esb", description = "Inbound Http  test case")
     public void inboundHttpTest() throws AxisFault {
         OMElement response = axis2Client
-                .sendSimpleStockQuoteRequest("http://localhost:8281/services/StockQuote", null, "IBM");
+                .sendSimpleStockQuoteRequest("http://localhost:8081/services/StockQuote", null, "IBM");
 
         Assert.assertNotNull(response);
         Assert.assertEquals("getQuoteResponse", response.getLocalName());
@@ -42,7 +42,7 @@ public class HttpInboundTransportTestCase extends ESBIntegrationTest {
 
     @Test(groups = "wso2.esb", description = "Inbound Http  test case for API")
     public void inboundHttpAPITest() throws AxisFault {
-        OMElement response = axis2Client.sendSimpleStockQuoteRequest("http://localhost:8282/testapi/map", null, "IBM");
+        OMElement response = axis2Client.sendSimpleStockQuoteRequest("http://localhost:8082/testapi/map", null, "IBM");
         Assert.assertNotNull(response);
         Assert.assertEquals("getQuoteResponse", response.getLocalName());
     }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/https/inbound/transport/test/HttpsInboundTransportTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/https/inbound/transport/test/HttpsInboundTransportTestCase.java
@@ -43,7 +43,7 @@ public class HttpsInboundTransportTestCase extends ESBIntegrationTest {
         CarbonLogReader reader = new CarbonLogReader();
         reader.start();
         Utils.deploySynapseConfiguration(getArtifactConfig(), INBOUND_NAME, Utils.ArtifactType.INBOUND_ENDPOINT, false);
-        Assert.assertTrue(reader.checkForLog("Pass-through HttpsListenerEP Listener started on 0.0.0.0:8287", 60));
+        Assert.assertTrue(reader.checkForLog("Pass-through HttpsListenerEP Listener started on 0.0.0.0:8087", 60));
         reader.stop();
     }
 
@@ -52,7 +52,7 @@ public class HttpsInboundTransportTestCase extends ESBIntegrationTest {
     public void testSecureProxyEndPointThruUri() throws Exception {
 
         OMElement response = secureAxisServiceClient.
-                sendSecuredStockQuoteRequest(userInfo, "https://localhost:8287/", "WSO2", false);
+                sendSecuredStockQuoteRequest(userInfo, "https://localhost:8087/", "WSO2", false);
         Assert.assertNotNull(response);
         Assert.assertEquals("getQuoteResponse", response.getLocalName());
         Utils.undeploySynapseConfiguration(INBOUND_NAME, Utils.ArtifactType.INBOUND_ENDPOINT, false);


### PR DESCRIPTION
## Purpose
This PR introduces a synapse property **inbound.port.offset.enable** to set whether to add the server port offset value for Inbound Endpoints or not.
Deployment toml config: inbound.port_offset_enable = false

Fixes https://github.com/wso2/micro-integrator/issues/2223