### PR TITLE
Construct apiInvocationUrl label using the context of the corresponding Api 

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/src/main/java/org/wso2/micro/integrator/observability/metric/handler/MetricHandler.java
@@ -133,12 +133,19 @@ public class MetricHandler extends AbstractExtendedSynapseHandler {
 
             if ((serviceInvokePort != internalHttpApiPort) && (null !=
                     axis2MessageContext.getProperty(MetricConstants.SERVICE_PREFIX))) {
-                String context = axis2MessageContext.getProperty(MetricConstants.TRANSPORT_IN_URL).
+                String url = axis2MessageContext.getProperty(MetricConstants.TRANSPORT_IN_URL).
                         toString();
-                String apiInvocationUrl = axis2MessageContext.getProperty(MetricConstants.SERVICE_PREFIX).
-                        toString() + context.replaceFirst(DELIMITER, EMPTY);
-                String apiName = getApiName(context, synCtx);
+                String apiName = getApiName(url, synCtx);
                 if (apiName != null) {
+                    String context = "";
+                    if (synCtx.getConfiguration() != null) {
+                        API api = synCtx.getConfiguration().getAPI(apiName);
+                        if (api != null) {
+                            context = api.getContext();
+                        }
+                    }
+                    String apiInvocationUrl = axis2MessageContext.getProperty(MetricConstants.SERVICE_PREFIX).
+                            toString() + context.replaceFirst(DELIMITER, EMPTY);
                     incrementAPICount(apiName, apiInvocationUrl);
                     startTimers(synCtx, apiName, SynapseConstants.FAIL_SAFE_MODE_API, apiInvocationUrl);
                 }


### PR DESCRIPTION
## Purpose
This PR constructs the apiInvocationUrl label using the context of the corresponding Api
```
<api context="/prometheus" name="testApi" xmlns="http://ws.apache.org/ns/synapse">
    <resource methods="GET" uri-template="/test/{testId}">
        <inSequence>
            <respond/>
        </inSequence>
        <outSequence/>
        <faultSequence/>
    </resource>
</api>
```
Prometheus metric for the above sample will be,
`wso2_integration_api_latency_seconds{instance="localhost:9201", invocation_url="http://127.0.0.1:8290/prometheus", job="esb_stats", le="+Inf", service_name="testApi", service_type="api"}`

Fixes https://github.com/wso2/micro-integrator/issues/2430
