### PR TITLE
Add proxy username and password configurations

### DIFF
--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -171,16 +171,12 @@
   "transport.blocking.http.sender.default_connections_per_host": "transport.blocking.http.sender.parameter.defaultMaxConnectionsPerHost",
   "transport.blocking.http.sender.omit_soap12_action": "transport.blocking.http.sender.parameter.OmitSOAP12Action",
   "transport.blocking.http.sender.so_timeout": "transport.blocking.http.sender.parameter.SO_TIMEOUT",
-  "transport.blocking.http.sender.proxy_host": "transport.blocking.http.sender.parameter.'http.proxyHost'",
-  "transport.blocking.http.sender.proxy_port": "transport.blocking.http.sender.parameter.'http.proxyPort'",
 
   "transport.blocking.http.sender.secured_enable_client_caching": "transport.blocking.https.sender.parameter.cacheHttpClient",
   "transport.blocking.http.sender.secured_transfer_encoding": "transport.blocking.https.sender.parameter.Transfer-Encoding",
   "transport.blocking.http.sender.secured_default_connections_per_host": "transport.blocking.https.sender.parameter.defaultMaxConnectionsPerHost",
   "transport.blocking.http.sender.secured_omit_soap12_action": "transport.blocking.https.sender.parameter.OmitSOAP12Action",
   "transport.blocking.http.sender.secured_so_timeout": "transport.blocking.https.sender.parameter.SO_TIMEOUT",
-  "transport.blocking.http.sender.secured_proxy_host": "transport.blocking.https.sender.parameter.'http.proxyHost'",
-  "transport.blocking.http.sender.secured_proxy_port": "transport.blocking.https.sender.parameter.'http.proxyPort'",
 
   "transport.mail.sender:parameter.hostname": "transport.mail.sender:parameter.'mail.smtp.host'",
   "transport.mail.sender:parameter.port": "transport.mail.sender:parameter.'mail.smtp.port'",

--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -146,11 +146,15 @@
   "transport.http.sender.warn_on_http_500": "transport.http.sender.parameter.'warnOnHTTP500'",
   "transport.http.sender.proxy_host": "transport.http.sender.parameter.'http.proxyHost'",
   "transport.http.sender.proxy_port": "transport.http.sender.parameter.'http.proxyPort'",
+  "transport.http.sender.proxy_username": "transport.http.sender.parameter.'http.proxy.username'",
+  "transport.http.sender.proxy_password": "transport.http.sender.parameter.'http.proxy.password'",
 
   "transport.http.sender.hostname_verifier": "transport.https.sender.parameter.'HostnameVerifier'",
   "transport.http.sender.secured_protocols": "transport.https.sender.parameter.HttpsProtocols",
   "transport.http.sender.secured_proxy_host": "transport.https.sender.parameter.'http.proxyHost'",
   "transport.http.sender.secured_proxy_port": "transport.https.sender.parameter.'http.proxyPort'",
+  "transport.http.sender.secured_proxy_username": "transport.https.sender.parameter.'http.proxy.username'",
+  "transport.http.sender.secured_proxy_password": "transport.https.sender.parameter.'http.proxy.password'",
 
   "transport.blocking.http.listener.port": "transport.blocking.http.listener.parameter.port",
   "transport.blocking.http.listener.hostname": "transport.blocking.http.listener.parameter.hostname",

--- a/distribution/src/resources/config-tool/templates/conf/axis2/axis2_blocking_client.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/axis2/axis2_blocking_client.xml.j2
@@ -21,13 +21,17 @@
     <!-- Parameters -->
     <!-- ================================================= -->
 
-    {% if transport.blocking.proxy is defined %}
+    {% if transport.blocking.http.sender.proxy_host is defined %}
     <parameter name="Proxy">
         <parameters>
-            <ProxyHost>{{transport.blocking.proxy.host}}</ProxyHost>
-            <ProxyPort>{{transport.blocking.proxy.port}}</ProxyPort>
-            <ProxyUser>{{transport.blocking.proxy.username}}</ProxyUser>
-            <ProxyPassword>{{transport.blocking.proxy.password}}</ProxyPassword>
+            <ProxyHost>{{transport.blocking.http.sender.proxy_host}}</ProxyHost>
+            <ProxyPort>{{transport.blocking.http.sender.proxy_port}}</ProxyPort>
+            {% if transport.blocking.http.sender.proxy_username is defined %}
+            <ProxyUser>{{transport.blocking.http.sender.proxy_username}}</ProxyUser>
+            {% endif %}
+            {% if transport.blocking.http.sender.proxy_password is defined %}
+            <ProxyPassword>{{transport.blocking.http.sender.proxy_password}}</ProxyPassword>
+            {% endif %}
         </parameters>
     </parameter>
     {% endif %}

--- a/distribution/src/resources/config-tool/templates/conf/axis2/axis2_blocking_client.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/axis2/axis2_blocking_client.xml.j2
@@ -20,6 +20,18 @@
     <!-- ================================================= -->
     <!-- Parameters -->
     <!-- ================================================= -->
+
+    {% if transport.blocking.proxy is defined %}
+    <parameter name="Proxy">
+        <parameters>
+            <ProxyHost>{{transport.blocking.proxy.host}}</ProxyHost>
+            <ProxyPort>{{transport.blocking.proxy.port}}</ProxyPort>
+            <ProxyUser>{{transport.blocking.proxy.username}}</ProxyUser>
+            <ProxyPassword>{{transport.blocking.proxy.password}}</ProxyPassword>
+        </parameters>
+    </parameter>
+    {% endif %}
+
     <parameter name="hotdeployment">true</parameter>
     <parameter name="hotupdate">false</parameter>
     <parameter name="enableMTOM">{{server.enableMTOM}}</parameter>


### PR DESCRIPTION
## Purpose
This PR adds proxy username and password configurations for blocking and non-blocking services.

Fixes https://github.com/wso2/api-manager/issues/167