### PR TITLE
Add support to use custom file location for registry

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
@@ -34,6 +34,7 @@ public class MicroIntegratorRegistryConstants {
     public static final String FILE = "http://wso2.org/projects/esb/registry/types/file";
 
     public static final String CONF_REG_ROOT = "ConfigRegRoot";
+    public static final String REG_ROOT = "RegRoot";
     public static final String GOV_REG_ROOT = "GovRegRoot";
     public static final String LOCAL_REG_ROOT = "LocalRegRoot";
 
@@ -42,6 +43,7 @@ public class MicroIntegratorRegistryConstants {
     public static final String PROTOCOL_FILE = "file";
     public static final String PROTOCOL_HTTP = "http";
     public static final String PROTOCOL_HTTPS = "https";
+    public static final String FILE_PROTOCOL_PREFIX = "file:";
 
 
     public static final String CONFIG_REGISTRY_PREFIX = "conf:";
@@ -50,6 +52,7 @@ public class MicroIntegratorRegistryConstants {
 
     public static final String CONFIG_DIRECTORY_NAME = "config";
     public static final String GOVERNANCE_DIRECTORY_NAME = "governance";
+    public static final String LOCAL_DIRECTORY_NAME = "local";
 
     public static final char URL_SEPARATOR_CHAR = '/';
     public static final String URL_SEPARATOR = "/";

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/test/java/org/wso2/micro/integrator/registry/TestMicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/test/java/org/wso2/micro/integrator/registry/TestMicroIntegratorRegistry.java
@@ -43,6 +43,8 @@ public class TestMicroIntegratorRegistry {
     private static MicroIntegratorRegistry microIntegratorRegistry;
     private static Path governanceRegistry;
 
+    private static Path registryRoot;
+
     @BeforeClass
     public static void init() throws IOException {
         //create registry folder
@@ -50,12 +52,13 @@ public class TestMicroIntegratorRegistry {
         registryFolder.mkdir();
 
         microIntegratorRegistry = new MicroIntegratorRegistry();
+        registryRoot = Paths.get("src", "test", "resources", "registry").toAbsolutePath();
 
         governanceRegistry = Paths.get("src", "test", "resources", "registry", "governance").toAbsolutePath();
         Files.createDirectories(governanceRegistry);
 
         Properties properties = new Properties();
-        properties.setProperty(MicroIntegratorRegistryConstants.GOV_REG_ROOT, governanceRegistry.toUri().toURL().toString());
+        properties.setProperty(MicroIntegratorRegistryConstants.REG_ROOT, registryRoot.toUri().toURL().toString());
         microIntegratorRegistry.init(properties);
     }
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryMetadataResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryMetadataResource.java
@@ -60,13 +60,13 @@ public class RegistryMetadataResource implements MiApiResource {
             SynapseConfiguration synapseConfiguration) {
 
         String registryPath = Utils.getQueryParameter(messageContext, REGISTRY_PATH);
-        String validatedPath = validatePath(registryPath, axis2MessageContext);
+        String validatedPath = validatePath(registryPath, axis2MessageContext, messageContext);
 
         if (StringUtils.isEmpty(validatedPath)) {
             axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
             return true;
         }
-        handleGet(axis2MessageContext, registryPath, validatedPath);
+        handleGet(messageContext, axis2MessageContext, registryPath, validatedPath);
         axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
         return true;
     }
@@ -76,11 +76,11 @@ public class RegistryMetadataResource implements MiApiResource {
      *
      * @param axis2MessageContext AXIS2 message context
      */
-    private void handleGet(org.apache.axis2.context.MessageContext axis2MessageContext,
+    private void handleGet(MessageContext messageContext, org.apache.axis2.context.MessageContext axis2MessageContext,
             String registryPath, String validatedPath) {
 
         MicroIntegratorRegistry microIntegratorRegistry = new MicroIntegratorRegistry();
-        if (!isRegistryExist(validatedPath)) {
+        if (!isRegistryExist(validatedPath, messageContext)) {
             JSONObject jsonBody = Utils.createJsonError("Can not find the registry: " + registryPath,
                     axis2MessageContext, BAD_REQUEST);
             Utils.setJsonPayLoad(axis2MessageContext, jsonBody);
@@ -99,8 +99,8 @@ public class RegistryMetadataResource implements MiApiResource {
     private void populateRegistryMetadata(org.apache.axis2.context.MessageContext axis2MessageContext,
             MicroIntegratorRegistry microIntegratorRegistry, String path) {
 
-        String carbonHomePath = Utils.getCarbonHome();
-        String registryPath = formatPath(carbonHomePath + File.separator + path);
+        String regRoot = microIntegratorRegistry.getRegRoot();
+        String registryPath = formatPath(regRoot + File.separator + path);
         JSONObject jsonBody = microIntegratorRegistry.getRegistryMediaType(registryPath);
         try {
             String error = jsonBody.getString(ERROR_KEY);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java
@@ -90,7 +90,7 @@ public class RegistryPropertiesResource implements MiApiResource {
 
         String httpMethod = axis2MessageContext.getProperty(Constants.HTTP_METHOD_PROPERTY).toString();
         String registryPath = Utils.getQueryParameter(messageContext, REGISTRY_PATH);
-        String validatedPath = validatePath(registryPath, axis2MessageContext);
+        String validatedPath = validatePath(registryPath, axis2MessageContext, messageContext);
 
         if (StringUtils.isEmpty(validatedPath)) {
             axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
@@ -150,8 +150,9 @@ public class RegistryPropertiesResource implements MiApiResource {
             String registryPath, String validatedPath) {
 
         String propertyName = Utils.getQueryParameter(messageContext, NAME);
-        MicroIntegratorRegistry microIntegratorRegistry = new MicroIntegratorRegistry();
-        if (!isRegistryExist(validatedPath)) {
+        MicroIntegratorRegistry microIntegratorRegistry =
+                (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry();
+        if (!isRegistryExist(validatedPath, messageContext)) {
             JSONObject jsonBody = Utils.createJsonError("Can not find the registry: " + registryPath,
                     axis2MessageContext, BAD_REQUEST);
             Utils.setJsonPayLoad(axis2MessageContext, jsonBody);
@@ -239,9 +240,10 @@ public class RegistryPropertiesResource implements MiApiResource {
         JSONObject jsonBody;
         String pathWithPrefix = getRegistryPathPrefix(validatedPath);
         if (Objects.nonNull(pathWithPrefix)) {
-            if (isRegistryExist(validatedPath) && isRegistryExist(validatedPath + PROPERTY_EXTENSION)) {
+            if (isRegistryExist(validatedPath, messageContext) &&
+                    isRegistryExist(validatedPath + PROPERTY_EXTENSION, messageContext)) {
                 jsonBody = postRegistryProperties(messageContext, axis2MessageContext, pathWithPrefix);
-            } else if (isRegistryExist(validatedPath)) {
+            } else if (isRegistryExist(validatedPath, messageContext)) {
                 jsonBody = postNewRegistryProperties(messageContext, axis2MessageContext, pathWithPrefix);
             } else {
                 jsonBody = postEmptyRegistryProperties(messageContext, axis2MessageContext, pathWithPrefix);
@@ -265,7 +267,8 @@ public class RegistryPropertiesResource implements MiApiResource {
 
         String propertiesPayload = getPayload(axis2MessageContext);
         JSONObject jsonBody = new JSONObject();
-        MicroIntegratorRegistry microIntegratorRegistry = new MicroIntegratorRegistry();
+        MicroIntegratorRegistry microIntegratorRegistry =
+                (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry();
         Properties oldProperties = microIntegratorRegistry.getResourceProperties(registryPath);
         String performedBy = ANONYMOUS_USER;
         JSONObject info = new JSONObject();
@@ -317,7 +320,8 @@ public class RegistryPropertiesResource implements MiApiResource {
 
         String propertiesPayload = getPayload(axis2MessageContext);
         JSONObject jsonBody = new JSONObject();
-        MicroIntegratorRegistry microIntegratorRegistry = new MicroIntegratorRegistry();
+        MicroIntegratorRegistry microIntegratorRegistry =
+                (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry();
         String performedBy = ANONYMOUS_USER;
         JSONObject info = new JSONObject();
 
@@ -362,7 +366,8 @@ public class RegistryPropertiesResource implements MiApiResource {
 
         String propertiesPayload = getPayload(axis2MessageContext);
         JSONObject jsonBody = new JSONObject();
-        MicroIntegratorRegistry microIntegratorRegistry = new MicroIntegratorRegistry();
+        MicroIntegratorRegistry microIntegratorRegistry =
+                (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry();
         String performedBy = ANONYMOUS_USER;
         JSONObject info = new JSONObject();
 
@@ -458,7 +463,7 @@ public class RegistryPropertiesResource implements MiApiResource {
         if (Objects.nonNull(propertyName)) {
             String pathWithPrefix = getRegistryPathPrefix(validatedPath);
             if (Objects.nonNull(pathWithPrefix)) {
-                if (isRegistryExist(validatedPath + PROPERTY_EXTENSION)) {
+                if (isRegistryExist(validatedPath + PROPERTY_EXTENSION, messageContext)) {
                     jsonBody = deleteRegistryProperty(messageContext, axis2MessageContext, pathWithPrefix,
                             propertyName);
                 } else {
@@ -484,7 +489,8 @@ public class RegistryPropertiesResource implements MiApiResource {
      */
     private JSONObject deleteRegistryProperty(MessageContext messageContext,
             org.apache.axis2.context.MessageContext axis2MessageContext, String registryPath, String propertyName) {
-        MicroIntegratorRegistry microIntegratorRegistry = new MicroIntegratorRegistry();
+        MicroIntegratorRegistry microIntegratorRegistry =
+                (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry();
         Properties properties = microIntegratorRegistry.getResourceProperties(registryPath);
         JSONObject jsonBody = new JSONObject();
         String performedBy = ANONYMOUS_USER;

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryResource.java
@@ -59,7 +59,7 @@ public class RegistryResource implements MiApiResource {
             SynapseConfiguration synapseConfiguration) {
 
         String registryPath = Utils.getQueryParameter(messageContext, REGISTRY_PATH);
-        String validatedPath = validatePath(registryPath, axis2MessageContext);
+        String validatedPath = validatePath(registryPath, axis2MessageContext, messageContext);
         String searchKey = Utils.getQueryParameter(messageContext, SEARCH_KEY);
 
         if (StringUtils.isEmpty(validatedPath)) {
@@ -70,7 +70,7 @@ public class RegistryResource implements MiApiResource {
             if (searchKey.trim().isEmpty()) {
                 handleGet(messageContext, axis2MessageContext, validatedPath);
             } else {
-                populateRegistryResourceJSON(searchKey, axis2MessageContext, new MicroIntegratorRegistry(), validatedPath);
+                populateRegistryResourceJSON(searchKey, axis2MessageContext, (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry(), validatedPath);
             }
         } else {
             handleGet(messageContext, axis2MessageContext, validatedPath);
@@ -89,7 +89,7 @@ public class RegistryResource implements MiApiResource {
             String validatedPath) {
 
         String expandedEnabled = Utils.getQueryParameter(messageContext, EXPAND_PARAM);
-        MicroIntegratorRegistry microIntegratorRegistry = new MicroIntegratorRegistry();
+        MicroIntegratorRegistry microIntegratorRegistry = (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry();
         if (Objects.nonNull(expandedEnabled) && expandedEnabled.equals(VALUE_TRUE)) {
             populateRegistryResourceJSON("", axis2MessageContext, microIntegratorRegistry, validatedPath);
         } else {
@@ -108,8 +108,8 @@ public class RegistryResource implements MiApiResource {
     private void populateRegistryResourceJSON(String searchKey, org.apache.axis2.context.MessageContext axis2MessageContext,
             MicroIntegratorRegistry microIntegratorRegistry, String path) {
 
-        String carbonHomePath = Utils.getCarbonHome();
-        String folderPath = formatPath(carbonHomePath + File.separator + path + File.separator);
+        String regRoot = microIntegratorRegistry.getRegRoot();
+        String folderPath = formatPath(regRoot + File.separator + path + File.separator);
         File node = new File(folderPath);
         JSONObject jsonBody;
         if (node.exists() && node.isDirectory()) {
@@ -130,12 +130,12 @@ public class RegistryResource implements MiApiResource {
     private void populateImmediateChildren(org.apache.axis2.context.MessageContext axis2MessageContext,
             MicroIntegratorRegistry microIntegratorRegistry, String path) {
 
-        String carbonHomePath = formatPath(Utils.getCarbonHome());
-        String registryPath = formatPath(carbonHomePath + File.separator + path);
+        String regRoot = microIntegratorRegistry.getRegRoot();
+        String registryPath = formatPath(regRoot + File.separator + path);
         File node = new File(registryPath);
         JSONObject jsonBody;
         if (node.exists() && node.isDirectory()) {
-            JSONArray childrenList = microIntegratorRegistry.getChildrenList(registryPath, carbonHomePath);
+            JSONArray childrenList = microIntegratorRegistry.getChildrenList(registryPath, regRoot);
             jsonBody = Utils.createJSONList(childrenList.length());
             jsonBody.put(Constants.LIST, childrenList);
         } else {

--- a/distribution/src/conf/synapse-configs/default/registry.xml
+++ b/distribution/src/conf/synapse-configs/default/registry.xml
@@ -20,13 +20,11 @@
 <registry xmlns="http://ws.apache.org/ns/synapse" provider="org.wso2.micro.integrator.registry.MicroIntegratorRegistry">
     <parameter name="cachableDuration">15000</parameter>
     <!--
-        Uncomment below parameters (ConfigRegRoot, GovRegRoot, LocalRegRoot) to configure registry root paths
-        Default : <EI_HOME>/wso2/micro-integrator/registry/{governance | config | local}
-        Example : <parameter name="GovRegRoot">file:///Users/JohnDoe/registry/governance</parameter>
+        Uncomment below parameter "RegRoot" to configure registry root path
+        Default : <MI_HOME>/registry
+        Example : <parameter name="RegRoot">file:///Users/JohnDoe/registry</parameter>
     -->
     <!--
-    <parameter name="ConfigRegRoot">{Root directory path for configuration Registry}</parameter>
-    <parameter name="GovRegRoot">{Root directory path for governance Registry}</parameter>
-    <parameter name="LocalRegRoot">{Root directory path for local Registry}</parameter>
+    <parameter name="RegRoot">file:///tmp/registry</parameter>
     -->
 </registry>

--- a/integration/mediation-tests/tests-patches-with-smb2/src/test/resources/artifacts/ESB/synapseconfig/registry/caching/registry.xml
+++ b/integration/mediation-tests/tests-patches-with-smb2/src/test/resources/artifacts/ESB/synapseconfig/registry/caching/registry.xml
@@ -20,13 +20,11 @@
 <registry xmlns="http://ws.apache.org/ns/synapse" provider="org.wso2.micro.integrator.registry.MicroIntegratorRegistry">
     <parameter name="cachableDuration">0</parameter>
     <!--
-        Uncomment below parameters (ConfigRegRoot, GovRegRoot, LocalRegRoot) to configure registry root paths
-        Default : <EI_HOME>/wso2/micro-integrator/registry/{governance | config | local}
-        Example : <parameter name="GovRegRoot">file:///Users/JohnDoe/registry/governance</parameter>
+        Uncomment below parameter "RegRoot" to configure registry root path
+        Default : <MI_HOME>/registry
+        Example : <parameter name="RegRoot">file:///Users/JohnDoe/registry</parameter>
     -->
     <!--
-    <parameter name="ConfigRegRoot">{Root directory path for configuration Registry}</parameter>
-    <parameter name="GovRegRoot">{Root directory path for governance Registry}</parameter>
-    <parameter name="LocalRegRoot">{Root directory path for local Registry}</parameter>
+    <parameter name="RegRoot">file:///tmp/registry</parameter>
     -->
 </registry>

--- a/integration/mediation-tests/tests-patches-with-smb2/src/test/resources/artifacts/ESB/synapseconfig/registry/caching/registry_original.xml
+++ b/integration/mediation-tests/tests-patches-with-smb2/src/test/resources/artifacts/ESB/synapseconfig/registry/caching/registry_original.xml
@@ -20,13 +20,11 @@
 <registry xmlns="http://ws.apache.org/ns/synapse" provider="org.wso2.micro.integrator.registry.MicroIntegratorRegistry">
     <parameter name="cachableDuration">15000</parameter>
     <!--
-        Uncomment below parameters (ConfigRegRoot, GovRegRoot, LocalRegRoot) to configure registry root paths
-        Default : <EI_HOME>/wso2/micro-integrator/registry/{governance | config | local}
-        Example : <parameter name="GovRegRoot">file:///Users/JohnDoe/registry/governance</parameter>
+        Uncomment below parameter "RegRoot" to configure registry root path
+        Default : <MI_HOME>/registry
+        Example : <parameter name="RegRoot">file:///Users/JohnDoe/registry</parameter>
     -->
     <!--
-    <parameter name="ConfigRegRoot">{Root directory path for configuration Registry}</parameter>
-    <parameter name="GovRegRoot">{Root directory path for governance Registry}</parameter>
-    <parameter name="LocalRegRoot">{Root directory path for local Registry}</parameter>
+    <parameter name="RegRoot">file:///tmp/registry</parameter>
     -->
 </registry>

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/registry/caching/registry.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/registry/caching/registry.xml
@@ -20,13 +20,11 @@
 <registry xmlns="http://ws.apache.org/ns/synapse" provider="org.wso2.micro.integrator.registry.MicroIntegratorRegistry">
     <parameter name="cachableDuration">0</parameter>
     <!--
-        Uncomment below parameters (ConfigRegRoot, GovRegRoot, LocalRegRoot) to configure registry root paths
-        Default : <EI_HOME>/wso2/micro-integrator/registry/{governance | config | local}
-        Example : <parameter name="GovRegRoot">file:///Users/JohnDoe/registry/governance</parameter>
+        Uncomment below parameter "RegRoot" to configure registry root path
+        Default : <MI_HOME>/registry
+        Example : <parameter name="RegRoot">file:///Users/JohnDoe/registry</parameter>
     -->
     <!--
-    <parameter name="ConfigRegRoot">{Root directory path for configuration Registry}</parameter>
-    <parameter name="GovRegRoot">{Root directory path for governance Registry}</parameter>
-    <parameter name="LocalRegRoot">{Root directory path for local Registry}</parameter>
+    <parameter name="RegRoot">file:///tmp/registry</parameter>
     -->
 </registry>

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/registry/caching/registry_original.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/registry/caching/registry_original.xml
@@ -20,13 +20,11 @@
 <registry xmlns="http://ws.apache.org/ns/synapse" provider="org.wso2.micro.integrator.registry.MicroIntegratorRegistry">
     <parameter name="cachableDuration">15000</parameter>
     <!--
-        Uncomment below parameters (ConfigRegRoot, GovRegRoot, LocalRegRoot) to configure registry root paths
-        Default : <EI_HOME>/wso2/micro-integrator/registry/{governance | config | local}
-        Example : <parameter name="GovRegRoot">file:///Users/JohnDoe/registry/governance</parameter>
+        Uncomment below parameter "RegRoot" to configure registry root path
+        Default : <MI_HOME>/registry
+        Example : <parameter name="RegRoot">file:///Users/JohnDoe/registry</parameter>
     -->
     <!--
-    <parameter name="ConfigRegRoot">{Root directory path for configuration Registry}</parameter>
-    <parameter name="GovRegRoot">{Root directory path for governance Registry}</parameter>
-    <parameter name="LocalRegRoot">{Root directory path for local Registry}</parameter>
+    <parameter name="RegRoot">file:///tmp/registry</parameter>
     -->
 </registry>


### PR DESCRIPTION
## Purpose
This PR will improve the MI registry implementation to support custom file location.
A custom location can be provided in <MI_HOME>/repository/deployment/server/synapse-configs/default/registry.xml file as follows 


<img width="888" alt="Screenshot 2023-01-19 at 17 03 30" src="https://user-images.githubusercontent.com/19290404/213432037-c5a4b7a8-ffe7-4808-ad1d-69f585340eec.png">

Fixes https://github.com/wso2/api-manager/issues/1062


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
