### PR TITLE
Update/Delete user credentials via a Management Rest API

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -129,7 +129,11 @@ public class Constants {
     public static final String ROLES = "roles";
     public static final String ROLE = "role";
     public static final String PASSWORD = "password";
+    public static final String NEW_PASSWORD = "newPassword";
+    public static final String CONFIRM_PASSWORD = "confirmPassword";
+    public static final String OLD_PASSWORD = "oldPassword";
     public static final String IS_ADMIN = "isAdmin";
+    public static final String ADMIN = "admin";
     public static final String PATTERN = "pattern";
     public static final String PASSWORD_MASKED_VALUE = "*****";
 


### PR DESCRIPTION
### Purpose
Adding new management API to change non-user credentials using any admin user credentials. Admin user credentials can be changed by the same admin or the super admin.

Changing the password of users after logging with user 6 (admin user) can be done using the below request.
```
curl -X PATCH -d '{ "newPassword": "password45", "confirmPassword": "password45" , "oldPassword": "user4"}' "https://localhost:9164/management/users/user4" -H "accept: application/json" -H "Authorization: Bearer $AccessTokenuser6" -H "Content-Type: application/json" -k
```

Fix for : https://github.com/wso2/api-manager/issues/1696