### PR TITLE
Add custom message type for management API.

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -101,6 +101,7 @@ public class Constants {
     public static final String HTTP_DELETE = "DELETE";
 
     public static final String HEADER_VALUE_APPLICATION_JSON = "application/json";
+    public static final String MANAGEMENT_APPLICATION_JSON = "application/json+management";
     public static final String MESSAGE_JSON_ATTRIBUTE = "Message";
 
     // Json attribute in response for synapse configuration

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Utils.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Utils.java
@@ -123,7 +123,14 @@ public class Utils {
             axis2MessageContext.setProperty(Constants.HTTP_STATUS_CODE, Constants.INTERNAL_SERVER_ERROR);
             LOG.error("Error occurred while setting json payload", axisFault);
         }
-        axis2MessageContext.setProperty("messageType", Constants.HEADER_VALUE_APPLICATION_JSON);
+
+        if (axis2MessageContext.getConfigurationContext().getAxisConfiguration().
+                getMessageFormatter(Constants.MANAGEMENT_APPLICATION_JSON) != null) {
+            axis2MessageContext.setProperty("messageType", Constants.MANAGEMENT_APPLICATION_JSON);
+        } else {
+            axis2MessageContext.setProperty("messageType", Constants.HEADER_VALUE_APPLICATION_JSON);
+        }
+
         axis2MessageContext.setProperty("ContentType", Constants.HEADER_VALUE_APPLICATION_JSON);
         axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
     }


### PR DESCRIPTION
Fix: https://github.com/wso2/micro-integrator/issues/2682

When changing the default message formatter for application/json content type, user can add a custom formatter to preserve a the management API behavior.

```
[message_formatters]
application_json = "org.apache.axis2.json.JSONMessageFormatter"

[[custom_message_formatters]]
class = "org.wso2.micro.integrator.core.json.JsonStreamFormatter"
content_type = "application/json+management"
```