### PR TITLE
Add MariaDB in GetDatabaseType

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/util/DatabaseCreator.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/util/DatabaseCreator.java
@@ -247,6 +247,8 @@ public class DatabaseCreator {
                     type = "derby";
                 } else if (dbUrl.matches("(?i).*mysql.*")) {
                     type = "mysql";
+                } else if (dbUrl.matches("(?i).*mariadb.*")) {
+                    type = "mysql";
                 } else if (dbUrl.matches("(?i).*oracle.*")) {
                     type = "oracle";
                 } else if (dbUrl.matches("(?i).*microsoft.*")) {


### PR DESCRIPTION
adding else if for MariaDB with type = "mysql"
when using the MariaDB JDBC driver we get an error:
Unsupported database: MariaDB. Database will not be created automatically by the WSO2 Registry. Please create the database using appropriate database scripts for the database.

With the MySQL JDBC and a MariaDB database it works fine.

## Purpose
When using the [MariaDB Connector](https://mariadb.com/downloads/connectors/connectors-data-access/java8-connector/) for the user database it gives an error with initializing the user-store:
```
Unsupported database: MariaDB. 
Database will not be created automatically by the WSO2 Registry.
Please create the database using appropriate database scripts for the database.
```


## Goals
Usage of the MariaDB Connector for initializing the database instead of only for the connection

## Approach
Extra if check in the GetDatabaseType for MariaDB

## User stories
> Summary of user stories addressed by this change>

## Release note
add support for the MariaDB JDBC connector for the user-store

## Documentation
N/A

## Training
N/A

## Certification
N/A This only allows for usage of the official MariaDB JDBC

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
amazon-corretto-11-openjdk on Centos7 and AmazonLinux 2
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.