### PR TITLE
Use a modifiable map of the GRPC event headers map to allow content type changes

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/grpc/GRPCInjectHandler.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/grpc/GRPCInjectHandler.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.inbound.endpoint.protocol.grpc.util.Event;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 
 /**
  * Inject gRPC message into the sequence.
@@ -143,7 +144,7 @@ public class GRPCInjectHandler {
         MessageContext axis2MsgCtx =
                 ((org.apache.synapse.core.axis2.Axis2MessageContext) msgCtx).getAxis2MessageContext();
         //setting transport headers
-        axis2MsgCtx.setProperty(MessageContext.TRANSPORT_HEADERS, receivedEvent.getHeadersMap());
+        axis2MsgCtx.setProperty(MessageContext.TRANSPORT_HEADERS, new HashMap<>(receivedEvent.getHeadersMap()));
         String contentType = receivedEvent.getHeadersMap().
                 get(InboundGRPCConstants.HEADER_MAP_CONTENT_TYPE_PARAMETER_NAME);
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
When we use a Payloadfactory or a property mediator to change the content type of a GRPC inbound event, an `UnsupportedOperationException` is thrown since the GRPC event returns an Unmodifiable Map. This PR will clone this  Unmodifiable Map to a modifiable map to allow content type changes.

Fixes https://github.com/wso2/api-manager/issues/737