### PR TITLE
Include slf4j jar in data-services clients

### DIFF
--- a/integration/dataservice-hosting-tests/samples/data-services/clients/build.xml
+++ b/integration/dataservice-hosting-tests/samples/data-services/clients/build.xml
@@ -37,6 +37,7 @@
     <path id="axis2.class.path">
         <fileset dir="${wso2ds.home}">
             <include name="wso2/lib/*.jar" />
+            <include name="wso2/components/plugins/slf4j.api_*.jar" />
 	    <include name="wso2/components/plugins/joda-time_*.jar" />
         </fileset>
     </path>


### PR DESCRIPTION
## Purpose
When running integration tests for data services, DEBUG and INFO logs are printed by opensaml. To fix this we need to include the slf4j-api jar when building the data-services clients.