### PR TITLE
Fix test case to include the content-type for SAOP request.

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/callout/CARBON15119DuplicateSOAPActionHeader.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/callout/CARBON15119DuplicateSOAPActionHeader.java
@@ -61,6 +61,7 @@ public class CARBON15119DuplicateSOAPActionHeader extends ESBIntegrationTest {
 
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Soapaction", "urn:getQuote");
+        headers.put("Content-type", "text/xml;charset=UTF-8");
 
         HttpRequestUtil.doPost(new URL(proxyServiceUrl), requestPayload, headers);
         String capturedMsg = wireMonitorServer.getCapturedMessage();


### PR DESCRIPTION
- SOAP request needs to include the Content-type set to 'text/xml'
- Related to fix in: wso2-support/wso2-synapse#1195