### PR TITLE
Block starting the MI server on unsupported java versions

### DIFF
--- a/distribution/src/scripts/micro-integrator.bat
+++ b/distribution/src/scripts/micro-integrator.bat
@@ -154,7 +154,7 @@ goto supportedJdk
 :unknownJdk
 echo Starting WSO2 MI (in unsupported JDK %JAVA_VERSION%)
 echo [ERROR] WSO2 MI is supported only between JDK 11 and JDK 17"
-goto supportedJdk
+goto end
 
 :supportedJdk
 goto runServer

--- a/distribution/src/scripts/micro-integrator.sh
+++ b/distribution/src/scripts/micro-integrator.sh
@@ -195,6 +195,7 @@ java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$
 if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 MI (in unsupported JDK)"
    echo " [ERROR] WSO2 MI is supported only between JDK 11 and JDK 17"
+   exit 0
 fi
 
 CARBON_XBOOTCLASSPATH=""


### PR DESCRIPTION
## Purpose
> Block starting the MI server on unsupported java versions

Fixes 
https://github.com/wso2/api-manager/issues/1420
