### PR TITLE
Fix capp undeployment error in windows shared mount

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -763,7 +763,8 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                     renamedFile.deleteOnExit();
                 } else {
                     if (file.exists()) {
-                        handleException("Cannot delete the resource: " + file.getName());
+                        log.warn("Seems that the file still exists but unable to delete the resource: "
+                                + file.getName() + "could be due to another process is trying to delete the file");
                     } else {
                         if (log.isDebugEnabled()) {
                             log.debug("Unable to delete the resource as " +

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -762,7 +762,14 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                 if (file.renameTo(renamedFile)) {
                     renamedFile.deleteOnExit();
                 } else {
-                    handleException("Cannot delete the resource: " + file.getName());
+                    if (file.exists()) {
+                        handleException("Cannot delete the resource: " + file.getName());
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Unable to delete the resource as " +
+                                    file.getName() + " does not exist.");
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Purpose
This PR updates the registry resource deletion logic. The exception will be thrown when file.renameTo(renamedFile) fails and the corresponding file exists.
Fixes wso2/micro-integrator#2379
