### PR TITLE
Fix prepareCall not working when correlation log enabled

### DIFF
--- a/components/org.wso2.micro.integrator.ndatasource.rdbms/src/main/java/org/wso2/micro/integrator/ndatasource/rdbms/CorrelationLogInterceptor.java
+++ b/components/org.wso2.micro.integrator.ndatasource.rdbms/src/main/java/org/wso2/micro/integrator/ndatasource/rdbms/CorrelationLogInterceptor.java
@@ -21,6 +21,7 @@ package org.wso2.micro.integrator.ndatasource.rdbms;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.sql.CallableStatement;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -147,7 +148,11 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
             if (sql != null) {
                 this.prepareStatement(sql, time);
             }
-        } else if (!this.compare("prepareCall", name)) {
+        } else if (this.compare("prepareCall", name)) {
+            sql = (String) args[0];
+            constructor = this.getConstructor(2, CallableStatement.class);
+            this.prepareCall(sql, time);
+        } else {
             return statement;
         }
 


### PR DESCRIPTION
## Purpose
Fix prepareCall not working when correlation log enabled

Fixes: https://github.com/wso2/api-manager/issues/1869

Port [3096](https://github.com/wso2/carbon-kernel/pull/3096) from carbon-kernel