### PR TITLE
Add WebContextRoot deployment.toml config

### DIFF
--- a/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
@@ -89,8 +89,11 @@
     <!--
        Webapp context root of WSO2 Carbon management console.
     -->
+    {% if server.webcontexroot is defined %}
+    <WebContextRoot>{{ server.webcontexroot }}</WebContextRoot>
+    {% else %}
     <WebContextRoot>/</WebContextRoot>
-
+    {% endif %}
     <!--
     	Proxy context path is a useful parameter to add a proxy path when a Carbon server is fronted by reverse proxy. In addtion
         to the proxy host and proxy port this parameter allows you add a path component to external URLs. e.g.

--- a/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
@@ -89,8 +89,8 @@
     <!--
        Webapp context root of WSO2 Carbon management console.
     -->
-    {% if server.webcontexroot is defined %}
-    <WebContextRoot>{{ server.webcontexroot }}</WebContextRoot>
+    {% if server.web_context_root is defined %}
+    <WebContextRoot>{{ server.web_context_root }}</WebContextRoot>
     {% else %}
     <WebContextRoot>/</WebContextRoot>
     {% endif %}


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-manager/issues/1300

A new configuration parameter is added to set WebContextRoot in deplyment.toml

## Usage
In deplyment.toml, it can be defined as follows

```
[server]
web_context_root = ""
```