### PR TITLE
Fix duplicate API version issue in Prometheus

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
@@ -345,11 +345,7 @@ public class MetricHandler extends AbstractExtendedSynapseHandler {
         for (API api : synCtx.getEnvironment().getSynapseConfiguration().getAPIs()) {
             if (RESTUtils.matchApiPath(contextPath, api.getContext())) {
                 apiName = api.getName();
-                if (api.getVersionStrategy().getVersion() != null && !"".equals(api.getVersionStrategy().
-                        getVersion())) {
-                    apiName = apiName + ":v" + api.getVersionStrategy().getVersion();
-                }
-                 synCtx.setProperty(RESTConstants.PROCESSED_API, api);
+                synCtx.setProperty(RESTConstants.PROCESSED_API, api);
             }
         }
         return apiName;


### PR DESCRIPTION
## Purpose
> $subject. We can remove this additional version check here since api.getName() method already has that logic. 

Fix: https://github.com/wso2/micro-integrator/issues/2385