### PR TITLE
Changes need to build integration tests in JDK 17

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/pom.xml
@@ -232,7 +232,7 @@
                 <inherited>true</inherited>
                 <configuration>
                     <forkMode>pertest</forkMode>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m @{argLine}</argLine>
+                    <argLine>-Xms512m -Xmx1024m @{argLine}</argLine>
                     <testFailureIgnore>false</testFailureIgnore>
                     <includes>
                         <include>**/*TestSuite.java</include>

--- a/integration/cli-tests/pom.xml
+++ b/integration/cli-tests/pom.xml
@@ -52,7 +52,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/dataservice-hosting-tests/tests-integration/tests/pom.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/pom.xml
@@ -38,7 +38,7 @@
                 <version>2.12.4</version>
                 <configuration>
                     <!--<argLine>-Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5006</argLine>-->
-                    <argLine>-Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m</argLine>
+                    <argLine>-Xmx1024m</argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/management-api-tests/pom.xml
+++ b/integration/management-api-tests/pom.xml
@@ -53,7 +53,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/mediation-tests/tests-mediator-1/pom.xml
+++ b/integration/mediation-tests/tests-mediator-1/pom.xml
@@ -55,7 +55,7 @@
                 <inherited>false</inherited>
                 <configuration>
 
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/mediation-tests/tests-mediator-2/pom.xml
+++ b/integration/mediation-tests/tests-mediator-2/pom.xml
@@ -38,7 +38,7 @@
                 <inherited>false</inherited>
                 <configuration>
 
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>
@@ -75,6 +75,20 @@
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>copy-jar-dependencies</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/src/test/resources/artifacts/ESB/server/lib
+                            </outputDirectory>
+                            <includeTypes>jar</includeTypes>
+                            <includeArtifactIds>nashorn-core,asm-util,asm-commons</includeArtifactIds>
+                            <excludeTransitive>true</excludeTransitive>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>copy-jacoco-dependencies</id>
                         <phase>compile</phase>
@@ -399,6 +413,18 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+        </dependency>
+         <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/integration/mediation-tests/tests-other/pom.xml
+++ b/integration/mediation-tests/tests-other/pom.xml
@@ -37,7 +37,7 @@
                 <inherited>false</inherited>
                 <configuration>
 
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>
@@ -251,6 +251,14 @@
             <groupId>org.wso2.ei</groupId>
             <artifactId>org.wso2.micro.integrator.core</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
         </dependency>
     </dependencies>
 

--- a/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/connector/custom-connector-hello/pom.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/connector/custom-connector-hello/pom.xml
@@ -162,7 +162,7 @@
                 <version>2.12.4</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <testFailureIgnore>true</testFailureIgnore>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>

--- a/integration/mediation-tests/tests-patches/pom.xml
+++ b/integration/mediation-tests/tests-patches/pom.xml
@@ -38,7 +38,7 @@
                 <inherited>false</inherited>
                 <configuration>
 
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/mediation-tests/tests-platform/tests-coordination/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/pom.xml
@@ -54,7 +54,7 @@
                 <version>2.12.4</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <skipTests>${skipClusterTests}</skipTests>

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/pom.xml
@@ -153,7 +153,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <inherited>false</inherited>
                         <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <argLine>-Xms512m -Xmx1024m </argLine>
                             <disableXmlReport>false</disableXmlReport>
                             <parallel>false</parallel>
                             <suiteXmlFiles>

--- a/integration/mediation-tests/tests-platform/tests-sap/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-sap/pom.xml
@@ -72,7 +72,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/mediation-tests/tests-platform/tests-transaction/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-transaction/pom.xml
@@ -54,7 +54,7 @@
                 <version>2.12.4</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <skipTests>${skipTransactionTests}</skipTests>

--- a/integration/mediation-tests/tests-platform/tests-userstore/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-userstore/pom.xml
@@ -54,7 +54,7 @@
                 <version>2.12.4</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <skipTests>${skipTests}</skipTests>

--- a/integration/mediation-tests/tests-platform/tests-wso2mb/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-wso2mb/pom.xml
@@ -37,11 +37,11 @@
                 <version>2.12.4</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <!--<argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m -Xmx1024m -XX:PermSize=256m
+                    <!--<argLine>-Xms512m -Xmx1024m -Xmx1024m -XX:PermSize=256m
                         -XX:MaxPermSize=512m -Xdebug -Xnoagent -Djava.compiler=NONE
                         -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5006
                     </argLine>-->
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <testFailureIgnore>true</testFailureIgnore>
                     <disableXmlReport>false</disableXmlReport>
                     <skipTests>${skipPlatformTests}</skipTests>

--- a/integration/mediation-tests/tests-sample/pom.xml
+++ b/integration/mediation-tests/tests-sample/pom.xml
@@ -37,7 +37,7 @@
                 <inherited>false</inherited>
                 <configuration>
 
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/mediation-tests/tests-service/pom.xml
+++ b/integration/mediation-tests/tests-service/pom.xml
@@ -20,7 +20,7 @@
                 <version>2.12.4</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>
@@ -271,7 +271,7 @@
                 <inherited>false</inherited>
                 <configuration>
 
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/mediation-tests/tests-transport-2/pom.xml
+++ b/integration/mediation-tests/tests-transport-2/pom.xml
@@ -178,7 +178,7 @@
                 <version>${maven.surefire.plugin.version}</version>
                 <inherited>false</inherited>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/mediation-tests/tests-transport/pom.xml
+++ b/integration/mediation-tests/tests-transport/pom.xml
@@ -38,7 +38,7 @@
                 <inherited>false</inherited>
                 <configuration>
 
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -826,7 +826,7 @@
         <h2.version>1.4.199</h2.version>
         <jersey-client.version>1.8</jersey-client.version>
         <awaitility.version>3.1.2</awaitility.version>
-        <jacoco.agent.version>0.8.2</jacoco.agent.version>
+        <jacoco.agent.version>0.8.8</jacoco.agent.version>
         <greenmail.version>1.3</greenmail.version>
         <esotericsoftware.kryo.version>3.0.3</esotericsoftware.kryo.version>
         <rabbitmq.version>5.8.0</rabbitmq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1390,6 +1390,31 @@
                 <artifactId>activation</artifactId>
                 <version>${version.org.wso2.orbit.javax.activation}</version>
             </dependency>
+            <dependency>
+                <groupId>org.openjdk.nashorn</groupId>
+                <artifactId>nashorn-core</artifactId>
+                <version>${openjdk.nashorn.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-util</artifactId>
+                <version>${ow2.asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+                <version>${ow2.asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${ow2.asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.messaging.saaj</groupId>
+                <artifactId>saaj-impl</artifactId>
+                <version>${messaging.saaj.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1577,7 +1602,7 @@
         <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
-        <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
+        <jacoco.maven.plugin.version>0.8.8</jacoco.maven.plugin.version>
         <testng.version>6.11</testng.version>
         <javax.jms-api.version>2.0.1</javax.jms-api.version>
         <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
@@ -1606,7 +1631,7 @@
         <junit.version>4.8.2</junit.version>
         <netty.version>4.1.79.Final</netty.version>
         <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
-        <jacoco.agent.version>0.8.2</jacoco.agent.version>
+        <jacoco.agent.version>0.8.8</jacoco.agent.version>
         <activemq.version>5.2.0</activemq.version>
         <activemq.broker.version>5.15.2</activemq.broker.version>
         <aries.version>1.1.0</aries.version>
@@ -1810,6 +1835,9 @@
         <apache.http.nio.version>4.4.15.wso2v1</apache.http.nio.version>
         <wso2.caching.version>4.0.3</wso2.caching.version>
         <apache.http.protocol.version>4.4.14.wso2v1</apache.http.protocol.version>
+        <messaging.saaj.version>1.5.1</messaging.saaj.version>
+        <openjdk.nashorn.version>15.3</openjdk.nashorn.version>
+        <ow2.asm.version>9.2</ow2.asm.version>
     </properties>
 
     <repositories>

--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/pom.xml
@@ -42,7 +42,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/product-scenarios/10-file-processing/pom.xml
+++ b/product-scenarios/10-file-processing/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/product-scenarios/11-Asynchronous-message-processing/pom.xml
+++ b/product-scenarios/11-Asynchronous-message-processing/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/product-scenarios/13-micro-services/pom.xml
+++ b/product-scenarios/13-micro-services/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/product-scenarios/14-periodically-execute-an-integration-process/pom.xml
+++ b/product-scenarios/14-periodically-execute-an-integration-process/pom.xml
@@ -45,7 +45,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <inherited>true</inherited>
                         <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <argLine>-Xms512m -Xmx1024m </argLine>
                             <disableXmlReport>false</disableXmlReport>
                             <parallel>false</parallel>
                             <suiteXmlFiles>

--- a/product-scenarios/2-Bridging-systems-that-communicate-in-different-protocols/pom.xml
+++ b/product-scenarios/2-Bridging-systems-that-communicate-in-different-protocols/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/product-scenarios/4-gateway/pom.xml
+++ b/product-scenarios/4-gateway/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/product-scenarios/5-route-messages-between-systems/pom.xml
+++ b/product-scenarios/5-route-messages-between-systems/pom.xml
@@ -45,7 +45,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <inherited>true</inherited>
                         <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <argLine>-Xms512m -Xmx1024m </argLine>
                             <disableXmlReport>false</disableXmlReport>
                             <parallel>false</parallel>
                             <suiteXmlFiles>
@@ -105,7 +105,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <inherited>true</inherited>
                         <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <argLine>-Xms512m -Xmx1024m </argLine>
                             <disableXmlReport>false</disableXmlReport>
                             <parallel>false</parallel>
                             <suiteXmlFiles>

--- a/product-scenarios/7-connecting-with-packaged-applications/pom.xml
+++ b/product-scenarios/7-connecting-with-packaged-applications/pom.xml
@@ -37,7 +37,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <argLine>-Xms512m -Xmx1024m </argLine>
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>

--- a/product-scenarios/pom.xml
+++ b/product-scenarios/pom.xml
@@ -70,7 +70,7 @@
         <awaitility.version>3.1.2</awaitility.version>
         <commons.lang.version>2.6.0.wso2v1</commons.lang.version>
         <maven.surefire.version>2.12.4</maven.surefire.version>
-        <jacoco.version>0.7.9</jacoco.version>
+        <jacoco.version>0.8.8</jacoco.version>
         <activemq.client.version>5.15.8</activemq.client.version>
         <pax.logging.api.version>2.1.0-wso2v3</pax.logging.api.version>
     </properties>


### PR DESCRIPTION
## Purpose
> This PR will enable micro-integrator to build with JDK 17(without tests) and run integration test suite in JDK 17
Related Issue: https://github.com/wso2/api-manager/issues/179