### PR TITLE
Avoid building the API completely to get name.

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -18,7 +18,6 @@
 package org.wso2.micro.integrator.initializer.deployment.application.deployer;
 
 import com.google.gson.JsonObject;
-import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMException;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
@@ -31,12 +30,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.synapse.api.version.VersionStrategy;
 import org.apache.synapse.config.SynapseConfigUtils;
 import org.apache.synapse.config.SynapseConfiguration;
-import org.apache.synapse.config.xml.rest.APIFactory;
 import org.apache.synapse.api.API;
-import org.apache.synapse.config.xml.rest.VersionStrategyFactory;
 import org.wso2.micro.application.deployer.AppDeployerUtils;
 import org.wso2.micro.application.deployer.CarbonApplication;
 import org.wso2.micro.application.deployer.config.ApplicationConfiguration;
@@ -45,6 +41,7 @@ import org.wso2.micro.application.deployer.handler.AppDeploymentHandler;
 import org.wso2.micro.core.util.CarbonException;
 import org.wso2.micro.core.util.FileManipulator;
 import org.wso2.micro.integrator.initializer.dashboard.ArtifactDeploymentListener;
+import org.wso2.micro.integrator.initializer.utils.DeployerUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -650,11 +647,7 @@ public class CappDeployer extends AbstractDeployer {
 
         try {
             OMElement apiElement = new StAXOMBuilder(apiXmlStream).getDocumentElement();
-            OMAttribute nameAtt = apiElement.getAttribute(new QName("name"));
-            OMAttribute contextAtt = apiElement.getAttribute(new QName("context"));
-            API api = new API(nameAtt.getAttributeValue(), contextAtt.getAttributeValue());
-            VersionStrategy vStrategy = VersionStrategyFactory.createVersioningStrategy(api, apiElement);
-            api.setVersionStrategy(vStrategy);
+            API api = DeployerUtil.partiallyBuildAPI(apiElement);
             return api.getName();
         } catch (XMLStreamException | OMException e) {
             // Cannot find the API file or API is faulty.

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
@@ -43,7 +43,6 @@ import org.apache.synapse.config.xml.EntryFactory;
 import org.apache.synapse.config.xml.SynapseImportFactory;
 import org.apache.synapse.config.xml.SynapseImportSerializer;
 import org.apache.synapse.config.xml.XMLConfigConstants;
-import org.apache.synapse.config.xml.rest.APIFactory;
 import org.apache.synapse.core.axis2.ProxyService;
 import org.apache.synapse.deployers.APIDeployer;
 import org.apache.synapse.deployers.AbstractSynapseArtifactDeployer;
@@ -82,6 +81,7 @@ import org.wso2.micro.integrator.initializer.ServiceBusUtils;
 import org.wso2.micro.integrator.initializer.dashboard.ArtifactDeploymentListener;
 import org.wso2.micro.integrator.initializer.persistence.MediationPersistenceManager;
 import org.wso2.micro.integrator.initializer.utils.ConfigurationHolder;
+import org.wso2.micro.integrator.initializer.utils.DeployerUtil;
 import org.wso2.micro.integrator.initializer.utils.LocalEntryUtil;
 
 import java.io.ByteArrayInputStream;
@@ -306,7 +306,7 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                         if (artifact.getType().equals("synapse/api")) {
                             OMElement apiElement =
                                     new StAXOMBuilder(new FileInputStream(new File(artifactPath))).getDocumentElement();
-                            API api = APIFactory.createAPI(apiElement);
+                            API api = DeployerUtil.partiallyBuildAPI(apiElement);
                             artifactName = api.getName();
                         }
 

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/utils/DeployerUtil.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/utils/DeployerUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.integrator.initializer.utils;
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMElement;
+import org.apache.synapse.api.API;
+import org.apache.synapse.api.version.VersionStrategy;
+import org.apache.synapse.config.xml.rest.VersionStrategyFactory;
+
+import javax.xml.namespace.QName;
+
+public class DeployerUtil {
+
+    /**
+     * Partially build a synapse API for deployment purposes.
+     * @param apiElement OMElement of API configuration.
+     * @return API
+     */
+    public static API partiallyBuildAPI(OMElement apiElement) {
+        OMAttribute nameAtt = apiElement.getAttribute(new QName("name"));
+        OMAttribute contextAtt = apiElement.getAttribute(new QName("context"));
+        API api = new API(nameAtt.getAttributeValue(), contextAtt.getAttributeValue());
+        VersionStrategy vStrategy = VersionStrategyFactory.createVersioningStrategy(api, apiElement);
+        api.setVersionStrategy(vStrategy);
+        return api;
+    }
+}


### PR DESCRIPTION
## Purpose
Building the API after some of its artifacts have been un-deployed may lead to runtime issues.
Fixes: https://github.com/wso2/micro-integrator/issues/2308
