### PR TITLE
Added OpenTelemetry appender for log telemetry and synapse properties configurations

### DIFF
--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -303,6 +303,7 @@ logger.AUDIT_LOG.additivity = false
 logger.opentelemetry-trace.name = tracer
 logger.opentelemetry-trace.level = TRACE
 logger.opentelemetry-trace.appenderRef.OPEN_TELEMETRY.ref = OPEN_TELEMETRY
+logger.opentelemetry-trace.additivity = false
 
 logger.SERVICE_LOGGER.name= SERVICE_LOGGER
 logger.SERVICE_LOGGER.level = INFO

--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -37,7 +37,7 @@
 
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, osgi, SERVICE_LOGFILE, API_LOGFILE, ERROR_LOGFILE, CORRELATION
+appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, osgi, SERVICE_LOGFILE, API_LOGFILE, ERROR_LOGFILE, CORRELATION, OPEN_TELEMETRY
 #, syslog
 
 # CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
@@ -83,6 +83,23 @@ appender.AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.AUDIT_LOGFILE.strategy.max = 20
 appender.AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
 appender.AUDIT_LOGFILE.filter.threshold.level = INFO
+
+appender.OPEN_TELEMETRY.type = RollingFile
+appender.OPEN_TELEMETRY.name = OPEN_TELEMETRY
+appender.OPEN_TELEMETRY.fileName = ${sys:carbon.home}/repository/logs/wso2-mi-open-telemetry.log
+appender.OPEN_TELEMETRY.filePattern = ${sys:carbon.home}/repository/logs/wso2-mi-open-telemetry-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TELEMETRY.layout.type = PatternLayout
+appender.OPEN_TELEMETRY.layout.pattern = %d{MM-dd-yyyy}-%d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%n
+appender.OPEN_TELEMETRY.policies.type = Policies
+appender.OPEN_TELEMETRY.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TELEMETRY.policies.time.interval = 1
+appender.OPEN_TELEMETRY.policies.time.modulate = true
+appender.OPEN_TELEMETRY.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TELEMETRY.policies.size.size = 10MB
+appender.OPEN_TELEMETRY.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TELEMETRY.strategy.max = 20
+appender.OPEN_TELEMETRY.filter.threshold.type = ThresholdFilter
+appender.OPEN_TELEMETRY.filter.threshold.level = TRACE
 
 # Appender config to SERVICE_LOGFILE
 appender.SERVICE_LOGFILE.type = RollingFile
@@ -206,7 +223,7 @@ loggers = AUDIT_LOG, SERVICE_LOGGER, API_LOGGER, trace-messages, org-apache-coyo
   PassThroughHttpListener, PassThroughHttpSSLListener, DeploymentEngine, TaskServiceImpl, SynapseControllerFactory, \
   Axis2SynapseController, MultiXMLConfigurationBuilder, XMLConfigurationBuilder, \
   VFSTransportListener, NTaskTaskManager, MediationStatisticsComponent, SynapseConfigurationBuilder, ServerManager, correlation, \
-  synapse-transport-http-headers, synapse-transport-http-wire, httpclient-wire-header, httpclient-wire-content, SMBJ
+  synapse-transport-http-headers, synapse-transport-http-wire, httpclient-wire-header, httpclient-wire-content, SMBJ, trace
 
 # Uncomment the following section and comment the above for verbose logging
 #loggers = AUDIT_LOG, SERVICE_LOGGER, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, \
@@ -282,6 +299,10 @@ logger.AUDIT_LOG.name = AUDIT_LOG
 logger.AUDIT_LOG.level = INFO
 logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
 logger.AUDIT_LOG.additivity = false
+
+logger.trace.name = tracer
+logger.trace.level = TRACE
+logger.trace.appenderRef.OPEN_TELEMETRY.ref = OPEN_TELEMETRY
 
 logger.SERVICE_LOGGER.name= SERVICE_LOGGER
 logger.SERVICE_LOGGER.level = INFO

--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -223,7 +223,7 @@ loggers = AUDIT_LOG, SERVICE_LOGGER, API_LOGGER, trace-messages, org-apache-coyo
   PassThroughHttpListener, PassThroughHttpSSLListener, DeploymentEngine, TaskServiceImpl, SynapseControllerFactory, \
   Axis2SynapseController, MultiXMLConfigurationBuilder, XMLConfigurationBuilder, \
   VFSTransportListener, NTaskTaskManager, MediationStatisticsComponent, SynapseConfigurationBuilder, ServerManager, correlation, \
-  synapse-transport-http-headers, synapse-transport-http-wire, httpclient-wire-header, httpclient-wire-content, SMBJ, trace
+  synapse-transport-http-headers, synapse-transport-http-wire, httpclient-wire-header, httpclient-wire-content, SMBJ, opentelemetry-trace
 
 # Uncomment the following section and comment the above for verbose logging
 #loggers = AUDIT_LOG, SERVICE_LOGGER, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, \
@@ -300,9 +300,9 @@ logger.AUDIT_LOG.level = INFO
 logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
 logger.AUDIT_LOG.additivity = false
 
-logger.trace.name = tracer
-logger.trace.level = TRACE
-logger.trace.appenderRef.OPEN_TELEMETRY.ref = OPEN_TELEMETRY
+logger.opentelemetry-trace.name = tracer
+logger.opentelemetry-trace.level = TRACE
+logger.opentelemetry-trace.appenderRef.OPEN_TELEMETRY.ref = OPEN_TELEMETRY
 
 logger.SERVICE_LOGGER.name= SERVICE_LOGGER
 logger.SERVICE_LOGGER.level = INFO

--- a/distribution/src/resources/config-tool/infer.json
+++ b/distribution/src/resources/config-tool/infer.json
@@ -175,6 +175,9 @@
     },
     "zipkin": {
       "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.ZipkinTelemetryManager"
+    },
+    "log": {
+      "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.LogTelemetryManager"
     }
   }
 


### PR DESCRIPTION
## Purpose
> Added OpenTelemetry appender for log telemetry to create the log and synapse properties configurations for the type Log.

New OpenTelemetry configurations in deployment.toml file for WSO2 synapse.

**OpenTelemetry for Log,**

```
[opentelemetry]
enable = true
logs = true
type = "log"
```
After you invoke the APIs you will be able to see telemetry data in the `wso2-mi-open-telemetry.log` in the `<MI_HOME>/repository/logs` folder.

## Related PRs
> https://github.com/wso2/wso2-synapse/pull/1976
