### PR TITLE
Add runtime Configurable Correlation log support

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigNotFoundException.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigNotFoundException.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigNotFoundException.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigNotFoundException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.micro.integrator.management.apis;
+
+public class ConfigNotFoundException extends Exception {
+    public ConfigNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigNotFoundException.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigNotFoundException.java
@@ -1,19 +1,18 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC (http://www.wso2.com).
  *
- * WSO2 LLC. licenses this file to you under the Apache License,
+ * WSO2 LLC licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.wso2.micro.integrator.management.apis;
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigNotFoundException.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
@@ -86,12 +86,11 @@ public class ConfigsResource implements MiApiResource {
                     break;
                 }
             }
-
         } catch (ConfigNotFoundException e) {
             response = Utils.createJsonError(" Error : ", e, axis2MessageContext, Constants.BAD_REQUEST);
         } catch (IOException e) {
             LOG.error("Error when parsing JSON payload", e);
-            response = Utils.createJsonErrorObject("Error when parsing JSON payload");
+            response = Utils.createJsonErrorObject("Error while parsing JSON payload");
         }
 
         Utils.setJsonPayLoad(axis2MessageContext, response);
@@ -120,8 +119,7 @@ public class ConfigsResource implements MiApiResource {
                 if (!configs.has(ENABLED)) {
                     throw new ConfigNotFoundException("Missing Required Field: " + ENABLED);
                 }
-                String enabledAsaString = configs.get(ENABLED).getAsString();
-                boolean enabled = Boolean.parseBoolean(enabledAsaString);
+                boolean enabled = Boolean.parseBoolean(configs.get(ENABLED).getAsString());
                 PassThroughCorrelationConfigDataHolder.setEnable(enabled);
                 JSONObject response = new JSONObject();
                 response.put(Constants.MESSAGE, "Successfully Updated Correlation Logs Status");
@@ -143,7 +141,8 @@ public class ConfigsResource implements MiApiResource {
         switch (configName) {
             case CORRELATION: {
                 JSONObject configs = new JSONObject();
-                Boolean correlationEnabled = PassThroughCorrelationConfigDataHolder.isEnable();
+//                Boolean correlationEnabled = PassThroughCorrelationConfigDataHolder.isEnable();
+                Boolean correlationEnabled = true;
                 configs.put(ENABLED, correlationEnabled);
                 response = new JSONObject();
                 response.put(CONFIG_NAME, configName);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
@@ -85,7 +85,6 @@ public class ConfigsResource implements MiApiResource {
             }
 
         } catch (ConfigNotFoundException e) {
-            LOG.warn("Error when parsing the request :", e);
             response = Utils.createJsonError(" Error : ", e, axis2MessageContext, Constants.BAD_REQUEST);
         } catch (IOException e) {
             LOG.error("Error when parsing JSON payload", e);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -44,7 +44,6 @@ public class ConfigsResource implements MiApiResource {
     Set<String> methods;
 
     public ConfigsResource() {
-
         methods = new HashSet<>();
         methods.add(Constants.HTTP_GET);
         methods.add(Constants.HTTP_PUT);
@@ -52,22 +51,18 @@ public class ConfigsResource implements MiApiResource {
 
     @Override
     public Set<String> getMethods() {
-
         return methods;
     }
 
     @Override
     public boolean invoke(MessageContext messageContext,
                           org.apache.axis2.context.MessageContext axis2MessageContext, SynapseConfiguration synapseConfiguration) {
-
         String httpMethod = axis2MessageContext.getProperty(Constants.HTTP_METHOD_PROPERTY) != null ?
                 axis2MessageContext.getProperty(Constants.HTTP_METHOD_PROPERTY).toString() :
                 "method undefined";
-
         if (LOG.isDebugEnabled()) {
             LOG.debug("Handling" + httpMethod + "request");
         }
-
         JSONObject response;
         try {
             switch (httpMethod) {
@@ -92,14 +87,12 @@ public class ConfigsResource implements MiApiResource {
             LOG.error("Error when parsing JSON payload", e);
             response = Utils.createJsonErrorObject("Error while parsing JSON payload");
         }
-
         Utils.setJsonPayLoad(axis2MessageContext, response);
         return true;
     }
 
     private JSONObject handlePut(org.apache.axis2.context.MessageContext axis2MessageContext)
             throws ConfigNotFoundException, IOException {
-
         if (!JsonUtil.hasAJsonPayload(axis2MessageContext)) {
             return Utils.createJsonErrorObject("JSON payload is missing");
         }
@@ -132,7 +125,6 @@ public class ConfigsResource implements MiApiResource {
     }
 
     private JSONObject handleGet(MessageContext messageContext) throws ConfigNotFoundException {
-
         String configName = Utils.getQueryParameter(messageContext, CONFIG_NAME);
         if (configName == null) {
             throw new ConfigNotFoundException("Missing Required Query Parameter : configName");
@@ -141,8 +133,7 @@ public class ConfigsResource implements MiApiResource {
         switch (configName) {
             case CORRELATION: {
                 JSONObject configs = new JSONObject();
-//                Boolean correlationEnabled = PassThroughCorrelationConfigDataHolder.isEnable();
-                Boolean correlationEnabled = true;
+                Boolean correlationEnabled = PassThroughCorrelationConfigDataHolder.isEnable();
                 configs.put(ENABLED, correlationEnabled);
                 response = new JSONObject();
                 response.put(CONFIG_NAME, configName);
@@ -155,5 +146,4 @@ public class ConfigsResource implements MiApiResource {
         }
         return response;
     }
-
 }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
@@ -1,19 +1,18 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC (http://www.wso2.com).
  *
- * WSO2 LLC. licenses this file to you under the Apache License,
+ * WSO2 LLC licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.wso2.micro.integrator.management.apis;
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.micro.integrator.management.apis;
+
+import com.google.gson.JsonObject;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.transport.passthru.config.PassThroughCorrelationConfigDataHolder;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This resource will handle requests coming to configs/.
+ */
+public class ConfigsResource implements MiApiResource {
+
+    private static final Log LOG = LogFactory.getLog(ConfigsResource.class);
+
+    private static final String CONFIG_NAME = "configName";
+    private static final String CONFIGS = "configs";
+    private static final String CORRELATION = "correlation";
+    private static final String ENABLED = "enabled";
+    Set<String> methods;
+
+    public ConfigsResource() {
+
+        methods = new HashSet<>();
+        methods.add(Constants.HTTP_GET);
+        methods.add(Constants.HTTP_PUT);
+    }
+
+    @Override public Set<String> getMethods() {
+        return methods;
+    }
+
+    @Override public boolean invoke(MessageContext messageContext,
+            org.apache.axis2.context.MessageContext axis2MessageContext, SynapseConfiguration synapseConfiguration) {
+
+        String httpMethod = axis2MessageContext.getProperty(Constants.HTTP_METHOD_PROPERTY) != null ?
+                axis2MessageContext.getProperty(Constants.HTTP_METHOD_PROPERTY).toString() :
+                "method undefined";
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Handling" + httpMethod + "request");
+        }
+
+        JSONObject response;
+        try {
+            switch (httpMethod) {
+            case Constants.HTTP_GET: {
+                response = handleGet(messageContext);
+                break;
+            }
+            case Constants.HTTP_PUT: {
+                response = handlePut(axis2MessageContext);
+                break;
+            }
+            default: {
+                response = Utils.createJsonError(
+                        "Unsupported HTTP method, " + httpMethod + ". Only GET and " + "PUT methods are supported",
+                        axis2MessageContext, Constants.BAD_REQUEST);
+                break;
+            }
+            }
+
+        } catch (ConfigNotFoundException e) {
+            LOG.warn("Error when parsing the request :", e);
+            response = Utils.createJsonError(" Error : ", e, axis2MessageContext, Constants.BAD_REQUEST);
+        } catch (IOException e) {
+            LOG.error("Error when parsing JSON payload", e);
+            response = Utils.createJsonErrorObject("Error when parsing JSON payload");
+        }
+
+        Utils.setJsonPayLoad(axis2MessageContext, response);
+        return true;
+    }
+
+    private JSONObject handlePut(org.apache.axis2.context.MessageContext axis2MessageContext)
+            throws ConfigNotFoundException, IOException {
+
+        if (!JsonUtil.hasAJsonPayload(axis2MessageContext)) {
+            return Utils.createJsonErrorObject("JSON payload is missing");
+        }
+        JsonObject payload = Utils.getJsonPayload(axis2MessageContext);
+        String configName;
+        if (!payload.has(CONFIG_NAME)) {
+            throw new ConfigNotFoundException("Missing Required Field: " + CONFIG_NAME);
+        }
+        configName = payload.get(CONFIG_NAME).getAsString();
+        switch (configName) {
+        case CORRELATION: {
+            JsonObject configs;
+            if (!payload.has(CONFIGS)) {
+                throw new ConfigNotFoundException("Missing Required Field: " + CONFIGS);
+            }
+            configs = payload.get(CONFIGS).getAsJsonObject();
+            if (!configs.has(ENABLED)) {
+                throw new ConfigNotFoundException("Missing Required Field: " + ENABLED);
+            }
+            String enabledAsaString = configs.get(ENABLED).getAsString();
+            boolean enabled = Boolean.parseBoolean(enabledAsaString);
+            PassThroughCorrelationConfigDataHolder.setEnable(enabled);
+            JSONObject response = new JSONObject();
+            response.put(Constants.MESSAGE, "Successfully Updated Correlation Logs Status");
+            return response;
+        }
+        default: {
+            throw new ConfigNotFoundException(configName + " configName not found");
+        }
+        }
+    }
+
+    private JSONObject handleGet(MessageContext messageContext) throws ConfigNotFoundException {
+        String configName = Utils.getQueryParameter(messageContext, CONFIG_NAME);
+        if (configName == null) {
+            throw new ConfigNotFoundException("Missing Required Query Parameter : configName");
+        }
+        JSONObject response;
+        switch (configName) {
+        case CORRELATION: {
+            JSONObject configs = new JSONObject();
+            Boolean correlationEnabled = PassThroughCorrelationConfigDataHolder.isEnable();
+            configs.put(ENABLED, correlationEnabled);
+            response = new JSONObject();
+            response.put(CONFIG_NAME, configName);
+            response.put(CONFIGS, configs);
+            break;
+        }
+        default: {
+            throw new ConfigNotFoundException(configName + " configName not found");
+        }
+        }
+        return response;
+    }
+
+}

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -54,6 +54,7 @@ public class Constants {
     public static final String PATH_PARAM_ROLE = "/" + "{role}";
     public static final String PATH_PARAM_TRANSACTION = "/" + "{param}";
     public static final String ROOT_CONTEXT = "/";
+    public static final String PREFIX_CONFIGS = "/configs";
 
     public static final String COUNT = "count";
     public static final String TOTAL_COUNT = "totalCount";

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementInternalApi.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementInternalApi.java
@@ -56,6 +56,7 @@ import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_SERVER_
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_TASKS;
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_TEMPLATES;
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_TRANSACTION;
+import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_CONFIGS;
 import static org.wso2.micro.integrator.management.apis.Constants.PREFIX_USERS;
 import static org.wso2.micro.integrator.management.apis.Constants.REST_API_CONTEXT;
 import static org.wso2.micro.integrator.management.apis.Constants.ROOT_CONTEXT;
@@ -100,6 +101,7 @@ public class ManagementInternalApi implements InternalAPI {
         resourcesList.add(new ApiResourceAdapter(PREFIX_DATA_SOURCES, new DataSourceResource()));
         resourcesList.add(new ApiResourceAdapter(PREFIX_ROLES, new RolesResource()));
         resourcesList.add(new ApiResourceAdapter(PREFIX_ROLES + PATH_PARAM_ROLE, new RoleResource()));
+        resourcesList.add(new ApiResourceAdapter(PREFIX_CONFIGS, new ConfigsResource()));
         resources = new APIResource[resourcesList.size()];
         resources = resourcesList.toArray(resources);
     }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandler.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandler.java
@@ -51,6 +51,7 @@ public class AuthorizationHandler extends AuthorizationHandlerAdapter {
         defaultResources = new ArrayList<>(1);
         defaultResources.add(Constants.PREFIX_USERS);
         defaultResources.add(Constants.PREFIX_ROLES);
+        defaultResources.add(Constants.PREFIX_CONFIGS);
     }
 
     @Override

--- a/integration/management-api-tests/src/test/java/org/wso2/micro/integrator/api/ConfigsResourceTestCase.java
+++ b/integration/management-api-tests/src/test/java/org/wso2/micro/integrator/api/ConfigsResourceTestCase.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.micro.integrator.api;
+
+import org.apache.http.HttpResponse;
+import org.awaitility.Awaitility;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.exceptions.AutomationFrameworkException;
+import org.wso2.esb.integration.common.extensions.carbonserver.CarbonTestServerManager;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.clients.SimpleHttpClient;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test case to test the correlation configs of the management API.
+ */
+public class ConfigsResourceTestCase extends ESBIntegrationTest {
+
+    private String carbonHome;
+    private CarbonTestServerManager server;
+    private int offset;
+
+    /**
+     * Sets environment.
+     *
+     * @throws Exception the exception
+     */
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+        offset = portOffset + 10;
+    }
+
+    /**
+     * Test retrieve correlation configs. This will check whether the management API retrieves
+     * proper correlation config status which is 'false' and reads the correlation log file
+     * which should be blank.
+     *
+     * @throws IOException                  the io exception
+     * @throws AutomationFrameworkException the automation framework exception
+     */
+    @Test(groups = { "wso2.esb" }, description = "Test get configs resource for correlation")
+    public void testRetrieveCorrelationConfigs() throws IOException, AutomationFrameworkException{
+
+        startNewServer(false);
+        sendGetRequest(offset, false);
+        String apiLogFilePath = carbonHome + File.separator + "repository"
+                + File.separator + "logs" + File.separator + "correlation.log";
+        BufferedReader bufferedReader = new BufferedReader(new FileReader(apiLogFilePath));
+        String logLine = bufferedReader.readLine();
+        Assert.assertNull(logLine);
+
+    }
+
+    /**
+     * Test update correlation configs. This will update the correlation configs using the
+     * management API. It will check whether the update was successful by retrieving the
+     * correlation logs status from the management API and reading the correlation log file
+     * for logs.
+     *
+     * @throws IOException the io exception
+     */
+    @Test(groups = { "wso2.esb" }, dependsOnMethods = {"testRetrieveCorrelationConfigs"},
+            description = "Test get configs resource for correlation")
+    public void testUpdateCorrelationConfigs() throws IOException {
+
+        sendPutRequest(offset, true);
+        sendGetRequest(offset, true);
+
+        String apiLogFilePath = carbonHome + File.separator + "repository"
+                + File.separator + "logs" + File.separator + "correlation.log";
+        BufferedReader bufferedReader = new BufferedReader(new FileReader(apiLogFilePath));
+        String logLine = bufferedReader.readLine();
+        Assert.assertNotNull(logLine);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            Assert.assertTrue(logLine.contains("HTTP State Transition") ||
+                    logLine.contains("ROUND-TRIP LATENCY") || logLine.contains("Thread switch latency"));
+        }
+    }
+
+    /**
+     * Test retrieve correlation configs with system parameter. This will start up the server
+     * with the enableCorrelationLogs flag. It will check whether the GET request of correlation
+     * config retrieves the proper status which is 'true'. It will check whether a PUT request
+     * will override the setting from the system property. ( Should not be able to override ).
+     * This is confirmed by reading the correlation log file again.
+     *
+     * @throws IOException                  the io exception
+     * @throws AutomationFrameworkException the automation framework exception
+     */
+    @Test(groups = { "wso2.esb" }, dependsOnMethods = {"testUpdateCorrelationConfigs"},
+            description = "Test get configs resource for correlation with system parameter")
+    public void testRetrieveCorrelationConfigsWithSystemParameter() throws IOException, AutomationFrameworkException{
+        stopServer();
+        startNewServer(true);
+        sendGetRequest(offset, true);
+        sendPutRequest(offset, false);
+
+
+        String apiLogFilePath = carbonHome + File.separator + "repository"
+                + File.separator + "logs" + File.separator + "correlation.log";
+        BufferedReader bufferedReader = new BufferedReader(new FileReader(apiLogFilePath));
+        String logLine = bufferedReader.readLine();
+        Assert.assertNotNull(logLine);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            Assert.assertTrue(logLine.contains("HTTP State Transition") ||
+                    logLine.contains("ROUND-TRIP LATENCY") || logLine.contains("Thread switch latency"));
+        }
+
+
+        sendGetRequest(offset,true);
+
+        while ((logLine = bufferedReader.readLine()) != null) {
+            Assert.assertTrue(logLine.contains("HTTP State Transition") ||
+                    logLine.contains("ROUND-TRIP LATENCY") || logLine.contains("Thread switch latency"));
+        }
+
+
+    }
+
+    /**
+     * Start a new server.
+     * @throws IOException
+     * @throws AutomationFrameworkException
+     */
+    private void startNewServer(boolean enableCorrelationLogs) throws IOException, AutomationFrameworkException {
+        HashMap<String, String> startupParameterMap = new HashMap<>();
+        startupParameterMap.put("-DportOffset", String.valueOf(offset));
+        startupParameterMap.put("-DenableCorrelationLogs", String.valueOf(enableCorrelationLogs));
+        startupParameterMap.put("startupScript", "micro-integrator");
+
+        server = new CarbonTestServerManager(context, System.getProperty("carbon.zip"), startupParameterMap);
+        server.startServer();
+        Awaitility.await().pollInterval(50, TimeUnit.MILLISECONDS).atMost(DEFAULT_TIMEOUT, TimeUnit.SECONDS).
+                until(isManagementApiAvailable());
+        carbonHome = server.getCarbonHome();
+        Assert.assertNotNull(carbonHome);
+    }
+
+
+    private void stopServer() throws AutomationFrameworkException{
+        server.stopServer();
+    }
+
+
+
+    private void sendGetRequest(int offset, boolean correlationConfigStatus) throws IOException {
+        String accessToken = TokenUtil.getAccessToken(hostName, offset);
+        Assert.assertNotNull(accessToken);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept", "application/json");
+        headers.put("Authorization", "Bearer " + accessToken);
+
+        String endpoint = "https://" + hostName + ":" + (DEFAULT_INTERNAL_API_HTTPS_PORT + offset) + "/management/"
+                + "configs?configName=correlation";
+
+        SimpleHttpClient client = new SimpleHttpClient();
+
+        HttpResponse response = client.doGet(endpoint, headers);
+        String responsePayload = client.getResponsePayload(response);
+        Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+        JSONObject jsonResponse = new JSONObject(responsePayload);
+        Assert.assertTrue(jsonResponse.has("configName"));
+        Assert.assertEquals(jsonResponse.get("configName"), "correlation");
+        Assert.assertTrue(jsonResponse.has("configs"));
+        JSONObject responseConfigs = (JSONObject) jsonResponse.get("configs");
+        Assert.assertTrue(responseConfigs.has("enabled"));
+        Assert.assertEquals(responseConfigs.get("enabled"), correlationConfigStatus);
+    }
+
+
+    private void sendPutRequest(int offset, boolean correlationConfigEnabled) throws IOException {
+        String accessToken = TokenUtil.getAccessToken(hostName, offset);
+        Assert.assertNotNull(accessToken);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept", "application/json");
+        headers.put("Authorization", "Bearer " + accessToken);
+
+        String endpoint = "https://" + hostName + ":" + (DEFAULT_INTERNAL_API_HTTPS_PORT + offset) + "/management/"
+                + "configs";
+
+        JSONObject payloadConfigs = new JSONObject();
+        payloadConfigs.put("enabled", correlationConfigEnabled);
+        JSONObject payload = new JSONObject();
+        payload.put("configName", "correlation");
+        payload.put("configs", payloadConfigs);
+
+
+        SimpleHttpClient client = new SimpleHttpClient();
+        HttpResponse response = client.doPut(endpoint, headers, payload.toString(), "application/json");
+        String responsePayload = client.getResponsePayload(response);
+        Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+        JSONObject jsonResponse = new JSONObject(responsePayload);
+        Assert.assertTrue(jsonResponse.has("message"));
+        Assert.assertEquals(jsonResponse.get("message"), "Successfully Updated Correlation Logs Status");
+    }
+
+    /**
+     * Return if the management api is available.
+     * @return
+     */
+    public Callable<Boolean> isManagementApiAvailable() {
+        return this::checkIfManagementApiAvailable;
+    }
+
+    /**
+     * return if the management api is unavailable.
+     *
+     * @return callable callable
+     */
+    public Callable<Boolean> isManagementApiUnAvailable() {
+        return () -> !checkIfManagementApiAvailable();
+    }
+
+    /**
+     * Check if the management api is available
+     * @return
+     */
+    private boolean checkIfManagementApiAvailable() {
+        try (Socket socket = new Socket(hostName, DEFAULT_INTERNAL_API_HTTPS_PORT + offset)) {
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Clean state.
+     *
+     * @throws Exception the exception
+     */
+    @AfterClass(alwaysRun = true)
+    public void cleanState() throws Exception {
+        stopServer();
+        System.setProperty("port.offset", String.valueOf(portOffset));
+        System.setProperty("enableCorrelationLogs", String.valueOf(false));
+        super.cleanup();
+    }
+
+}

--- a/integration/management-api-tests/src/test/java/org/wso2/micro/integrator/api/ConfigsResourceTestCase.java
+++ b/integration/management-api-tests/src/test/java/org/wso2/micro/integrator/api/ConfigsResourceTestCase.java
@@ -72,7 +72,7 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
     public void testRetrieveCorrelationConfigs() throws IOException, AutomationFrameworkException {
 
         startNewServer(false);
-        sendGetRequest(offset, false);
+        getCorrelationLogStateAndAssert(offset, false);
         String apiLogFilePath = carbonHome + File.separator + "repository"
                 + File.separator + "logs" + File.separator + "correlation.log";
         BufferedReader bufferedReader = new BufferedReader(new FileReader(apiLogFilePath));
@@ -92,8 +92,8 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
             description = "Test get configs resource for correlation")
     public void testUpdateCorrelationConfigsEnable() throws IOException {
 
-        sendPutRequest(offset, true);
-        sendGetRequest(offset, true);
+        updateCorrelationLogState(offset, true);
+        getCorrelationLogStateAndAssert(offset, true);
 
         String apiLogFilePath = carbonHome + File.separator + "repository"
                 + File.separator + "logs" + File.separator + "correlation.log";
@@ -117,7 +117,7 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
             description = "Test get configs resource for correlation")
     public void testUpdateCorrelationConfigsDisable() throws IOException {
 
-        sendPutRequest(offset, false);
+        updateCorrelationLogState(offset, false);
 
         String apiLogFilePath = carbonHome + File.separator + "repository"
                 + File.separator + "logs" + File.separator + "correlation.log";
@@ -129,7 +129,7 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
                     logLine.contains("ROUND-TRIP LATENCY") || logLine.contains("Thread switch latency"));
         }
 
-        sendGetRequest(offset, false);
+        getCorrelationLogStateAndAssert(offset, false);
         logLine = bufferedReader.readLine();
         Assert.assertNull(logLine);
     }
@@ -150,8 +150,8 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
 
         stopServer();
         startNewServer(true);
-        sendGetRequest(offset, true);
-        sendPutRequest(offset, false);
+        getCorrelationLogStateAndAssert(offset, true);
+        updateCorrelationLogState(offset, false);
 
         String apiLogFilePath = carbonHome + File.separator + "repository"
                 + File.separator + "logs" + File.separator + "correlation.log";
@@ -163,7 +163,7 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
                     logLine.contains("ROUND-TRIP LATENCY") || logLine.contains("Thread switch latency"));
         }
 
-        sendGetRequest(offset, true);
+        getCorrelationLogStateAndAssert(offset, true);
 
         while ((logLine = bufferedReader.readLine()) != null) {
             Assert.assertTrue(logLine.contains("HTTP State Transition") ||
@@ -197,7 +197,7 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
         server.stopServer();
     }
 
-    private void sendGetRequest(int offset, boolean correlationConfigStatus) throws IOException {
+    private void getCorrelationLogStateAndAssert(int offset, boolean correlationConfigStatus) throws IOException {
 
         String accessToken = TokenUtil.getAccessToken(hostName, offset);
         Assert.assertNotNull(accessToken);
@@ -223,7 +223,7 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
         Assert.assertEquals(responseConfigs.get("enabled"), correlationConfigStatus);
     }
 
-    private void sendPutRequest(int offset, boolean correlationConfigEnabled) throws IOException {
+    private void updateCorrelationLogState(int offset, boolean correlationConfigEnabled) throws IOException {
 
         String accessToken = TokenUtil.getAccessToken(hostName, offset);
         Assert.assertNotNull(accessToken);
@@ -284,7 +284,7 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
 
         stopServer();
         System.setProperty("port.offset", String.valueOf(portOffset));
-        System.setProperty("enableCorrelationLogs", String.valueOf(false));
+        System.setProperty("enableCorrelationLogs", "false");
         super.cleanup();
     }
 }

--- a/integration/management-api-tests/src/test/java/org/wso2/micro/integrator/api/ConfigsResourceTestCase.java
+++ b/integration/management-api-tests/src/test/java/org/wso2/micro/integrator/api/ConfigsResourceTestCase.java
@@ -77,7 +77,6 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
         BufferedReader bufferedReader = new BufferedReader(new FileReader(apiLogFilePath));
         String logLine = bufferedReader.readLine();
         Assert.assertNull(logLine);
-
     }
 
     /**
@@ -135,15 +134,12 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
                     logLine.contains("ROUND-TRIP LATENCY") || logLine.contains("Thread switch latency"));
         }
 
-
         sendGetRequest(offset,true);
 
         while ((logLine = bufferedReader.readLine()) != null) {
             Assert.assertTrue(logLine.contains("HTTP State Transition") ||
                     logLine.contains("ROUND-TRIP LATENCY") || logLine.contains("Thread switch latency"));
         }
-
-
     }
 
     /**
@@ -165,12 +161,9 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
         Assert.assertNotNull(carbonHome);
     }
 
-
     private void stopServer() throws AutomationFrameworkException{
         server.stopServer();
     }
-
-
 
     private void sendGetRequest(int offset, boolean correlationConfigStatus) throws IOException {
         String accessToken = TokenUtil.getAccessToken(hostName, offset);
@@ -197,7 +190,6 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
         Assert.assertEquals(responseConfigs.get("enabled"), correlationConfigStatus);
     }
 
-
     private void sendPutRequest(int offset, boolean correlationConfigEnabled) throws IOException {
         String accessToken = TokenUtil.getAccessToken(hostName, offset);
         Assert.assertNotNull(accessToken);
@@ -215,7 +207,6 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
         payload.put("configName", "correlation");
         payload.put("configs", payloadConfigs);
 
-
         SimpleHttpClient client = new SimpleHttpClient();
         HttpResponse response = client.doPut(endpoint, headers, payload.toString(), "application/json");
         String responsePayload = client.getResponsePayload(response);
@@ -231,15 +222,6 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
      */
     public Callable<Boolean> isManagementApiAvailable() {
         return this::checkIfManagementApiAvailable;
-    }
-
-    /**
-     * return if the management api is unavailable.
-     *
-     * @return callable callable
-     */
-    public Callable<Boolean> isManagementApiUnAvailable() {
-        return () -> !checkIfManagementApiAvailable();
     }
 
     /**
@@ -266,5 +248,4 @@ public class ConfigsResourceTestCase extends ESBIntegrationTest {
         System.setProperty("enableCorrelationLogs", String.valueOf(false));
         super.cleanup();
     }
-
 }

--- a/integration/management-api-tests/src/test/resources/testng.xml
+++ b/integration/management-api-tests/src/test/resources/testng.xml
@@ -31,6 +31,7 @@
             <class name="org.wso2.micro.integrator.api.AuditLogTestCase"/>
             <class name="org.wso2.micro.integrator.api.CarbonAppResourceTestCase"/>
             <class name="org.wso2.micro.integrator.api.MetaDataResourceTestCase"/>
+            <class name="org.wso2.micro.integrator.api.ConfigsResourceTestCase"/>
         </classes>
     </test>
 </suite>

--- a/integration/management-api-tests/src/test/resources/testng.xml
+++ b/integration/management-api-tests/src/test/resources/testng.xml
@@ -28,10 +28,10 @@
 
     <test name="Management-API-Tests" verbose="2" parallel="false">
         <classes>
+            <class name="org.wso2.micro.integrator.api.ConfigsResourceTestCase"/>
             <class name="org.wso2.micro.integrator.api.AuditLogTestCase"/>
             <class name="org.wso2.micro.integrator.api.CarbonAppResourceTestCase"/>
             <class name="org.wso2.micro.integrator.api.MetaDataResourceTestCase"/>
-            <class name="org.wso2.micro.integrator.api.ConfigsResourceTestCase"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -1449,7 +1449,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
 
-        <synapse.version>2.1.7-wso2v282</synapse.version>
+        <synapse.version>2.1.7-wso2v288-SNAPSHOT</synapse.version>
         <imp.pkg.version.synapse>[2.1.7, 2.1.8)</imp.pkg.version.synapse>
         <carbon.mediation.version>4.7.131</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1449,7 +1449,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
 
-        <synapse.version>2.1.7-wso2v288-SNAPSHOT</synapse.version>
+        <synapse.version>2.1.7-wso2v282</synapse.version>
         <imp.pkg.version.synapse>[2.1.7, 2.1.8)</imp.pkg.version.synapse>
         <carbon.mediation.version>4.7.131</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1449,7 +1449,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
 
-        <synapse.version>2.1.7-wso2v282</synapse.version>
+        <synapse.version>2.1.7-wso2v303</synapse.version>
         <imp.pkg.version.synapse>[2.1.7, 2.1.8)</imp.pkg.version.synapse>
         <carbon.mediation.version>4.7.131</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>


### PR DESCRIPTION
## Purpose
> Fix: wso2/api-manager#191
> Fix: wso2/api-manager#263
> Fix: wso2/api-manager#265




## Approach
> A management API resource is added with context path /configs to
support enable/disable correlation logs without a server restart.

