### PR TITLE
Fix analytics related issues in MI

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/main/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/observer/AnalyticsMediationFlowObserver.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/main/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/observer/AnalyticsMediationFlowObserver.java
@@ -23,9 +23,11 @@ import org.apache.synapse.aspects.flow.statistics.publishing.PublishingFlow;
 import org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.ei.EIStatisticsPublisher;
 import org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.StatisticsPublisher;
 import org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.elasticsearch.ElasticStatisticsPublisher;
+import org.wso2.micro.integrator.analytics.messageflow.data.publisher.util.MediationDataPublisherConstants;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 public class AnalyticsMediationFlowObserver implements MessageFlowObserver, TenantInformation {
 
@@ -33,9 +35,19 @@ public class AnalyticsMediationFlowObserver implements MessageFlowObserver, Tena
     private int tenantId = -1234;
     private final Collection<StatisticsPublisher> statPublishers = new ArrayList<>();
 
-    public AnalyticsMediationFlowObserver() {
-        statPublishers.add(EIStatisticsPublisher.GetInstance());
-        statPublishers.add(ElasticStatisticsPublisher.GetInstance());
+    public AnalyticsMediationFlowObserver(List<String> publisherTypes) {
+        if (publisherTypes != null && !publisherTypes.isEmpty() &&
+                (publisherTypes.contains(MediationDataPublisherConstants.DATABRIDGE_PUBLISHER_TYPE )
+                        || publisherTypes.contains(MediationDataPublisherConstants.LOG_PUBLISHER_TYPE))) {
+            if (publisherTypes.contains(MediationDataPublisherConstants.DATABRIDGE_PUBLISHER_TYPE)) {
+                statPublishers.add(EIStatisticsPublisher.GetInstance());
+            }
+            if (publisherTypes.contains(MediationDataPublisherConstants.LOG_PUBLISHER_TYPE)) {
+                statPublishers.add(ElasticStatisticsPublisher.GetInstance());
+            }
+        } else {
+            statPublishers.add(ElasticStatisticsPublisher.GetInstance());
+        }
     }
 
     @Override

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/main/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/util/MediationDataPublisherConstants.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/main/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/util/MediationDataPublisherConstants.java
@@ -24,5 +24,9 @@ public class MediationDataPublisherConstants {
 
     public static final String CONFIG_STREAM_NAME = "org.wso2.esb.analytics.stream.ConfigEntry";
     public static final String CONFIG_STREAM_VERSION = "1.0.0";
+    public static final String DATABRIDGE_PUBLISHER_TYPE = "databridge";
+    public static final String LOG_PUBLISHER_TYPE = "log";
+    public static final String ANALYTICS_TYPE = "analytics.publisher";
+
 
 }

--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -85,6 +85,7 @@
   "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.JaegerTelemetryManager",
 
   "synapse_properties.'analytics.enabled'": false,
+  "synapse_properties.'analytics.publisher'": "log",
   "synapse_properties.'analytics.prefix'": "SYNAPSE_ANALYTICS_DATA",
   "synapse_properties.'analytics.id'": "$ref{server.hostname}",
   "synapse_properties.'analytics.api_analytics.enabled'": true,

--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -505,6 +505,7 @@
   "custom_transport.sender:parameter.non_blocking": "custom_transport.sender:parameter.non-blocking",
 
   "analytics.enabled" : "synapse_properties.'analytics.enabled'",
+  "analytics.publisher":   "synapse_properties.'analytics.publisher'",
   "analytics.prefix" : "synapse_properties.'analytics.prefix'",
   "analytics.id" : "synapse_properties.'analytics.id'",
   "analytics.api_analytics.enabled" : "synapse_properties.'analytics.api_analytics.enabled'",


### PR DESCRIPTION
## Purpose
Fix analytics related issues in MI

With this, a new property is introduced to mention which analytics publisher has to be enabled. With that, the analytics configurations will be as below. multiple publishers can be provided with a "," character. 

```
[analytics]
enabled = true
publisher = “log” <- publisher types supported are log and databridge ->
id = "wso2mi_server_1234"
prefix = "SYNAPSE_ANALYTICS_DATA"
api_analytics.enabled = true
proxy_service_analytics.enabled = true
sequence_analytics.enabled = true
endpoint_analytics.enabled = true
inbound_endpoint_analytics.enabled = true
```

Fixes 
https://github.com/wso2/api-manager/issues/1498