### PR TITLE
Update saxon version to provide XSTL 3.0, XQuery and XPATH 3.1 support

### DIFF
--- a/distribution/src/LICENSE.txt
+++ b/distribution/src/LICENSE.txt
@@ -308,7 +308,7 @@ org.wso2.ciphertool-1.1.15.jar                                                  
 antlr4-runtime-4.7.1.jar                                                                            bundle         bsd
 slf4j-simple-1.7.36.jar                                                                             bundle         mit
 slf4j-api-1.7.36.jar                                                                                bundle         mit
-Saxon-HE-9.5.1-8.jar                                                                                jar            mpl20
+Saxon-HE-10.8.jar                                                                                   jar            mpl20
 commons-logging-1.2.jar                                                                             bundle         apache2
 org.wso2.micro.integrator.bootstrap-4.1.0.jar                                                       bundle         apache2
 tomcat-juli-9.0.58.jar                                                                              bundle         apache2

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/registry/governance/datamapperSimpleTestCase/xml_to_xml_using_xslt/xsltStyleSheet.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/registry/governance/datamapperSimpleTestCase/xml_to_xml_using_xslt/xsltStyleSheet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:firstElementOfTheInput="company" xmlns:notXSLTCompatible="false" xmlns:own="http://ownfunction.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" extension-element-prefixes="xs own notXSLTCompatible firstElementOfTheInput" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:firstElementOfTheInput="company" xmlns:notXSLTCompatible="false" xmlns:own="http://ownfunction.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" extension-element-prefixes="own notXSLTCompatible firstElementOfTheInput" exclude-result-prefixes="xs" version="2.0">
     <xsl:function name="own:setPrecision">
         <xsl:param name="resultString"/>
         <xsl:param name="noOfDigits"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1750,7 +1750,7 @@
         <antlr4.runtime.version>4.5.1.wso2v1</antlr4.runtime.version>
 
         <atomikos.version>3.8.0.wso2v1</atomikos.version>
-        <saxon.wso2.version>9.5.1-8</saxon.wso2.version>
+        <saxon.wso2.version>10.8</saxon.wso2.version>
         <xercesImpl.orbit.version>2.12.2.wso2v1</xercesImpl.orbit.version>
         <commons-logging.version>1.2</commons-logging.version>
         <mockito.version>2.23.4</mockito.version>


### PR DESCRIPTION
## Purpose
Provide support to XSTL 3.0, XQuery and XPATH 3.1

## Approach
Upgrade saxon jar to version 10.8

## Release note
This will provide XSTL 3.0, XQuery and XPATH 3.1 support

## Documentation
Documentations are in-progress

## Migrations (if applicable)
Migration scripts are in-progress
