### PR TITLE
Update the year to 2023 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ WSO2 Micro Integrator is licensed under the [Apache License](http://www.apache.o
 
 ## Copyright
 
-(c) 2020, [WSO2 Inc.](http://www.wso2.org) All Rights Reserved.
+(c) 2023, [WSO2 Inc.](http://www.wso2.org) All Rights Reserved.


### PR DESCRIPTION
Noticed that the year in the README was 2020 which would give an outdated vibe. Updating it to 2023.