### PR TITLE
Update File based User Store properties

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/ConfigurationLoader.java
@@ -203,7 +203,7 @@ public class ConfigurationLoader {
      * Populates individual users.
      *
      * @param users the parent element of users
-     * @return map of users against credentials
+     * @return map of users against UserInfo config
      */
     private static Map<String, UserInfo> populateUsers(OMElement users) {
         HashMap<String, UserInfo> userMap = new HashMap<>();
@@ -224,10 +224,10 @@ public class ConfigurationLoader {
                         }
                         boolean isAdmin = false;
                         if (isAdminElement != null) {
-                            isAdmin = Boolean.parseBoolean(isAdminElement.getText());
+                            isAdmin = Boolean.parseBoolean(isAdminElement.getText().trim());
                         }
-                        userMap.put(userName, new UserInfo(resolveSecret(passwordElement.getText()).toCharArray(),
-                                isAdmin));
+                        userMap.put(userName, new UserInfo(userName,
+                                resolveSecret(passwordElement.getText()).toCharArray(), isAdmin));
                     }
                 }
             }

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/UserInfo.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/UserInfo.java
@@ -23,11 +23,13 @@ package org.wso2.carbon.inbound.endpoint.internal.http.api;
  */
 public class UserInfo {
 
+    private String username;
     private char[] password;
     private boolean admin;
 
-    public UserInfo(char[] password, boolean admin) {
+    public UserInfo(String username, char[] password, boolean admin) {
 
+        this.username = username;
         this.password = password;
         this.admin = admin;
     }

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/UserInfo.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/internal/http/api/UserInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.inbound.endpoint.internal.http.api;
+
+/**
+ * This class is the DTO for User configs in internal-apis.xml
+ */
+public class UserInfo {
+
+    private char[] password;
+    private boolean admin;
+
+    public UserInfo(char[] password, boolean admin) {
+
+        this.password = password;
+        this.admin = admin;
+    }
+
+    public char[] getPassword() {
+
+        return password;
+    }
+
+    public void setPassword(char[] password) {
+
+        this.password = password;
+    }
+
+    public boolean isAdmin() {
+
+        return admin;
+    }
+
+    public void setAdmin(boolean admin) {
+
+        this.admin = admin;
+    }
+}

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/java/internal/http/api/ConfigurationLoaderTestCase.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.Constants;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPI;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIHandler;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.UserInfo;
 
 import java.net.URL;
 import java.util.List;
@@ -88,20 +89,23 @@ public class ConfigurationLoaderTestCase {
         Assert.assertNotNull("Configuration file not found", url);
 
         ConfigurationLoader.loadInternalApis("internal/http/api/internal-apis.xml");
-        Map<String, char[]> userMap = ConfigurationLoader.getUserMap();
+        Map<String, UserInfo> userMap = ConfigurationLoader.getUserMap();
 
         org.junit.Assert.assertEquals(3, userMap.size());
         //Assert admin:admin
         org.junit.Assert.assertNotNull(userMap.get("admin"));
-        org.junit.Assert.assertEquals("admin", String.valueOf(userMap.get("admin")));
+        org.junit.Assert.assertEquals("admin", String.valueOf(userMap.get("admin").getPassword()));
+        org.junit.Assert.assertTrue("isAdmin", userMap.get("admin").isAdmin());
 
         //Assert user1:pwd1
         org.junit.Assert.assertNotNull(userMap.get("user1"));
-        org.junit.Assert.assertEquals("pwd1", String.valueOf(userMap.get("user1")));
+        org.junit.Assert.assertEquals("pwd1", String.valueOf(userMap.get("user1").getPassword()));
+        org.junit.Assert.assertFalse("isAdmin", userMap.get("user1").isAdmin());
 
         //Assert user2:pwd2
         org.junit.Assert.assertNotNull(userMap.get("user2"));
-        org.junit.Assert.assertEquals("pwd2", String.valueOf(userMap.get("user2")));
+        org.junit.Assert.assertEquals("pwd2", String.valueOf(userMap.get("user2").getPassword()));
+        org.junit.Assert.assertFalse("isAdmin", userMap.get("user2").isAdmin());
     }
 
     /**

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/resources/internal/http/api/internal-apis.xml
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/test/resources/internal/http/api/internal-apis.xml
@@ -43,6 +43,7 @@
             <user>
                 <username>admin</username>
                 <password>admin</password>
+                <isAdmin>true</isAdmin>
             </user>
             <user>
                 <username>user1</username>

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LoginResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LoginResource.java
@@ -32,6 +32,7 @@ import org.wso2.micro.integrator.management.apis.security.handler.JWTTokenCleanu
 import org.wso2.micro.integrator.management.apis.security.handler.JWTTokenGenerator;
 import org.wso2.micro.integrator.management.apis.security.handler.JWTTokenInfoDTO;
 import org.wso2.micro.integrator.management.apis.security.handler.JWTTokenStore;
+import org.wso2.micro.integrator.management.apis.security.handler.SecurityUtils;
 import org.wso2.micro.integrator.security.MicroIntegratorSecurityUtils;
 import org.wso2.micro.integrator.security.user.api.UserStoreException;
 
@@ -88,7 +89,7 @@ public class LoginResource implements MiApiResource {
         JWTTokenInfoDTO newToken = new JWTTokenInfoDTO(username);
         newToken.setToken(randomUUIDString);
         try {
-            if (MicroIntegratorSecurityUtils.isAdmin(username)) {
+            if (SecurityUtils.isAdmin(username)) {
                 newToken.setScope(AuthConstants.JWT_TOKEN_ADMIN_SCOPE);
             } else {
                 newToken.setScope(AuthConstants.JWT_TOKEN_DEFAULT_SCOPE);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementApiParser.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementApiParser.java
@@ -22,6 +22,7 @@ import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.UserInfo;
 import org.wso2.micro.core.util.CarbonException;
 import org.wso2.micro.integrator.core.util.MicroIntegratorBaseUtils;
 import org.wso2.securevault.SecretResolverFactory;
@@ -94,8 +95,8 @@ public class ManagementApiParser {
      * @return a non null map if the user store is defined.
      * @throws UserStoreUndefinedException if the user store is not defined in internal-apis.xml
      */
-    public Map<String, char[]> getUserMap() throws UserStoreUndefinedException {
-        Map<String, char[]> usersMap = ConfigurationLoader.getUserMap();
+    public Map<String, UserInfo> getUserMap() throws UserStoreUndefinedException {
+        Map<String, UserInfo> usersMap = ConfigurationLoader.getUserMap();
         if (Objects.nonNull(usersMap)) {
             return usersMap;
         } else {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/UserResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/UserResource.java
@@ -121,7 +121,7 @@ public class UserResource implements MiApiResource {
         }
         JSONObject userObject = new JSONObject();
         userObject.put(USER_ID, user);
-        userObject.put(IS_ADMIN, MicroIntegratorSecurityUtils.isAdmin(user));
+        userObject.put(IS_ADMIN, SecurityUtils.isAdmin(user));
         String[] roles = getUserStore().getRoleListOfUser(user);
         JSONArray list = new JSONArray(roles);
         userObject.put(ROLES, list);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthenticationHandlerAdapter.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthenticationHandlerAdapter.java
@@ -125,7 +125,7 @@ public abstract class AuthenticationHandlerAdapter extends SecurityHandlerAdapte
      * Processes authentication request with basic auth and in memory user store
      *
      * @param messageContext synapse message context
-     * @param token extracted basic auth token
+     * @param token          extracted basic auth token
      * @return boolean if successfully authenticated
      */
     boolean processAuthRequestWithFileBasedUserStore(MessageContext messageContext, String token) {
@@ -134,17 +134,12 @@ public abstract class AuthenticationHandlerAdapter extends SecurityHandlerAdapte
         if (userDetails.length == 0) {
             return false;
         }
-        if (!usersList.isEmpty()) {
-            for (String userNameFromStore : usersList.keySet()) {
-                if (userNameFromStore.equals(userDetails[0])) {
-                    String passwordFromStore = String.valueOf(usersList.get(userNameFromStore));
-                    if (isValid(passwordFromStore) && passwordFromStore.equals(userDetails[1])) {
-                        messageContext.setProperty(USERNAME_PROPERTY, userDetails[0]);
-                        LOG.info("User " + userDetails[0] + " logged in successfully");
-                        return true;
-                    }
-                }
-            }
+        boolean isAuthenticated = FileBasedUserStoreManager.getUserStoreManager().authenticate(userDetails[0],
+                userDetails[1]);
+        if (isAuthenticated) {
+            messageContext.setProperty(USERNAME_PROPERTY, userDetails[0]);
+            LOG.info("User " + userDetails[0] + " logged in successfully");
+            return true;
         }
         return false;
     }
@@ -157,15 +152,5 @@ public abstract class AuthenticationHandlerAdapter extends SecurityHandlerAdapte
             return new String[] {};
         }
         return new String[] { usernamePasswordArray[0], usernamePasswordArray[1] };
-    }
-
-    /**
-     * Checks if a given value is not null and not empty.
-     *
-     * @param value String value
-     */
-    private Boolean isValid(String value) {
-
-        return (Objects.nonNull(value) && !value.isEmpty());
     }
 }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandler.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandler.java
@@ -93,11 +93,11 @@ public class AuthorizationHandler extends AuthorizationHandlerAdapter {
      */
     private boolean processAuthorizationWithFileBasedUserStore(String userName) {
 
-        boolean isAuthorized = FileBasedUserStoreManager.getUserStoreManager().isAdmin(userName);
-        if (!isAuthorized) {
+        boolean isAdmin = FileBasedUserStoreManager.getUserStoreManager().isAdmin(userName);
+        if (!isAdmin) {
             LOG.error("User " + userName + " cannot be authorized");
         }
-        return isAuthorized;
+        return isAdmin;
     }
 
     /**

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandler.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandler.java
@@ -82,10 +82,22 @@ public class AuthorizationHandler extends AuthorizationHandlerAdapter {
             }
         } else {
             //Uses in memory user store
-            LOG.error("Authorization is not supported with the in memory user store. Please plug in a user store for "
-                      + "the correct functionality");
-            return false;
+            return processAuthorizationWithFileBasedUserStore(userName);
         }
+    }
+
+    /**
+     * Processes the authorization request using file based user store.
+     *
+     * @return true if successfully authorized
+     */
+    private boolean processAuthorizationWithFileBasedUserStore(String userName) {
+
+        boolean isAuthorized = FileBasedUserStoreManager.getUserStoreManager().isAdmin(userName);
+        if (!isAuthorized) {
+            LOG.error("User " + userName + " cannot be authorized");
+        }
+        return isAuthorized;
     }
 
     /**

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/FileBasedUserStoreManager.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/FileBasedUserStoreManager.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.integrator.management.apis.security.handler;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.UserInfo;
+import org.wso2.micro.integrator.management.apis.ManagementApiParser;
+import org.wso2.micro.integrator.management.apis.UserStoreUndefinedException;
+
+import java.util.Map;
+
+public class FileBasedUserStoreManager {
+
+    private static final Log LOG = LogFactory.getLog(FileBasedUserStoreManager.class);
+    private static final FileBasedUserStoreManager userStoreManager = new FileBasedUserStoreManager();
+    private static Map<String, UserInfo> usersList;
+    private static boolean isInitialized = false;
+
+    private FileBasedUserStoreManager() {
+
+        initializeUserStore();
+    }
+
+    /**
+     * Method to retrieve FileBasedUserStoreManager
+     *
+     * @return FileBasedUserStoreManager
+     */
+    public static FileBasedUserStoreManager getUserStoreManager() {
+
+        return userStoreManager;
+    }
+
+    /**
+     * Authenticate the user against the file based user store.
+     *
+     * @param username the user to be authenticated
+     * @param password the password used for authentication
+     * @return true if authenticated
+     */
+    public boolean authenticate(String username, String password) {
+
+        if (usersList.containsKey(username)) {
+            String passwordFromStore = String.valueOf(usersList.get(username).getPassword());
+            if (StringUtils.isNotBlank(passwordFromStore) && passwordFromStore.equals(password)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Method to assert if a user is an admin
+     *
+     * @param username the user to be validated as an admin
+     * @return true if the admin role is assigned to the user
+     */
+    public boolean isAdmin(String username) {
+
+        if (usersList.containsKey(username)) {
+            UserInfo userInfo = usersList.get(username);
+            return userInfo.isAdmin();
+        }
+        return false;
+    }
+
+    /**
+     * Method to check whether FileBasedUserStoreManager is initialized
+     *
+     * @return true if successfully initialized
+     */
+    public boolean isInitialized() {
+
+        return isInitialized;
+    }
+
+    private static void initializeUserStore() {
+
+        ManagementApiParser mgtParser = new ManagementApiParser();
+        try {
+            usersList = mgtParser.getUserMap();
+            isInitialized = true;
+        } catch (UserStoreUndefinedException e) {
+            LOG.error("User store config has not been defined in file "
+                    + ManagementApiParser.getConfigurationFilePath(), e);
+        }
+    }
+}

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/FileBasedUserStoreManager.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/FileBasedUserStoreManager.java
@@ -27,6 +27,9 @@ import org.wso2.micro.integrator.management.apis.UserStoreUndefinedException;
 
 import java.util.Map;
 
+/**
+ * This class is used to authenticate, authorize users against the File based user store defined in internal-apis.xml
+ */
 public class FileBasedUserStoreManager {
 
     private static final Log LOG = LogFactory.getLog(FileBasedUserStoreManager.class);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityHandlerAdapter.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityHandlerAdapter.java
@@ -25,9 +25,7 @@ import org.apache.synapse.rest.RESTConstants;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIHandler;
 import org.wso2.micro.core.util.CarbonException;
 import org.wso2.micro.integrator.management.apis.Constants;
-import org.wso2.micro.integrator.management.apis.ManagementApiParser;
 import org.wso2.micro.integrator.management.apis.ManagementApiUndefinedException;
-import org.wso2.micro.integrator.management.apis.UserStoreUndefinedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +38,6 @@ import javax.xml.stream.XMLStreamException;
  */
 public abstract class SecurityHandlerAdapter implements InternalAPIHandler {
 
-    protected static Map<String, char[]> usersList;
     protected static boolean useCarbonUserStore = false;
     private static boolean isInitialized = false;
     /**
@@ -70,15 +67,7 @@ public abstract class SecurityHandlerAdapter implements InternalAPIHandler {
             XMLStreamException {
         if (!isInitialized) {
             if (SecurityUtils.isFileBasedUserStoreEnabled()) {
-                ManagementApiParser mgtParser = new ManagementApiParser();
-                try {
-                    usersList = mgtParser.getUserMap();
-                    isInitialized = true;
-                } catch (UserStoreUndefinedException e) {
-                    LOG.error("User store config has not been defined in file "
-                            + ManagementApiParser.getConfigurationFilePath(), e);
-                    isInitialized = false;
-                }
+                isInitialized = FileBasedUserStoreManager.getUserStoreManager().isInitialized();
             } else {
                 LOG.info("File based user store has been disabled. Carbon user store settings will be used.");
                 useCarbonUserStore = true;

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityUtils.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityUtils.java
@@ -106,7 +106,7 @@ public class SecurityUtils {
     }
 
     /**
-     * Method to assert if a user is an admin
+     * Method to assert if a user is an admin.
      *
      * @param username the user to be validated as an admin
      * @return true if the admin role is assigned to the user

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityUtils.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityUtils.java
@@ -25,6 +25,8 @@ import org.apache.synapse.commons.crypto.CryptoConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.wso2.config.mapper.ConfigParser;
 import org.wso2.micro.integrator.management.apis.Constants;
+import org.wso2.micro.integrator.security.MicroIntegratorSecurityUtils;
+import org.wso2.micro.integrator.security.user.api.UserStoreException;
 import org.wso2.securevault.SecretResolver;
 import org.wso2.securevault.SecureVaultException;
 
@@ -101,5 +103,21 @@ public class SecurityUtils {
             return Boolean.valueOf(fileUserStore.toString());
         }
         return false;
+    }
+
+    /**
+     * Method to assert if a user is an admin
+     *
+     * @param username the user to be validated as an admin
+     * @return true if the admin role is assigned to the user
+     * @throws UserStoreException if any error occurs while retrieving the user store manager or reading the user realm
+     *                            configuration
+     */
+    public static boolean isAdmin(String username) throws UserStoreException {
+        if (isFileBasedUserStoreEnabled()) {
+            return FileBasedUserStoreManager.getUserStoreManager().isAdmin(username);
+        } else {
+            return MicroIntegratorSecurityUtils.isAdmin(username);
+        }
     }
 }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/test/java/org/wso2/micro/integrator/management/apis/ManagementApiParserTest.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/test/java/org/wso2/micro/integrator/management/apis/ManagementApiParserTest.java
@@ -27,6 +27,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
+import org.wso2.carbon.inbound.endpoint.internal.http.api.UserInfo;
 import org.wso2.micro.core.util.CarbonException;
 import org.wso2.micro.integrator.core.internal.MicroIntegratorBaseConstants;
 
@@ -58,14 +59,14 @@ public class ManagementApiParserTest {
 
     @Test
     public void testGetUserList() throws UserStoreUndefinedException {
-        Map<String, char[]> userMap = new HashMap<>();
-        userMap.put("user1", "pwd1".toCharArray());
+        Map<String, UserInfo> userMap = new HashMap<>();
+        userMap.put("user1", new UserInfo("user1", "pwd1".toCharArray(), false));
         PowerMockito.mockStatic(ConfigurationLoader.class);
         Mockito.when(ConfigurationLoader.getUserMap()).thenReturn(userMap);
         ManagementApiParser managementApiParser = new ManagementApiParser();
-        Map<String, char[]> retrievedUserMap = managementApiParser.getUserMap();
+        Map<String, UserInfo> retrievedUserMap = managementApiParser.getUserMap();
         Assert.assertNotNull(retrievedUserMap);
-        Assert.assertEquals("pwd1", new String(retrievedUserMap.get("user1")));
+        Assert.assertEquals("pwd1", new String(retrievedUserMap.get("user1").getPassword()));
     }
 
     @Test(expected = UserStoreUndefinedException.class)

--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -447,7 +447,8 @@
   "internal_apis.users": [
     {
       "user.name": "admin",
-      "user.password": "admin"
+      "user.password": "admin",
+      "user.is_admin": true
     }
   ],
 

--- a/distribution/src/resources/config-tool/templates/conf/internal-apis.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/internal-apis.xml.j2
@@ -112,6 +112,7 @@
             <user>
                 <username>{{user.user.name}}</username>
                 <password>{{user.user.password}}</password>
+                <isAdmin>{{user.user.is_admin}}</isAdmin>
             </user>
             {% endfor %}
         </users>


### PR DESCRIPTION
## Purpose
Allow admin role for users defined in File-based User Store.
Fixes https://github.com/wso2/micro-integrator/issues/2356

## User stories

Set `user.is_admin` property to true to define the user as an admin user in the deployment.toml.

```toml
[[internal_apis.users]]
user.name = "admin"
user.password = "admin"
user.is_admin = true
```