### PR TITLE
JDK 17 migration

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.common/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.common/pom.xml
@@ -50,4 +50,19 @@
         </plugins>
     </build>
 
+    <dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/components/org.wso2.micro.integrator.bootstrap/src/main/java/org/wso2/micro/integrator/bootstrap/CarbonSecurityManager.java
+++ b/components/org.wso2.micro.integrator.bootstrap/src/main/java/org/wso2/micro/integrator/bootstrap/CarbonSecurityManager.java
@@ -18,8 +18,6 @@
 
 package org.wso2.micro.integrator.bootstrap;
 
-import sun.security.util.SecurityConstants;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +28,7 @@ import java.util.List;
 public class CarbonSecurityManager extends SecurityManager {
 
     private List<String> deniedProperties = new ArrayList<String>();
+    private static final RuntimePermission MODIFY_THREADGROUP_PERMISSION = new RuntimePermission("modifyThreadGroup");
 
     public CarbonSecurityManager() {
         super();
@@ -82,7 +81,7 @@ public class CarbonSecurityManager extends SecurityManager {
             throw new NullPointerException("thread group can't be null");
         }
 
-        checkPermission(SecurityConstants.MODIFY_THREADGROUP_PERMISSION);
+        checkPermission(MODIFY_THREADGROUP_PERMISSION);
     }
 
     /**
@@ -97,7 +96,7 @@ public class CarbonSecurityManager extends SecurityManager {
             throw new NullPointerException("thread can't be null");
         }
 
-        checkPermission(SecurityConstants.MODIFY_THREADGROUP_PERMISSION);
+        checkPermission(MODIFY_THREADGROUP_PERMISSION);
     }
 
 }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/pom.xml
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/pom.xml
@@ -128,6 +128,11 @@
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
+                    <argLine>
+                        @{argLine}
+                        -Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl
+                        -Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/test/java/org/wso2/micro/integrator/management/apis/ManagementApiParserTest.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/test/java/org/wso2/micro/integrator/management/apis/ManagementApiParserTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.ConfigurationLoader;
@@ -42,6 +43,8 @@ import static org.wso2.micro.integrator.management.apis.Constants.NAME_ATTR;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ConfigurationLoader.class)
+@PowerMockIgnore({"javax.xml.*", "org.xml.*", "javax.management.*", "javax.xml.parsers.*", "javax.naming.spi.*", "javax.naming.*", "javax" +
+        ".xml.stream.*",  "org.apache.xerces.jaxp.*", "com.sun.org.apache.xerces.internal.jaxp.*", "org.w3c.dom.*"})
 public class ManagementApiParserTest {
 
     private void initializeConfDirectory() {

--- a/components/org.wso2.micro.integrator.ndatasource.rdbms/pom.xml
+++ b/components/org.wso2.micro.integrator.ndatasource.rdbms/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${maven.bundle.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/internal/ServiceComponent.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/internal/ServiceComponent.java
@@ -43,7 +43,7 @@ import org.wso2.micro.integrator.security.user.core.ldap.ReadOnlyLDAPUserStoreMa
 import java.util.Hashtable;
 
 @Component (
-        name = "org.wso2.micro.integrator.security.internal.ServiceComponent",
+        name = "org.wso2.micro.integrator.security",
         immediate = true
 )
 public class ServiceComponent {

--- a/distribution/src/scripts/micro-integrator.bat
+++ b/distribution/src/scripts/micro-integrator.bat
@@ -148,12 +148,12 @@ set CMD=RUN %*
 :checkJdk
 PATH %PATH%;%JAVA_HOME%\bin\
 for /f tokens^=2-5^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set "JAVA_VERSION=%%j%%k"
-if %JAVA_VERSION% LSS 90 goto unknownJdk
+if %JAVA_VERSION% LSS 110 goto unknownJdk
 goto supportedJdk
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK %JAVA_VERSION%)
-echo [ERROR] CARBON is not supported below JDK 9
+echo [ERROR] CARBON is not supported below JDK 11
 goto supportedJdk
 
 :supportedJdk

--- a/distribution/src/scripts/micro-integrator.bat
+++ b/distribution/src/scripts/micro-integrator.bat
@@ -148,12 +148,12 @@ set CMD=RUN %*
 :checkJdk
 PATH %PATH%;%JAVA_HOME%\bin\
 for /f tokens^=2-5^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set "JAVA_VERSION=%%j%%k"
-if %JAVA_VERSION% LSS 18 goto unknownJdk
+if %JAVA_VERSION% LSS 90 goto unknownJdk
 goto supportedJdk
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK %JAVA_VERSION%)
-echo [ERROR] CARBON is not supported below JDK 1.8
+echo [ERROR] CARBON is not supported below JDK 9
 goto supportedJdk
 
 :supportedJdk

--- a/distribution/src/scripts/micro-integrator.sh
+++ b/distribution/src/scripts/micro-integrator.sh
@@ -192,9 +192,9 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0107 ] || [ $java_version_formatted -gt 1100 ]; then
+if [ $java_version_formatted -lt 0109 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 MI (in unsupported JDK)"
-   echo " [ERROR] MI is supported only on JDK 1.8, 9, 10 and 11"
+   echo " [ERROR] CARBON is not supported below JDK 9 to 17"
 fi
 
 CARBON_XBOOTCLASSPATH=""

--- a/distribution/src/scripts/micro-integrator.sh
+++ b/distribution/src/scripts/micro-integrator.sh
@@ -192,9 +192,9 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0109 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 MI (in unsupported JDK)"
-   echo " [ERROR] CARBON is not supported below JDK 9 to 17"
+   echo " [ERROR] CARBON is not supported below JDK 11 to 17"
 fi
 
 CARBON_XBOOTCLASSPATH=""

--- a/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml
+++ b/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml
@@ -53,6 +53,10 @@
             <groupId>org.wso2.carbon.mediation</groupId>
             <artifactId>org.wso2.carbon.connector.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/migration/migration-service/pom.xml
+++ b/migration/migration-service/pom.xml
@@ -71,7 +71,7 @@
     <properties>
         <commons.logging.version>1.1</commons.logging.version>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
-        <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
+        <maven.bundle.plugin.version>${maven.bundle.plugin.version}</maven.bundle.plugin.version>
         <migration.from.mi.version>1.1.0</migration.from.mi.version>
         <org.osgi.version>1.3.0</org.osgi.version>
         <carbon.registry.version>4.7.24</carbon.registry.version>

--- a/p2-profile/carbon.product
+++ b/p2-profile/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.6.3" useFeatures="true" includeLaunchers="true">
+version="4.7.1" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.6.3" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.6.3"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.7.1"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -1370,6 +1370,21 @@
                 <artifactId>jsonassert</artifactId>
                 <version>${jsonassert.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${com.sun.jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${com.sun.jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>${version.org.wso2.orbit.javax.activation}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1462,11 +1477,12 @@
         <carbon.kernel.version>4.6.3</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
+        <com.sun.jaxb.version>2.3.0</com.sun.jaxb.version>
 
 
-        <synapse.version>2.1.7-wso2v304</synapse.version>
+        <synapse.version>2.1.7-wso2v305</synapse.version>
         <imp.pkg.version.synapse>[2.1.7, 2.1.8)</imp.pkg.version.synapse>
-        <carbon.mediation.version>4.7.136</carbon.mediation.version>
+        <carbon.mediation.version>4.7.137</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>
         <carbon.crypto.api.imp.pkg.version.range>[1.1.0,1.2.0)</carbon.crypto.api.imp.pkg.version.range>
         <carbon.data.version>4.5.2</carbon.data.version>
@@ -1479,7 +1495,7 @@
         <sap-adapter.feature.version>4.7.36</sap-adapter.feature.version>
 
         <cipher.tool.version>1.1.15</cipher.tool.version>
-        <axis2.transport.version>2.0.0-wso2v65</axis2.transport.version>
+        <axis2.transport.version>2.0.0-wso2v66</axis2.transport.version>
         <transport.http.netty.version>6.3.35</transport.http.netty.version>
 
         <esotericsoftware.kryo.version>3.0.3</esotericsoftware.kryo.version>
@@ -1784,6 +1800,8 @@
         <version.disruptor>3.4.2</version.disruptor>
         <version.geronimo.jta.spec>1.1</version.geronimo.jta.spec>
         <quartz.orbit.version>2.3.2.wso2v1</quartz.orbit.version>
+        <!-- Maven bundle plugin -->
+        <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
     </properties>
 
     <repositories>
@@ -1910,20 +1928,13 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-scr-plugin</artifactId>
-                    <version>1.7.2</version>
-                    <executions>
-                        <execution>
-                            <id>generate-scr-scrdescriptor</id>
-                            <goals>
-                                <goal>scr</goal>
-                            </goals>
-                        </execution>
-                    </executions>
+                    <version>1.26.2</version>
+
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>${maven.bundle.plugin.version}</version>
                     <extensions>true</extensions>
                     <configuration>
                         <obrRepository>NONE</obrRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -1474,15 +1474,15 @@
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
 
         <!-- Carbon kernel version-->
-        <carbon.kernel.version>4.6.3</carbon.kernel.version>
+        <carbon.kernel.version>4.7.1</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.5.0,5.0.0)</carbon.kernel.imp.pkg.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
         <com.sun.jaxb.version>2.3.0</com.sun.jaxb.version>
 
 
-        <synapse.version>2.1.7-wso2v305</synapse.version>
+        <synapse.version>2.1.7-wso2v310</synapse.version>
         <imp.pkg.version.synapse>[2.1.7, 2.1.8)</imp.pkg.version.synapse>
-        <carbon.mediation.version>4.7.137</carbon.mediation.version>
+        <carbon.mediation.version>4.7.141</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>
         <carbon.crypto.api.imp.pkg.version.range>[1.1.0,1.2.0)</carbon.crypto.api.imp.pkg.version.range>
         <carbon.data.version>4.5.2</carbon.data.version>
@@ -1544,7 +1544,7 @@
         <orbit.version.tiles>2.0.5.wso2v1</orbit.version.tiles>
         <version.ant>1.7.0.wso2v1</version.ant>
         <version.xmlbeans>2.3.0</version.xmlbeans>
-        <orbit.version.axiom>1.2.11-wso2v22</orbit.version.axiom>
+        <orbit.version.axiom>1.2.11-wso2v25</orbit.version.axiom>
         <neethi.osgi.version>2.0.4.wso2v5</neethi.osgi.version>
         <version.woden>1.0.0.M9-wso2v1</version.woden>
         <orbit.version.wsdl4j>1.6.2.wso2v4</orbit.version.wsdl4j>


### PR DESCRIPTION
## Purpose
> Migrating Micro Integrator to run on JDK 17
> This PR address the JDK 11 build issues. Building in JDK 11 is a sub-task for migrating Micro Integrator to JDK 17
Related issue: https://github.com/wso2/api-manager/issues/179