### PR TITLE
Add SSL and Auth source support to Mongo data-sources.

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.common/src/main/java/org/wso2/micro/integrator/dataservices/common/DBConstants.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.common/src/main/java/org/wso2/micro/integrator/dataservices/common/DBConstants.java
@@ -673,6 +673,8 @@ public final class DBConstants {
         public static final String CONNECT_TIMEOUT = "mongoDB_connectTimeout";
         public static final String MAX_WAIT_TIME = "mongoDB_maxWaitTime";
         public static final String SOCKET_TIMEOUT = "mongoDB_socketTimeout";
+        public static final String SSL_ENABLED = "mongoDB_ssl_enabled";
+        public static final String AUTH_SOURCE = "mongoDB_auth_source";
         public static final String CONNECTIONS_PER_HOST = "mongoDB_connectionsPerHost";
         public static final String THREADS_ALLOWED_TO_BLOCK_CONN_MULTIPLIER = "mongoDB_threadsAllowedToBlockForConnectionMultiplier";
         public static final String RESULT_COLUMN_NAME = "Document";


### PR DESCRIPTION
Adding the SSL and Auth Source Support for MongoDb in MI.
Related  MI 4.1 Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/3296
Related MI 4.2 Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/3413
Related Commit: https://github.com/wso2/carbon-data/commit/6f76b1d13cc473dfc02eee8f70243e427424d93a