### PR TITLE
Use secureDocumentBuilderFactory instead of the DocumentBuilderFactory

### DIFF
--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/vault/utils/Utils.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/vault/utils/Utils.java
@@ -18,6 +18,7 @@ package org.wso2.micro.integrator.security.vault.utils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.micro.integrator.security.vault.SecureVaultException;
 import org.wso2.micro.integrator.security.vault.Constants;
 import org.xml.sax.SAXException;
@@ -222,7 +223,7 @@ public class Utils {
         if (Files.exists(path)) {
             //WSO2 Environment
             try {
-                DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory docFactory = IdentityUtil.getSecuredDocumentBuilderFactory();
                 DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
                 Document document = docBuilder.parse(path.toAbsolutePath().toString());
 


### PR DESCRIPTION
## Purpose
As per section 2.4 in [WSO2 Secure Engineering Guidelines](https://wso2.com/technical-reports/wso2-secure-engineering-guidelines/), it requires to use the secure document builder.

`DocumentBuilderFactory documentFactory = IdentityUtil.getSecuredDocumentBuilderFactory();`

The commit contains the above change