### PR TITLE
Added configurations to enable OtlpExporter

### DIFF
--- a/distribution/src/resources/config-tool/infer.json
+++ b/distribution/src/resources/config-tool/infer.json
@@ -178,6 +178,9 @@
     },
     "log": {
       "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.LogTelemetryManager"
+    },
+    "otlp": {
+      "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.OTLPTelemetryManager"
     }
   }
 

--- a/distribution/src/resources/config-tool/templates/conf/synapse.properties.j2
+++ b/distribution/src/resources/config-tool/templates/conf/synapse.properties.j2
@@ -29,3 +29,6 @@ synapse.sal.endpoints.sesssion.timeout.default=600000
 synapse.carbon.ext.tenant.info=org.wso2.micro.integrator.initializer.handler.MITenantInfoConfigurator
 mediation.flow.statistics.event.consume.interval=1000
 mediation.flow.statistics.event.clean.interval=15000
+{%for property in opentelemetry.otlp.header_properties %}
+opentelemetry.otlp.header_properties.{{property.name}} = {{property.value}}
+{% endfor %}

--- a/distribution/src/resources/config-tool/templates/conf/synapse.properties.j2
+++ b/distribution/src/resources/config-tool/templates/conf/synapse.properties.j2
@@ -29,6 +29,6 @@ synapse.sal.endpoints.sesssion.timeout.default=600000
 synapse.carbon.ext.tenant.info=org.wso2.micro.integrator.initializer.handler.MITenantInfoConfigurator
 mediation.flow.statistics.event.consume.interval=1000
 mediation.flow.statistics.event.clean.interval=15000
-{%for property in opentelemetry.otlp.header_properties %}
-opentelemetry.otlp.header_properties.{{property.name}} = {{property.value}}
+{%for property in opentelemetry.properties %}
+opentelemetry.properties.{{property.name}} = {{property.value}}
 {% endfor %}

--- a/pom.xml
+++ b/pom.xml
@@ -1454,9 +1454,9 @@
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
 
-        <synapse.version>2.1.7-wso2v299</synapse.version>
+        <synapse.version>2.1.7-wso2v301</synapse.version>
         <imp.pkg.version.synapse>[2.1.7, 2.1.8)</imp.pkg.version.synapse>
-        <carbon.mediation.version>4.7.131</carbon.mediation.version>
+        <carbon.mediation.version>4.7.135</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>
         <carbon.crypto.api.imp.pkg.version.range>[1.1.0,1.2.0)</carbon.crypto.api.imp.pkg.version.range>
         <carbon.data.version>4.5.2</carbon.data.version>


### PR DESCRIPTION
## Purpose
> Added the OtlpExporter with OpenTelemetry support to enable tracing.

## Goals
> This exporter support for APMs such as NewRelic, Elastic, etc.
> Recommended to use OtlpExporter with following configuration types to view traces in respective APMs.

## Approach
> The following configurations should be added in deployment.toml file,
```
[opentelemetry]
enable = true
logs = true
type = “otlp”
url = “endpoint-url”

[[opentelemetry.properties]]
name = “name-of-the-header”
value = “key-value-of-the-header” 
```
if anyone uses NewRelic APM to view the traces, the following configurations should be added.
```
[opentelemetry]
enable = true
logs = true
type = “otlp”
url = “https://otlp.nr-data.net:4317/v1/traces”

[[opentelemetry.properties]]
name = “api-key”
value = “<your-insight-insert-key>” 
```

## Related PRs
> https://github.com/wso2/wso2-synapse/pull/1984
