### PR TITLE
Adds j2 mapping for KeyAlias property for Keystore

### DIFF
--- a/distribution/src/resources/config-tool/templates/conf/axis2/axis2.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/axis2/axis2.xml.j2
@@ -236,6 +236,9 @@
                 <Type>{{transport.http.listener.keystore.type}}</Type>
                 <Password>{{transport.http.listener.keystore.password}}</Password>
                 <KeyPassword>{{transport.http.listener.keystore.key_password}}</KeyPassword>
+                {% if transport.http.listener.keystore.key_alias is defined %}
+                <KeyAlias>{{transport.http.listener.keystore.key_alias}}</KeyAlias>
+                {% endif %}
             </KeyStore>
         </parameter>
         <parameter name="truststore" locked="false">
@@ -483,6 +486,9 @@
                 <Type>{{transport.http.sender.keystore.type}}</Type>
                 <Password>{{transport.http.sender.keystore.password}}</Password>
                 <KeyPassword>{{transport.http.sender.keystore.key_password}}</KeyPassword>
+                {% if transport.http.sender.keystore.key_alias is defined %}
+                <KeyAlias>{{transport.http.sender.keystore.key_alias}}</KeyAlias>
+                {% endif %}
             </KeyStore>
         </parameter>
         <parameter name="truststore" locked="false">


### PR DESCRIPTION
## Purpose
To add j2 mapping for KeyAlias property for transport.http.listener.keystore and transport.http.sender.keystore

## Related Issues
[apim#1178](https://github.com/wso2/api-manager/issues/1178)

## Implementation

Add the following configuration in axis2.xml.j2 file

For TransportReceiver:
```
<transportReceiver name="https" class="{{transport.https.listener.class}}">
       .
       .
       .
        <parameter name="keystore" locked="false">
            <KeyStore>
                .
                .
                .
                 {% if transport.http.listener.keystore.key_alias is defined %}
                 <KeyAlias>{{transport.http.listener.keystore.key_alias}}</KeyAlias>
                 {% endif %}
             </KeyStore>
        </parameter>
</transportReceiver>
```
For TransportSender: 
```
<transportSender name="https" class="{{transport.https.listener.class}}">
       .
       .
       .
        <parameter name="keystore" locked="false">
            <KeyStore>
                .
                .
                .
                 {% if transport.http.sender.keystore.key_alias is defined %}
                 <KeyAlias>{{transport.http.sender.keystore.key_alias}}</KeyAlias>
                 {% endif %}
             </KeyStore>
        </parameter>
</transportSender >
```
