### PR TITLE
Revert "Update saxon jar to version 10.6 to support XSTL 3.0 and XPATH 3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1677,7 +1677,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
 
         <atomikos.version>3.8.0.wso2v1</atomikos.version>
-        <saxon.wso2.version>10.6</saxon.wso2.version>
+        <saxon.wso2.version>9.5.1-8</saxon.wso2.version>
         <xercesImpl.orbit.version>2.12.0.wso2v1</xercesImpl.orbit.version>
         <commons-logging.version>1.2</commons-logging.version>
         <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
Reverts wso2/micro-integrator#2567

Reverting this since **dataMapperOneToOneXmlToXmlUsingXSLTTestProxy** test case is failing due to the following compilation issue,
```
Error at xsl:stylesheet on line 1 column 304
  XTSE0085: Namespace http://www.w3.org/2001/XMLSchema is reserved: it cannot be used for
  extension instructions (perhaps exclude-result-prefixes was intended).
[2022-02-08 11:52:36,813] ERROR {DataMapperMediator} - {proxy:testDatamapper} DataMapper mediator : mapping failed javax.xml.transform.TransformerConfigurationException: net.sf.saxon.s9api.SaxonApiException: Errors were reported during stylesheet compilation
at net.sf.saxon.jaxp.SaxonTransformerFactory.newTemplates(SaxonTransformerFactory.java:157)
at net.sf.saxon.jaxp.SaxonTransformerFactory.newTransformer(SaxonTransformerFactory.java:111)
at org.wso2.carbon.mediator.datamapper.engine.core.mapper.XSLTMappingHandler.<init>(XSLTMappingHandler.java:46)
at org.wso2.carbon.mediator.datamapper.DataMapperMediator.transform(DataMapperMediator.java:384)
at org.wso2.carbon.mediator.datamapper.DataMapperMediator.mediate(DataMapperMediator.java:314)
at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:109)
at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:71)
at org.apache.synapse.mediators.base.SequenceMediator.mediate(SequenceMediator.java:158)
at org.apache.synapse.core.axis2.ProxyServiceMessageReceiver.receive(ProxyServiceMessageReceiver.java:228)
at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180)
at org.apache.synapse.transport.passthru.ServerWorker.processNonEntityEnclosingRESTHandler(ServerWorker.java:375)
at org.apache.synapse.transport.passthru.ServerWorker.run(ServerWorker.java:189)
at org.apache.axis2.transport.base.threads.NativeWorkerPool$1.run(NativeWorkerPool.java:172)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
Caused by: net.sf.saxon.s9api.SaxonApiException: Errors were reported during stylesheet compilation
at net.sf.saxon.s9api.XsltCompiler.compile(XsltCompiler.java:843)
at net.sf.saxon.jaxp.SaxonTransformerFactory.newTemplates(SaxonTransformerFactory.java:154)
... 15 more
Caused by: net.sf.saxon.trans.XPathException: Errors were reported during stylesheet compilation
at net.sf.saxon.style.StylesheetModule.loadStylesheet(StylesheetModule.java:254)
at net.sf.saxon.style.Compilation.compileSingletonPackage(Compilation.java:113)
at net.sf.saxon.s9api.XsltCompiler.compile(XsltCompiler.java:838)
```
Since Namespace http://www.w3.org/2001/XMLSchema is used by default in datamapper stylesheet, we need to find a way to fix this without breaking the backward compatibility.