### PR TITLE
Upgrade transport-http version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1541,7 +1541,7 @@
 
         <cipher.tool.version>1.1.15</cipher.tool.version>
         <axis2.transport.version>2.0.0-wso2v67</axis2.transport.version>
-        <transport.http.netty.version>6.3.35</transport.http.netty.version>
+        <transport.http.netty.version>6.3.42</transport.http.netty.version>
 
         <esotericsoftware.kryo.version>3.0.3</esotericsoftware.kryo.version>
         <esotericsoftware.minlog.version>1.3.0</esotericsoftware.minlog.version>


### PR DESCRIPTION
## Purpose
Upgrades transport-http version to latest in order to reflect the netty version upgrade done in [1].

[1]. https://github.com/wso2/transport-http/pull/455

