### PR TITLE
Fix ClassNotFoundException upon server startup after updating MI

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.odata.endpoint/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.odata.endpoint/pom.xml
@@ -96,7 +96,7 @@
                             org.apache.commons.collections4.*,
                             javax.servlet;version="${imp.pkg.version.javax.servlet}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
-                            org.apache.synapse.*
+                            org.apache.synapse.*; version="${imp.pkg.version.synapse}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1373,6 +1373,7 @@
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
 
         <synapse.version>2.1.7-wso2v243</synapse.version>
+        <imp.pkg.version.synapse>[2.1.7, 2.1.8)</imp.pkg.version.synapse>
         <carbon.mediation.version>4.7.109</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>
         <carbon.crypto.api.imp.pkg.version.range>[1.1.0,1.2.0)</carbon.crypto.api.imp.pkg.version.range>


### PR DESCRIPTION
## Purpose
This PR fixes ClassNotFoundException upon server startup after updating MI via U2 update. 
The issue may happen since the synapse version will be wired to compile time version unless a version range is specified.

Fixes https://github.com/wso2/micro-integrator/issues/2056
