### PR TITLE
Add optional flag support to JSON results

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QueryFactory.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QueryFactory.java
@@ -809,9 +809,9 @@ public class QueryFactory {
 
         private String dataType;
 
-		private String requiredRoles;
+        private String requiredRoles;
 
-		private String isOptional;
+        private String isOptional;
 
         public ResultEntryColumnInfo(String value) throws DataServiceFault {
             // {"name":"$jack(type:integer;requiredRoles:admin,role1)"

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QueryFactory.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QueryFactory.java
@@ -809,7 +809,9 @@ public class QueryFactory {
 
         private String dataType;
 
-        private String requiredRoles;
+		private String requiredRoles;
+
+		private String isOptional;
 
         public ResultEntryColumnInfo(String value) throws DataServiceFault {
             // {"name":"$jack(type:integer;requiredRoles:admin,role1)"
@@ -848,6 +850,8 @@ public class QueryFactory {
                 this.requiredRoles = value;
             } else if (DBSFields.TYPE.equals(name)) {
                 this.dataType = value;
+            } else if (DBSFields.OPTIONAL.equals(name)) {
+                this.isOptional = value;
             } else {
                 throw new DataServiceFault("Unrecognized option type '" + name + "', "
                         + "found: " + name);
@@ -866,6 +870,9 @@ public class QueryFactory {
             return dataType;
         }
 
+        public String getIsOptional() {
+            return isOptional;
+        }
     }
 
     private static ResultEntryColumnInfo extractJSONResultColumnInfo(
@@ -927,6 +934,9 @@ public class QueryFactory {
             }
             if (info.getRequiredRoles() != null) {
                 childEl.addAttribute(DBSFields.REQUIRED_ROLES, info.getRequiredRoles(), null);
+            }
+            if (info.getIsOptional() != null) {
+                childEl.addAttribute(DBSFields.OPTIONAL, info.getIsOptional(), null);
             }
         }
     }


### PR DESCRIPTION
## Purpose
> Fixes: [134](https://github.com/wso2-enterprise/wso2-apim-internal/issues/134)

## Approach
> Added optional flag support to JSON results. 

## Test environment
> wso2mi-1.2.0