### PR TITLE
Fix custom swagger with special characters not getting retrieved

### DIFF
--- a/components/mediation/extensions/org.wso2.micro.integrator.transport.handlers/src/main/java/org/wso2/micro/integrator/transport/handlers/requestprocessors/swagger/format/SwaggerGenerator.java
+++ b/components/mediation/extensions/org.wso2.micro.integrator.transport.handlers/src/main/java/org/wso2/micro/integrator/transport/handlers/requestprocessors/swagger/format/SwaggerGenerator.java
@@ -53,8 +53,9 @@ public class SwaggerGenerator {
     protected void updateResponse(CarbonHttpResponse response, String responseString, String contentType) throws
             AxisFault {
         try {
-            ((BlobOutputStream) response.getOutputStream()).getBlob().readFrom(new ByteArrayInputStream
-                    (responseString.getBytes(SwaggerConstants.DEFAULT_ENCODING)), responseString.length());
+            byte[] responseStringBytes = responseString.getBytes(SwaggerConstants.DEFAULT_ENCODING);
+            ((BlobOutputStream) response.getOutputStream()).getBlob()
+                    .readFrom(new ByteArrayInputStream(responseStringBytes), responseStringBytes.length);
         } catch (StreamCopyException streamCopyException) {
             handleException("Error in generating Swagger definition : failed to copy data to response ",
                     streamCopyException);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/micro-integrator/issues/2026

## Approach
Use byte array length instead of string length when reading the input stream