### PR TITLE
[WIP] Fix SSL issue in Netty transport

### DIFF
--- a/integration/mediation-tests/tests-transport-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/inbound-endpoints/httpswss.xml
+++ b/integration/mediation-tests/tests-transport-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/inbound-endpoints/httpswss.xml
@@ -47,7 +47,7 @@
             </CertificateRevocationVerifier>
         </p:parameter>
         <p:parameter name="SSLProtocol">TLS</p:parameter>
-        <p:parameter name="HttpsProtocols">TLSv1.2,TLSv1.3</p:parameter>
+        <p:parameter name="HttpsProtocols">TLSv1.2,TLSv1.1</p:parameter>
         <p:parameter name="PreferredCiphers">
             TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
         </p:parameter>

--- a/integration/mediation-tests/tests-transport-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/inbound-endpoints/httpswssWithBackendCall.xml
+++ b/integration/mediation-tests/tests-transport-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/inbound-endpoints/httpswssWithBackendCall.xml
@@ -47,7 +47,7 @@
             </CertificateRevocationVerifier>
         </p:parameter>
         <p:parameter name="SSLProtocol">TLS</p:parameter>
-        <p:parameter name="HttpsProtocols">TLSv1.2,TLSv1.3</p:parameter>
+        <p:parameter name="HttpsProtocols">TLSv1.2,TLSv1.1</p:parameter>
         <p:parameter name="PreferredCiphers">
             TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
         </p:parameter>


### PR DESCRIPTION
## Purpose
HTTP/2 integration tests fail as the Jenkins java 8 build doesn't support TLSv1.3. It needs java8u272 and a later version to support TLSv1.3.

##Goal
Remove TLSv1.3 from the inbound endpoint configuration.


