### PR TITLE
Remove unnecessary check for axis2service in MI

### DIFF
--- a/components/mediation/extensions/org.wso2.micro.integrator.transport.handlers/src/main/java/org/wso2/micro/integrator/transport/handlers/PassThroughNHttpGetProcessor.java
+++ b/components/mediation/extensions/org.wso2.micro.integrator.transport.handlers/src/main/java/org/wso2/micro/integrator/transport/handlers/PassThroughNHttpGetProcessor.java
@@ -295,10 +295,6 @@ public class PassThroughNHttpGetProcessor implements HttpGetRequestProcessor {
                 	    serviceName = requestUri.substring(beginIndex);
                 	    axisService = cfgCtx.getAxisConfiguration().getServiceForActivation(serviceName);
                 	}
-
-                    if (axisService == null && !loadBalancer && serviceName != null) {
-                    	log.error("Unable to find axis service for service name : " + serviceName);
-                    }
                 }
 
                 if (queryString != null) {


### PR DESCRIPTION
Fixes: https://github.com/wso2/micro-integrator/issues/2351

As in MI we don't have tenants, we can remove the following if condition:

```
if (axisService == null && !loadBalancer && serviceName != null) {
                    	log.error("Unable to find axis service for service name : " + serviceName);
}
```

In EI [1] we do that to get the axis service from the tenant if it is null for super tenant. Since we don't have tenants in MI, we can remove that logic. 

[1] https://github.com/wso2/carbon-mediation/blob/master/components/mediation-initializer/org.wso2.carbon.mediation.transport.handlers/src/main/java/org/wso2/carbon/mediation/transport/handlers/PassThroughNHttpGetProcessor.java#L317
