### PR TITLE
Fix the issue of exchnage auto declaration declaration failure

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConsumer.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQConsumer.java
@@ -95,7 +95,20 @@ public class RabbitMQConsumer implements Consumer {
         // declaring queue, exchange and binding
         queueName = rabbitMQProperties.get(RabbitMQConstants.QUEUE_NAME);
         String exchangeName = rabbitMQProperties.get(RabbitMQConstants.EXCHANGE_NAME);
-        RabbitMQUtils.declareQueuesExchangesAndBindings(channel, queueName, exchangeName, rabbitMQProperties);
+
+        try {
+            RabbitMQUtils.declareQueue(channel, queueName, rabbitMQProperties);
+        } catch (IOException ex) {
+            channel = RabbitMQUtils.checkAndIgnoreInEquivalentParamException(connection, ex,
+                    org.apache.axis2.transport.rabbitmq.RabbitMQConstants.QUEUE, queueName);
+        }
+        try {
+            RabbitMQUtils.declareExchange(channel, exchangeName, rabbitMQProperties);
+        } catch (IOException ex) {
+            channel = RabbitMQUtils.checkAndIgnoreInEquivalentParamException(connection, ex,
+                    org.apache.axis2.transport.rabbitmq.RabbitMQConstants.EXCHANGE, exchangeName);
+        }
+        RabbitMQUtils.bindQueueToExchange(channel, queueName, exchangeName, rabbitMQProperties);
 
         // get max dead-lettered count
         maxDeadLetteredCount =


### PR DESCRIPTION
This has occurred due to the availability of in equivalent parameters in the exchange which has already been created
in the rabbitmq console. Both Exchange and queue declaration is fixed with this.

Fixes wso2/micro-integrator#2376
