### PR TITLE
Bump Carbon Mediation to v4.7.142

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1482,7 +1482,7 @@
 
         <synapse.version>2.1.7-wso2v310</synapse.version>
         <imp.pkg.version.synapse>[2.1.7, 2.1.8)</imp.pkg.version.synapse>
-        <carbon.mediation.version>4.7.141</carbon.mediation.version>
+        <carbon.mediation.version>4.7.142</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>
         <carbon.crypto.api.imp.pkg.version.range>[1.1.0,1.2.0)</carbon.crypto.api.imp.pkg.version.range>
         <carbon.data.version>4.5.2</carbon.data.version>


### PR DESCRIPTION
## Purpose
To update free marker from 2.3.30 to 2.3.31

