### PR TITLE
Downgrade Rhino

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/script/ScriptMediatorWithImports.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/script/ScriptMediatorWithImports.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.esb.mediators.script;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+public class ScriptMediatorWithImports extends ESBIntegrationTest {
+
+    private final Map<String, String> httpHeaders = new HashMap<>();
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        super.init();
+        httpHeaders.put("Content-Type", "application/json");
+    }
+
+    @Test(groups = {"wso2.esb"}, description = "Testing the Script Mediator importClass method")
+    public void testScriptMediatorWithImports() throws Exception {
+
+        String payload = "{\n" +
+                "   \"sessionId\":\"QwWsHJyTPW.1pd0_jXlNKOSU\"\n" +
+                "}";
+
+        HttpResponse response = HttpRequestUtil.doPost(
+                new URL(getApiInvocationURL("ScriptMediatorWithImportsTestAPI")), payload, httpHeaders);
+        assertTrue(response.getData().contains("UUID"), "Fault: Script Mediator failed to response with expected " +
+                "payload.");
+    }
+}

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/ScriptMediatorWithImportsTestAPI.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/ScriptMediatorWithImportsTestAPI.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api xmlns="http://ws.apache.org/ns/synapse" name="ScriptMediatorWithImportsTestAPI"
+     context="/ScriptMediatorWithImportsTestAPI">
+    <resource methods="POST">
+        <inSequence>
+            <script language="js">
+                <![CDATA[
+                    importClass(Packages.java.util.UUID);
+                    var uuid = java.util.UUID.randomUUID().toString().replace('-','');
+                    var request = mc.getPayloadJSON();
+                    var response = new Object();
+                    response.session = request.sessionId;
+                    response.name = "UUID"
+                    response.value = uuid;
+                    mc.setPayloadJSON(response);
+                ]]>
+            </script>
+            <respond/>
+        </inSequence>
+        <outSequence/>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
@@ -64,6 +64,7 @@
             <class name="org.wso2.carbon.esb.mediators.cache.DistributedCachingHeaderSerializationTestcase"/>
             <!--class name="org.wso2.carbon.esb.mediators.cache.ESBJAVA4318Testcase"/-->
             <class name="org.wso2.carbon.esb.mediators.rule.ESBJAVA2506RuleFetchFromRegistryFailsForTheFirstTime"/>
+            <class name="org.wso2.carbon.esb.mediators.script.ScriptMediatorWithImports"/>
         </classes>
     </test>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1654,7 +1654,7 @@
         <imp.package.version.osgi.services>[1.2.0,2.0.0)</imp.package.version.osgi.services>
 
         <org.apache.bsf.wso2.version>3.0.0.wso2v5</org.apache.bsf.wso2.version>
-        <rhino.wso2.js.version>1.7.14.wso2v1</rhino.wso2.js.version>
+        <rhino.wso2.js.version>1.7.13.wso2v1</rhino.wso2.js.version>
         <org.apache.velocity.version>2.3</org.apache.velocity.version>
 
         <javax.servlet.version>3.0.0.v201112011016</javax.servlet.version>


### PR DESCRIPTION
## Purpose

Due to an API change in the latest Mozilla Rhino version 1.7.14, Script Mediator's `importClass` method was throwing an error.
Therefore, rhino will be downgraded to version 1.7.13

Fixes https://github.com/wso2/api-manager/issues/1337