### PR TITLE
Add changing JCE provider via config

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/Constants.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/Constants.java
@@ -97,4 +97,6 @@ public class Constants {
     public static final String TRUST = "Trust";
     public static final String TRUST_MODULE = "rahas";
 
+    public static final String BOUNCY_CASTLE_PROVIDER = "BC";
+    public static final String BOUNCY_CASTLE_FIPS_PROVIDER = "BCFIPS";
 }

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/util/CryptoUtil.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/util/CryptoUtil.java
@@ -135,13 +135,13 @@ public class CryptoUtil {
                     if (log.isDebugEnabled()) {
                         log.debug("Cipher transformation for encryption : " + cipherTransformation);
                     }
-                    keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
+                    keyStoreCipher = Cipher.getInstance(cipherTransformation, getJceProvider());
                     isCipherTransformEnabled = true;
                 } else {
                     if (log.isDebugEnabled()) {
                         log.debug("Default Cipher transformation for encryption : RSA");
                     }
-                    keyStoreCipher = Cipher.getInstance("RSA", "BC");
+                    keyStoreCipher = Cipher.getInstance("RSA", getJceProvider());
                 }
 
                 keyStoreCipher.init(Cipher.ENCRYPT_MODE, certs[0].getPublicKey());
@@ -243,17 +243,17 @@ public class CryptoUtil {
                         if (log.isDebugEnabled()) {
                             log.debug("Cipher transformation for decryption : " + cipherHolder.getTransformation());
                         }
-                        keyStoreCipher = Cipher.getInstance(cipherHolder.getTransformation(), "BC");
+                        keyStoreCipher = Cipher.getInstance(cipherHolder.getTransformation(), getJceProvider());
                         cipherTextBytes = cipherHolder.getCipherBase64Decoded();
                         isCipherTransformEnabled = true;
                     } else {
-                        keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
+                        keyStoreCipher = Cipher.getInstance(cipherTransformation, getJceProvider());
                         isCipherTransformEnabled = true;
                     }
                 } else {
                     // This will reach if the user have removed org.wso2.CipherTransformation from the carbon.properties
                     // or delete carbon.properties file
-                    keyStoreCipher = Cipher.getInstance("RSA", "BC");
+                    keyStoreCipher = Cipher.getInstance("RSA", getJceProvider());
                 }
 
                 keyStoreCipher.init(Cipher.DECRYPT_MODE, privateKey);
@@ -308,9 +308,9 @@ public class CryptoUtil {
                     privateKey = (PrivateKey) keyStore.getKey(primaryKeyStoreAlias, primaryKeyStoreKeyPass.toCharArray());
                 }
                 if (cipherTransformation != null) {
-                    keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
+                    keyStoreCipher = Cipher.getInstance(cipherTransformation, getJceProvider());
                 } else {
-                    keyStoreCipher = Cipher.getInstance("RSA", "BC");
+                    keyStoreCipher = Cipher.getInstance("RSA", getJceProvider());
                 }
 
                 keyStoreCipher.init(Cipher.DECRYPT_MODE, privateKey);
@@ -451,6 +451,19 @@ public class CryptoUtil {
         }
 
         return strBuffer.toString();
+    }
+
+    /**
+     * Get the JCE provider to be used for encryption/decryption
+     *
+     * @return
+     */
+    private String getJceProvider() {
+        String provider = CarbonServerConfigurationService.getInstance().getFirstProperty("JCEProvider");
+        if (provider == null && provider.equalsIgnoreCase(Constants.BOUNCY_CASTLE_FIPS_PROVIDER)) {
+            return Constants.BOUNCY_CASTLE_FIPS_PROVIDER;
+        }
+        return Constants.BOUNCY_CASTLE_PROVIDER;
     }
 }
 

--- a/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
@@ -607,4 +607,8 @@
         <Password>{{monitoring.ei_analytics.password}}</Password>
     </Analytics>
 
+    <!-- Configure JCE provider -->
+    {% if jce_provider.provider_name is defined %}
+        <JCEProvider>{{jce_provider.provider_name}}</JCEProvider>
+    {% endif %}
 </Server>


### PR DESCRIPTION
## Purpose
The micro-integrator repo by default uses the BouncyCastleProvider as the Crypto provider. Since the BouncyCastleProvider does not FIPS compliant, it is necessary to introduce a mechanism to configure a FIPS compliant Crypto provider.

Related to https://github.com/wso2/api-manager/issues/1219

## Goals
To allow configuring a FIPS-compliant Crypto provider on demand.

## Approach
This PR introduces a new `deployment.toml` configuration which can be used to switch the Crypto provider from `BouncyCastleProvider` to `BouncyCastleFIPSProvider`.

```toml
[jce_provider]
provider_name = "BCFIPS"
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes