### PR TITLE
carbon.analytics.common version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1553,7 +1553,7 @@
         <axis2.wso2.integration.test.version>1.6.1-wso2v64</axis2.wso2.integration.test.version>
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
 
-        <carbon.analytics.common.version>5.2.50</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.2.52</carbon.analytics.common.version>
         <carbon.analytics.common.imp.pkg.version>[5.2.0, 6.0.0)</carbon.analytics.common.imp.pkg.version>
         <fasterxml.jackson.version>2.13.5</fasterxml.jackson.version>
         <carbon.commons.version>4.7.49</carbon.commons.version>


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/1252

This version bump is needed to upgrade libthrift version