### PR TITLE
Add remote message processor clean up.

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
@@ -123,9 +123,7 @@ public class MetricHandler extends AbstractExtendedSynapseHandler {
             incrementInboundEndPointCount(inboundEndpointName);
             startTimers(synCtx, inboundEndpointName, MetricConstants.INBOUND_ENDPOINT,
                     null);
-        } else if (null != axis2MessageContext.getProperty(MetricConstants.TRANSPORT_IN_URL) &&
-                !axis2MessageContext.getProperty(MetricConstants.TRANSPORT_IN_URL).toString().
-                        contains("services")) {
+        } else {
             serviceInvokePort = getServiceInvokePort(synCtx);
 
             if ((serviceInvokePort != internalHttpApiPort) && (null !=

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
@@ -369,8 +369,10 @@ public class MetricHandler extends AbstractExtendedSynapseHandler {
                 getProperty(NhttpConstants.SERVICE_PREFIX)) {
             String servicePort = ((Axis2MessageContext) synCtx).getAxis2MessageContext().
                     getProperty(NhttpConstants.SERVICE_PREFIX).toString();
-            servicePort = servicePort.substring((servicePort.lastIndexOf(':') + 1),
-                    servicePort.lastIndexOf(DELIMITER));
+            servicePort = servicePort.substring(servicePort.lastIndexOf(':') + 1);
+            if (servicePort.contains(DELIMITER)) {
+                servicePort = servicePort.substring(0, servicePort.indexOf(DELIMITER));
+            }
             invokePort = Integer.parseInt(servicePort);
         }
         return invokePort;

--- a/pom.xml
+++ b/pom.xml
@@ -1357,7 +1357,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
 
-        <synapse.version>2.1.7-wso2v227</synapse.version>
+        <synapse.version>2.1.7-wso2v228</synapse.version>
         <carbon.mediation.version>4.7.99</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>
         <carbon.crypto.api.imp.pkg.version.range>[1.1.0,1.2.0)</carbon.crypto.api.imp.pkg.version.range>


### PR DESCRIPTION
## Purpose
Adds a mechanism to clean up the message processor for non-local nodes
Adds a mechanism for message processors to change the registry state when it is resumed
Fixes: https://github.com/wso2/product-ei/issues/5426