### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ matrix:
       install: true
 
       script: mvn -B clean install -P smoke-tests
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.