### PR TITLE
netty jars version upgrade to fix micro-integrator startup issue in aarch64

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/pom.xml
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/pom.xml
@@ -94,6 +94,10 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
         </dependency>
         <dependency>

--- a/features/data-features/data-services-feature/org.wso2.micro.integrator.dataservices.server.feature/pom.xml
+++ b/features/data-features/data-services-feature/org.wso2.micro.integrator.dataservices.server.feature/pom.xml
@@ -80,6 +80,7 @@
                                 <bundleDef>io.netty:netty-handler</bundleDef>
                                 <bundleDef>io.netty:netty-buffer</bundleDef>
                                 <bundleDef>io.netty:netty-transport</bundleDef>
+                                <bundleDef>io.netty:netty-transport-native-unix-common</bundleDef>
                                 <bundleDef>io.netty:netty-codec</bundleDef>
                                 <bundleDef>io.netty:netty-common</bundleDef>
                                 <bundleDef>org.mongodb:mongo-java-driver</bundleDef>

--- a/features/mediation-features/inbound-endpoint/org.wso2.micro.integrator.inbound.endpoints.server.feature/pom.xml
+++ b/features/mediation-features/inbound-endpoint/org.wso2.micro.integrator.inbound.endpoints.server.feature/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
         </dependency>
         <dependency>
@@ -142,6 +146,7 @@
                                 <bundleDef>ca.uhn.hapi.wso2:hapi</bundleDef>
                                 <bundleDef>io.netty:netty-common:compatible:${netty.version}</bundleDef>
                                 <bundleDef>io.netty:netty-transport:compatible:${netty.version}</bundleDef>
+                                <bundleDef>io.netty:netty-transport-native-unix-common:compatible:${netty.version}</bundleDef>
                                 <bundleDef>io.netty:netty-codec-http:compatible:${netty.version}</bundleDef>
                                 <bundleDef>io.netty:netty-codec:compatible:${netty.version}</bundleDef>
                                 <bundleDef>io.netty:netty-buffer:compatible:${netty.version}</bundleDef>

--- a/features/mediation-features/transport-features/org.wso2.micro.integrator.websocket.feature/pom.xml
+++ b/features/mediation-features/transport-features/org.wso2.micro.integrator.websocket.feature/pom.xml
@@ -90,6 +90,7 @@
                                 <bundleDef>org.wso2.ei:org.wso2.micro.integrator.websocket.transport</bundleDef>
                                 <bundleDef>io.netty:netty-common:compatible:${netty.version}</bundleDef>
                                 <bundleDef>io.netty:netty-transport:compatible:${netty.version}</bundleDef>
+                                <bundleDef>io.netty:netty-transport-native-unix-common:compatible:${netty.version}</bundleDef>
                                 <bundleDef>io.netty:netty-codec-http:compatible:${netty.version}</bundleDef>
                                 <bundleDef>io.netty:netty-codec:compatible:${netty.version}</bundleDef>
                                 <bundleDef>io.netty:netty-buffer:compatible:${netty.version}</bundleDef>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -618,6 +618,11 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
                 <version>${netty.version}</version>
             </dependency>
@@ -804,8 +809,8 @@
         <hawtbuf.version>1.9</hawtbuf.version>
         <geronimo.specs.jms.version>1.1.1</geronimo.specs.jms.version>
         <ibatis-core.version>3.0</ibatis-core.version>
-        <netty.version>4.1.77.Final</netty.version>
-        <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
+        <netty.version>4.1.79.Final</netty.version>
+        <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <org.eclipse.paho.version>1.2.0</org.eclipse.paho.version>
         <activemq.version>5.9.1</activemq.version>
         <ca.uhn.hapi.wso2.version>2.1.0.wso2v1</ca.uhn.hapi.wso2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -577,6 +577,11 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
                 <version>${netty.version}</version>
             </dependency>
@@ -1567,8 +1572,8 @@
         <google.guava.version>31.0.1-jre</google.guava.version>
         <ca.uhn.hapi.wso2.version>2.1.0.wso2v1</ca.uhn.hapi.wso2.version>
         <junit.version>4.8.2</junit.version>
-        <netty.version>4.1.73.Final</netty.version>
-        <netty.tcnative.version>2.0.47.Final</netty.tcnative.version>
+        <netty.version>4.1.79.Final</netty.version>
+        <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <jacoco.agent.version>0.8.2</jacoco.agent.version>
         <activemq.version>5.2.0</activemq.version>
         <activemq.broker.version>5.15.2</activemq.broker.version>


### PR DESCRIPTION
## Purpose
WSO2 Micro Gateway was not properly starting on aarch64 architecture. The root cause was regarding to an issue in netty libraries which was [fixed](https://github.com/netty/netty/pull/12498). This change upgrades the netty libraries used in micro-integrator so that the fix provided by netty is reflected.