### PR TITLE
Fix NPE in DataServiceCall mediator

### DIFF
--- a/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediator.java
+++ b/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediator.java
@@ -152,7 +152,7 @@ public class DataServiceCallMediator extends AbstractMediator {
             if (rootOperation.equals(DataServiceCallMediatorConstants.JSON_OBJECT)) {
                 return handleJsonObject(operationElement, axis2MessageContext);
             } else {
-                AxisOperation axisOperation = axis2MessageContext.getAxisMessage().getAxisOperation();
+                AxisOperation axisOperation = axis2MessageContext.getAxisOperation();
                 QName rootOpQName = new QName(rootOperation);
                 axisOperation.setName(rootOpQName);
             }


### PR DESCRIPTION
## Purpose
> This PR fixes Null pointer exception occurs when DataServiceCall mediator invoked from Inbound Endpoint.