### PR TITLE
Explicitly set the commons-codec version to 1.12 in User Store Test Module

### DIFF
--- a/integration/mediation-tests/tests-platform/tests-userstore/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-userstore/pom.xml
@@ -301,6 +301,10 @@
             <artifactId>ojdbc8</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.ibm.db2</groupId>
             <artifactId>jcc</artifactId>
         </dependency>


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/1098

An older commons-codec version led to the 3 test failures in the MI test Module - UserStore. This older version was coming from axis2-client. This PR will explicitly set the commons-codec version to 1.12 in UserStore Test Module.