### PR TITLE
Update saxon jar to version 10.6 to support XSTL 3.0 and XPATH 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1671,7 +1671,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
 
         <atomikos.version>3.8.0.wso2v1</atomikos.version>
-        <saxon.wso2.version>9.5.1-8</saxon.wso2.version>
+        <saxon.wso2.version>10.6</saxon.wso2.version>
         <xercesImpl.orbit.version>2.12.0.wso2v1</xercesImpl.orbit.version>
         <commons-logging.version>1.2</commons-logging.version>
         <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
## Purpose
This PR upgrades the saxon dependency version to 10.6, in order to support XSLT and XPATH 3.x
Fixes https://github.com/wso2/micro-integrator/issues/1582

Tested the following sample, executed the integration tests without any issues.
```
<?xml version="1.0" encoding="UTF-8"?>
<proxy name="test" startOnLoad="true" transports="http https" xmlns="http://ws.apache.org/ns/synapse">
    <target>
<inSequence>
            <log level="full">
                <property name="Environment" expression="fn:environment-variable('vathsan')" xmlns:fn="http://www.w3.org/2005/xpath-functions"/>
                <property name="Substring" expression="fn:substring('helloWorld',1,5)" xmlns:fn="http://www.w3.org/2005/xpath-functions" />
                <property name="Concat" expression="fn:concat('test','concat')" xmlns:fn="http://www.w3.org/2005/xpath-functions"/>
            </log>
            <respond/>
        </inSequence>
        <outSequence/>
        <faultSequence/>
    </target>
</proxy>
```
You may refer to https://www.saxonica.com/documentation10/#!changes/all/9.5.1-10 for complete change history.


