### PR TITLE
Add carbon custom TOML configurations

### DIFF
--- a/distribution/src/resources/config-tool/deployment-full.toml
+++ b/distribution/src/resources/config-tool/deployment-full.toml
@@ -33,6 +33,18 @@ class = "org.wso2.micro.integrator.transport.handlers.requestprocessors.swagger.
 internal_crypto_provider = "org.wso2.micro.integrator.crypto.provider.KeyStoreBasedInternalCryptoProvider" #inferred
 key = "SECRET_KEY" # inferred
 
+# carbon.xml server configurations
+[[server_conf]]
+title = "MediationFlowStatisticConfig"
+
+[[server_conf.param]]
+key="StatWorkerCount"
+value="500"
+
+[[server_conf.param]]
+key="StatWorkerIdleInterval"
+value="600"
+
 [super_admin]
 #usr-mgt.xml
 username = "admin"              # inferred

--- a/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
@@ -549,6 +549,14 @@
         <RegistryPersistence>enabled</RegistryPersistence>
     </MediationConfig>
 
+    {% for serverConf in server_conf %}
+    <{{serverConf.title}}>
+        {% for serverVal in serverConf.param %}
+        <{{ serverVal.key}}>{{serverVal.value}}</{{ serverVal.key}}>
+        {% endfor %}
+    </{{serverConf.title}}>
+    {% endfor %}
+
     <!--
     Server intializing code, specified as implementation classes of org.wso2.carbon.core.ServerInitializer.
     This code will be run when the Carbon server is initialized


### PR DESCRIPTION
This fix adds support to define custom parameters in the carbon.xml file. As an example, you can add the following TOML configurations to the deployment.toml file to generate custom parameters in carbon.xml file.
```
[[server_conf]]
title = "MediationFlowStatisticConfig"

[[server_conf.param]]
key="StatWorkerCount"
value="500"

[[server_conf.param]]
key="StatWorkerIdleInterval"
value="600"
```
The result carbon.xml file is as follows:
```
    <MediationFlowStatisticConfig>
        <StatWorkerCount>500</StatWorkerCount>
        <StatWorkerIdleInterval>600</StatWorkerIdleInterval>
    </MediationFlowStatisticConfig>
```
