### PR TITLE
Add null pointer check when setting the message ID

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
@@ -157,7 +157,9 @@ public class JMSInjectHandler {
                                     msg.getBooleanProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED));
             // set the JMS Message ID as the Message ID of the MessageContext
             try {
-                msgCtx.setMessageID(msg.getJMSMessageID());
+                if (msg.getJMSMessageID() != null) {
+                    msgCtx.setMessageID(msg.getJMSMessageID());
+                }
                 String jmsCorrelationID = msg.getJMSCorrelationID();
                 if (jmsCorrelationID != null && !jmsCorrelationID.isEmpty()) {
                     msgCtx.setProperty(JMSConstants.JMS_COORELATION_ID, jmsCorrelationID);


### PR DESCRIPTION
## Purpose
This PR adds a null pointer check when setting the message ID.

Fixes https://github.com/wso2/product-ei/issues/5573