### PR TITLE
Upgrade Carbon Identity OAuth version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1533,7 +1533,7 @@
         <carbon.data.version>4.5.2</carbon.data.version>
         <securevault.version>1.1.2</securevault.version>
         <hashicorp.vault.version>5.1.0</hashicorp.vault.version>
-        <carbon.identity.oauth.version>6.1.0</carbon.identity.oauth.version>
+        <carbon.identity.oauth.version>6.8.0</carbon.identity.oauth.version>
         <carbon.identity.oauth.imp.pkg.version>[6.1.0, 7.0.0)</carbon.identity.oauth.imp.pkg.version>
 
         <!-- SAP adapter - sap transport feature version -->


### PR DESCRIPTION
## Purpose
Since the IS 6.0 use org.wso2.carbon.identity.oauth2.stub 6.8.0, update the org.wso2.carbon.identity.oauth2.stub version to 6.8.0 to make MI compatible with the latest IS releases.

Since backward compatibility is preserved we can use IS 5.x versions even with this upgrade. 

Fixes: https://github.com/wso2/api-manager/issues/1374