### PR TITLE
Add ability to get current update level through prometheus

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
@@ -30,6 +30,7 @@ import org.apache.synapse.rest.RESTUtils;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.wso2.config.mapper.ConfigParser;
 import org.wso2.micro.integrator.core.internal.MicroIntegratorBaseConstants;
+import org.wso2.micro.integrator.core.services.CarbonServerConfigurationService;
 import org.wso2.micro.integrator.observability.metric.handler.prometheus.reporter.PrometheusReporter;
 import org.wso2.micro.integrator.observability.util.MetricConstants;
 
@@ -56,12 +57,16 @@ public class MetricHandler extends AbstractExtendedSynapseHandler {
     private static final String JAVA_HOME = System.getProperty(MetricConstants.JAVA_HOME);
     private int internalHttpApiPort = getInternalHttpApiPort();
 
+
     @Override
     public boolean handleServerInit() {
         metricReporterInstance = this.getMetricReporter();
+        CarbonServerConfigurationService serverConfig = CarbonServerConfigurationService.getInstance();
+        String miVersion = serverConfig.getServerVersion();
+        String updateLevel = System.getProperty(MetricConstants.UPDATE_LEVEL);
         metricReporterInstance.initMetrics();
-
         metricReporterInstance.serverUp(HOST, PORT, JAVA_HOME, JAVA_VERSION);
+        metricReporterInstance.serverVersion(miVersion, updateLevel);
         return true;
     }
 

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricReporter.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricReporter.java
@@ -108,6 +108,15 @@ public interface MetricReporter {
     void serverUp(String host, String port, String javaHome, String javaVersion);
 
     /**
+     * Instrument metrics related to MI server version is and the
+     * specific update 2 level of the MI server.
+     *
+     * @param version        The MI server version
+     * @param updateLevel    The specific update 2 level of the MI server
+     */
+    void serverVersion(String version, String updateLevel);
+
+    /**
      * Instrument metrics on server undeployment.
      *
      * @param host        The IP Address of the host the MI server is running

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/prometheus/reporter/PrometheusReporter.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/prometheus/reporter/PrometheusReporter.java
@@ -51,6 +51,7 @@ public class PrometheusReporter implements MetricReporter {
 
     private Gauge SERVER_UP;
     private Gauge SERVICE_UP;
+    private Gauge SERVER_VERSION;
 
     private static Log log = LogFactory.getLog(PrometheusReporter.class);
 
@@ -63,6 +64,7 @@ public class PrometheusReporter implements MetricReporter {
     @Override
     public void initMetrics() {
         this.initializeServeMetrics();
+        this.initializeServerVersionMetrics();
         this.initializeArtifactDeploymentMetrics();
 
         this.initializeProxyMetrics();
@@ -134,6 +136,10 @@ public class PrometheusReporter implements MetricReporter {
             SERVER_UP = Gauge.build(MetricConstants.SERVER_UP, "Server status").
                     labelNames(labels).register();
             metricMap.put(MetricConstants.SERVER_UP, SERVER_UP);
+        } else if (serviceType.equals(MetricConstants.VERSION)) {
+            SERVER_VERSION = Gauge.build(MetricConstants.SERVER_VERSION, metricHelp).
+                    labelNames(labels).register();
+            metricMap.put(MetricConstants.SERVER_VERSION, SERVER_VERSION);
         } else {
             SERVICE_UP = Gauge.build(MetricConstants.SERVICE_UP, "Service status").
                     labelNames(labels).register();
@@ -196,6 +202,12 @@ public class PrometheusReporter implements MetricReporter {
     public void serverUp(String host, String port, String javaHome, String javaVersion) {
         Gauge gauge = (Gauge) metricMap.get(MetricConstants.SERVER_UP);
         gauge.labels(host, port, javaHome, javaVersion).setToCurrentTime();
+    }
+
+    @Override
+    public void serverVersion(String version, String updateLevel) {
+        Gauge gauge = (Gauge) metricMap.get(MetricConstants.SERVER_VERSION);
+        gauge.labels(version, updateLevel).setToCurrentTime();
     }
 
     @Override
@@ -357,6 +369,15 @@ public class PrometheusReporter implements MetricReporter {
         createMetrics(MetricConstants.SERVER, MetricConstants.GAUGE, MetricConstants.SERVER_UP,
                 "Server Status", new String[]{MetricConstants.HOST, MetricConstants.PORT,
                         MetricConstants.JAVA_HOME_LABEL, MetricConstants.JAVA_VERSION_LABEL});
+    }
+
+    /**
+     * Create the metrics related to server version.
+     */
+    public void initializeServerVersionMetrics() {
+        createMetrics(MetricConstants.VERSION, MetricConstants.GAUGE, MetricConstants.SERVER_VERSION,
+                "Version and Update Level of Server",
+                new String[]{MetricConstants.VERSION_LABEL, MetricConstants.UPDATE_LEVEL_LABEL});
     }
 
     /**

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/util/MetricConstants.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/util/MetricConstants.java
@@ -28,6 +28,7 @@ public class MetricConstants {
     public static final String HTTP_PORT = "http.nio.port";
     public static final String JAVA_VERSION = "java.vm.specification.version";
     public static final String JAVA_HOME = "java.home";
+    public static final String UPDATE_LEVEL = "UPDATE_LEVEL";
 
     //Constants for Synapse properties
     public static final String TRANSPORT_IN_URL = "TransportInURL";
@@ -53,6 +54,7 @@ public class MetricConstants {
 
     public static final String SERVER_UP = "wso2_integration_server_up";
     public static final String SERVICE_UP = "wso2_integration_service_up";
+    public static final String SERVER_VERSION = "wso2_integration_server_version";
 
     public static final String METRIC_HANDLER = "metric_handler";
     public static final String PROXY_LATENCY_BUCKETS = "proxy_latency_buckets";
@@ -65,6 +67,7 @@ public class MetricConstants {
 
     public static final String SERVER = "Server";
     public static final String SERVICE = "Service";
+    public static final String VERSION = "Version";
 
     //Constants for Prometheus Metrics types
     public static final String COUNTER = "Counter";
@@ -78,5 +81,7 @@ public class MetricConstants {
     public static final String JAVA_HOME_LABEL = "java_home";
     public static final String HOST = "host";
     public static final String PORT = "port";
+    public static final String VERSION_LABEL = "version";
+    public static final String UPDATE_LEVEL_LABEL = "update_level";
 
 }

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/CoreServerInitializer.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/CoreServerInitializer.java
@@ -152,7 +152,8 @@ public class CoreServerInitializer {
                 log.fatal(serverName + " startup failed.");
                 throw new ServletException(msg);
             }
-
+            String updateLevel = MicroIntegratorBaseUtils.getUpdateLevel();
+            System.setProperty(MicroIntegratorBaseConstants.UPDATE_LEVEL, updateLevel);
             try {
                 System.setProperty(MicroIntegratorBaseConstants.LOCAL_IP_ADDRESS, NetworkUtils.getLocalHostname());
             } catch (SocketException ignored) {

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/MicroIntegratorBaseConstants.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/internal/MicroIntegratorBaseConstants.java
@@ -45,6 +45,7 @@ public class MicroIntegratorBaseConstants {
 
     public static final String COMPONENT_REP0_ENV = "COMPONENTS_REPO";
     public static final String AXIS2_REPO_ENV = "AXIS2_REPO";
+    public static final String UPDATE_LEVEL = "UPDATE_LEVEL";
 
     /**
      * Remove default constructor and make it not available to initialize.

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/util/MicroIntegratorBaseUtils.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/util/MicroIntegratorBaseUtils.java
@@ -18,6 +18,7 @@
 
 package org.wso2.micro.integrator.core.util;
 
+import com.google.gson.Gson;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.axis2.AxisFault;
@@ -46,20 +47,24 @@ import org.wso2.micro.integrator.core.internal.MicroIntegratorBaseConstants;
 import org.wso2.micro.integrator.core.resolver.CarbonEntityResolver;
 import org.wso2.micro.integrator.core.services.CarbonServerConfigurationService;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.lang.management.ManagementPermission;
 import java.lang.reflect.Array;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
@@ -80,6 +85,7 @@ public class MicroIntegratorBaseUtils {
     private static Log log = LogFactory.getLog(MicroIntegratorBaseUtils.class);
 
     private static final String REPOSITORY = "repository";
+    private static final String UPDATES = "updates";
     private static boolean isServerConfigInitialized;
     private static OMElement axis2Config;
     private static final String TRUE = "true";
@@ -97,6 +103,28 @@ public class MicroIntegratorBaseUtils {
             return getCarbonConfigDirPath() + File.separator + "carbon.xml";
         }
         return carbonXML + File.separator + "carbon.xml";
+    }
+
+    public static String getUpdateLevel() {
+        String defaultUpdateLevel = "-";
+        String carbonHome = getCarbonHome();
+        if (carbonHome != null) {
+            String configFilePath = carbonHome + File.separator + UPDATES + File.separator + "config.json";
+            File configFile = new File(configFilePath);
+            if (configFile.exists()) {
+                Gson gsonParser = new Gson();
+                try {
+                    Reader configFileReader = Files.newBufferedReader(Paths.get(configFilePath));
+                    Map<?, ?> configMap = gsonParser.fromJson(configFileReader, Map.class);
+                    return (String) configMap.get("update-level");
+                } catch (Exception e) {
+                    return defaultUpdateLevel;
+                }
+            } else {
+                return defaultUpdateLevel;
+            }
+        }
+        return defaultUpdateLevel;
     }
 
     public static String getCarbonConfigDirPath() {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.probes/src/main/java/org/wso2/micro/integrator/probes/ReadinessResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.probes/src/main/java/org/wso2/micro/integrator/probes/ReadinessResource.java
@@ -42,7 +42,7 @@ public class ReadinessResource extends APIResource {
     private static Log log = LogFactory.getLog(ReadinessResource.class);
     private static final String NO_ENTITY_BODY = "NO_ENTITY_BODY";
     private static final String HTTP_SC = "HTTP_SC";
-
+    public static final String UPDATE_LEVEL = "UPDATE_LEVEL";
     private int responseCode;
 
     /**
@@ -80,7 +80,8 @@ public class ReadinessResource extends APIResource {
         // appending MI server version number to the response
         CarbonServerConfigurationService serverConfig = CarbonServerConfigurationService.getInstance();
         String miVersion = serverConfig.getServerVersion();
-        response = "{\"version\":\"" + miVersion + "\",";
+        response = "{\"version\":\"" + miVersion + "\", \"update_level\":\"" + System.getProperty(UPDATE_LEVEL) +
+                "\", ";
 
         ArrayList<String> faultyCapps = new ArrayList<>(CappDeployer.getFaultyCapps());
         if (!faultyCapps.isEmpty()) {


### PR DESCRIPTION


## Purpose
Get version information of the MI Server and current update level
through helth check api and as a prometheus metrics.

Fix: https://github.com/wso2/micro-integrator/issues/2417