### PR TITLE
Backup axis2 operation name in a property.

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/dispatch/DataServiceRequest.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/dispatch/DataServiceRequest.java
@@ -22,6 +22,7 @@ import org.apache.axiom.om.impl.llom.OMSourcedElementImpl;
 import org.apache.axis2.context.MessageContext;
 import org.apache.axis2.description.AxisOperation;
 import org.apache.axis2.description.AxisService;
+import org.wso2.micro.core.util.StringUtils;
 import org.wso2.micro.integrator.dataservices.common.DBConstants;
 import org.wso2.micro.integrator.dataservices.common.DBConstants.BoxcarringOps;
 import org.wso2.micro.integrator.dataservices.core.DBUtils;
@@ -45,8 +46,12 @@ import java.util.Map;
  * Represents a data services request.
  */
 public abstract class DataServiceRequest {
-	
-	/** 
+
+	/**
+	 * Used to hold the axis2 operation name of the current dataservice operation.
+	 */
+	public static final String AXIS_OPERATION_NAME = "axisOperationName";
+	/**
 	 * contains the username of the user who made the current message request 
 	 */
 	private String user;
@@ -89,8 +94,13 @@ public abstract class DataServiceRequest {
 		AxisService axisService = msgContext.getAxisService();
 		AxisOperation axisOp = msgContext.getAxisOperation();
 		OMElement inputMessage = msgContext.getEnvelope().getBody().getFirstElement();
+		// Fetching the operation name from the property
+		// since axisOp.getName() provide different results in a load test scenario.
+		String requestName = (String) msgContext.getProperty(AXIS_OPERATION_NAME);
 		/* get operation/request name */
-		String requestName = axisOp.getName().getLocalPart();
+		if (StringUtils.isEmpty(requestName)) {
+			requestName = axisOp.getName().getLocalPart();
+		}
 		if (Boolean.parseBoolean(System.getProperty("dss.force.xml.validation"))) {
 			if (inputMessage != null && !requestName.equals(inputMessage.getLocalName())) {
 				throw new DataServiceFault("Input Message and " + requestName + " Axis Operation didn't match.");

--- a/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediator.java
+++ b/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/src/main/java/org/wso2/micro/integrator/mediator/dataservice/DataServiceCallMediator.java
@@ -58,6 +58,8 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.regex.Matcher;
 
+import static org.wso2.micro.integrator.dataservices.core.dispatch.DataServiceRequest.AXIS_OPERATION_NAME;
+
 public class DataServiceCallMediator extends AbstractMediator {
 
     private String dsName;
@@ -203,6 +205,8 @@ public class DataServiceCallMediator extends AbstractMediator {
         }
         QName rootOpQName = new QName(rootOpName);
         axis2MessageContext.getAxisOperation().setName(rootOpQName);
+        // Setting axis2 operation name as a property since its getting changes before invocation under high load.
+        axis2MessageContext.setProperty(AXIS_OPERATION_NAME, rootOpQName.getLocalPart());
         OMElement payload = fac.createOMElement(rootOpName, omNamespace);
         addOperations(rootOperations, payload, messageContext, rootOperations.getType());
         return payload;


### PR DESCRIPTION
## Purpose
> Backup axis2 opration name in a property to avoid it being changed under high concurrency. Fixes wso2/api-manager/issues/817
