### PR TITLE
Fix vfs testcases connect to RSA supported sftp server

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/vfs/transport/test/ESBJAVA3470.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/vfs/transport/test/ESBJAVA3470.java
@@ -38,6 +38,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
 import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.base.CarbonBaseUtils;
 import org.wso2.carbon.proxyadmin.stub.ProxyServiceAdminProxyAdminException;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
@@ -79,6 +80,8 @@ public class ESBJAVA3470 extends ESBIntegrationTest {
     private File SFTPFolder;
     private String carbonHome;
     private ServerConfigurationManager serverConfigurationManager;
+    private static final String SH_FILE_NAME = "micro-integrator.sh";
+    private static final String BAT_FILE_NAME = "micro-integrator.bat";
 
     public static KeyPairProvider createTestHostKeyProvider(Path path) {
         SimpleGeneratorHostKeyProvider keyProvider = new SimpleGeneratorHostKeyProvider();
@@ -97,6 +100,18 @@ public class ESBJAVA3470 extends ESBIntegrationTest {
         setupSftpFolders(carbonHome);
         setupSftpServer(carbonHome);
         Thread.sleep(15000);
+        File newShFile = new File(
+                getESBResourceLocation() + File.separator + "vfs" + File.separator + SH_FILE_NAME);
+        File oldShFile =
+                new File(CarbonBaseUtils.getCarbonHome() + File.separator + "bin" + File.separator + SH_FILE_NAME);
+        serverConfigurationManager.applyConfigurationWithoutRestart(newShFile, oldShFile, true);
+        File newBatFile = new File(
+                getESBResourceLocation() + File.separator + "vfs" + File.separator + BAT_FILE_NAME);
+        File oldBatFile =
+                new File(CarbonBaseUtils.getCarbonHome() + File.separator + "bin" + File.separator + BAT_FILE_NAME);
+        serverConfigurationManager.applyConfigurationWithoutRestart(newBatFile, oldBatFile, true);
+        serverConfigurationManager.restartGracefully();
+        super.init();
     }
 
     @Test(groups = "wso2.esb", description = "VFS absolute path test for sftp")
@@ -154,6 +169,7 @@ public class ESBJAVA3470 extends ESBIntegrationTest {
         //sshd.stop();
         log.info("SFTP Server stopped successfully");
         super.cleanup();
+        serverConfigurationManager.restoreToLastMIConfiguration();
     }
 
     /**

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/vfs/transport/test/ESBJAVA4770VFSPasswordSecurityWithLargekeyTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/vfs/transport/test/ESBJAVA4770VFSPasswordSecurityWithLargekeyTestCase.java
@@ -66,6 +66,8 @@ public class ESBJAVA4770VFSPasswordSecurityWithLargekeyTestCase extends ESBInteg
     private String outputFolderName = "out";
     private static final String USERNAME = "SFTPUser";
     private static final String PASSWORD = "SFTP321";
+    private static final String SH_FILE_NAME = "micro-integrator.sh";
+    private static final String BAT_FILE_NAME = "micro-integrator.bat";
 
     @BeforeClass(alwaysRun = true)
     public void runFTPServer() throws Exception {
@@ -116,9 +118,20 @@ public class ESBJAVA4770VFSPasswordSecurityWithLargekeyTestCase extends ESBInteg
 
         // replace the axis2.xml enabled vfs transfer and restart the ESB server gracefully.
         serverConfigurationManager = new ServerConfigurationManager(context);
-        serverConfigurationManager.applyMIConfiguration(new File(
+        serverConfigurationManager.applyMIConfigurationWithRestart(new File(
                 getClass().getResource("/artifacts/ESB/synapseconfig/" + "vfsTransport/ESBJAVA4770/deployment.toml")
                         .getPath()));
+        File newShFile = new File(
+                getESBResourceLocation() + File.separator + "vfs" + File.separator + SH_FILE_NAME);
+        File oldShFile =
+                new File(CarbonBaseUtils.getCarbonHome() + File.separator + "bin" + File.separator + SH_FILE_NAME);
+        serverConfigurationManager.applyConfigurationWithoutRestart(newShFile, oldShFile, true);
+        File newBatFile = new File(
+                getESBResourceLocation() + File.separator + "vfs" + File.separator + BAT_FILE_NAME);
+        File oldBatFile =
+                new File(CarbonBaseUtils.getCarbonHome() + File.separator + "bin" + File.separator + BAT_FILE_NAME);
+        serverConfigurationManager.applyConfigurationWithoutRestart(newBatFile, oldBatFile, true);
+        serverConfigurationManager.restartGracefully();
         super.init();
     }
 

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/vfs/micro-integrator.bat
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/vfs/micro-integrator.bat
@@ -1,0 +1,212 @@
+@echo off
+REM ---------------------------------------------------------------------------
+REM        Copyright 2018 WSO2, Inc. http://www.wso2.org
+REM
+REM  Licensed under the Apache License, Version 2.0 (the "License");
+REM  you may not use this file except in compliance with the License.
+REM  You may obtain a copy of the License at
+REM
+REM      http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM  Unless required by applicable law or agreed to in writing, software
+REM  distributed under the License is distributed on an "AS IS" BASIS,
+REM  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM  See the License for the specific language governing permissions and
+REM  limitations under the License.
+
+rem ---------------------------------------------------------------------------
+rem Main Script for WSO2 Carbon
+rem
+rem Environment Variable Prequisites
+rem
+rem   CARBON_HOME   Home of CARBON installation. If not set I will  try
+rem                   to figure it out.
+rem
+rem   JAVA_HOME       Must point at your Java Development Kit installation.
+rem
+rem   JAVA_OPTS       (Optional) Java runtime options used when the commands
+rem                   is executed.
+rem ---------------------------------------------------------------------------
+
+rem --------- NOTE: This is an edited wso2server.sh script to facilitate
+rem spark environment variables for WSO2DAS!
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+SET CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\version.txt" goto noServerHome
+
+set AXIS2_HOME=%CARBON_HOME%
+goto updateClasspath
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+rem ----- update classpath -----------------------------------------------------
+:updateClasspath
+
+setlocal EnableDelayedExpansion
+cd %CARBON_HOME%
+set CARBON_CLASSPATH=
+FOR %%C in ("%CARBON_HOME%\bin\*.jar") DO set CARBON_CLASSPATH=!CARBON_CLASSPATH!;".\bin\%%~nC%%~xC"
+
+set CARBON_CLASSPATH="%JAVA_HOME%\lib\tools.jar";%CARBON_CLASSPATH%;
+
+FOR %%D in ("%CARBON_HOME%\wso2\lib\*.jar") DO set CARBON_CLASSPATH=!CARBON_CLASSPATH!;".\wso2\lib\%%~nD%%~xD"
+
+rem ----- Process the input command -------------------------------------------
+
+rem Slurp the command line arguments. This loop allows for an unlimited number
+rem of arguments (up to the command line limit, anyway).
+
+
+:setupArgs
+if ""%1""=="""" goto doneStart
+
+if ""%1""==""-run""     goto commandLifecycle
+if ""%1""==""--run""    goto commandLifecycle
+if ""%1""==""run""      goto commandLifecycle
+
+if ""%1""==""-restart""  goto commandLifecycle
+if ""%1""==""--restart"" goto commandLifecycle
+if ""%1""==""restart""   goto commandLifecycle
+
+if ""%1""==""debug""    goto commandDebug
+if ""%1""==""-debug""   goto commandDebug
+if ""%1""==""--debug""  goto commandDebug
+
+if ""%1""==""version""   goto commandVersion
+if ""%1""==""-version""  goto commandVersion
+if ""%1""==""--version"" goto commandVersion
+
+if ""%1""==""stop""   goto stopServer
+if ""%1""==""-stop""  goto stopServer
+if ""%1""==""--stop"" goto stopServer
+
+if ""%1""==""car""   goto setCar
+if ""%1""==""-car""  goto setCar
+if ""%1""==""--car"" goto setCar
+
+shift
+goto setupArgs
+
+rem ----- commandVersion -------------------------------------------------------
+:commandVersion
+shift
+type "%CARBON_HOME%\bin\version.txt"
+type "%CARBON_HOME%\bin\wso2carbon-version.txt"
+goto end
+
+rem ----- commandDebug ---------------------------------------------------------
+:commandDebug
+shift
+set DEBUG_PORT=%1
+if "%DEBUG_PORT%"=="" goto noDebugPort
+if not "%JAVA_OPTS%"=="" echo Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option.
+set JAVA_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%DEBUG_PORT%
+echo Please start the remote debugging client to continue...
+goto findJdk
+
+:noDebugPort
+echo Please specify the debug port after the --debug option
+goto end
+
+:stopServer
+set /p processId= < %CARBON_HOME%\wso2carbon.pid
+echo Stopping the Micro Integrator Server
+taskkill /F /PID %processId%
+goto end
+
+rem ----- commandLifecycle -----------------------------------------------------
+:commandLifecycle
+goto findJdk
+
+:doneStart
+if "%OS%"=="Windows_NT" @setlocal
+if "%OS%"=="WINNT" @setlocal
+
+:setCar
+set CAR_NAME=%2
+
+rem ---------- Handle the SSL Issue with proper JDK version --------------------
+rem find the version of the jdk
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk
+PATH %PATH%;%JAVA_HOME%\bin\
+for /f tokens^=2-5^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set "JAVA_VERSION=%%j%%k"
+if %JAVA_VERSION% LSS 110 goto unknownJdk
+goto supportedJdk
+
+:unknownJdk
+echo Starting WSO2 MI (in unsupported JDK %JAVA_VERSION%)
+echo [ERROR] WSO2 MI is supported only between JDK 11 and JDK 17"
+goto end
+
+:supportedJdk
+goto runServer
+
+rem ----------------- Execute The Requested Command ----------------------------
+
+:runServer
+cd %CARBON_HOME%
+
+rem ------------------ Remove tmp folder on startup -----------------------------
+set TMP_DIR=%CARBON_HOME%\tmp
+cd "%TMP_DIR%"
+del *.* /s /q > nul
+FOR /d %%G in ("*.*") DO rmdir %%G /s /q
+cd ..
+
+rem ---------- Add jars to classpath --c _CLASSPATH%
+
+if %JAVA_VERSION% GEQ 110 set CARBON_CLASSPATH=.\wso2\lib\*;%CARBON_CLASSPATH%
+if %JAVA_VERSION% GEQ 110 set JAVA_VER_BASED_OPTS=--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED
+
+rem ---------------- Setting default profile for Runtime if not parsed --------------
+
+set profileSet=false
+
+for %%x in (%*) do (
+    if "%%x" == "%x:-Dprofile%" (
+        set profileSet=true
+    )
+)
+
+if "%profileSet%" == "false" (
+    set profile=-Dprofile=micro-integrator-default
+)
+
+set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%CARBON_HOME%\repository\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED% -DandesConfig=broker.xml -Dcarbon.registry.root=/ -Dcarbon.home="%CARBON_HOME%" -Dlogfiles.home="%CARBON_HOME%\repository\logs" -Dwso2.server.standalone=true -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcatalina.base="%CARBON_HOME%\wso2\lib\tomcat" -Dwso2.carbon.xml="%CARBON_HOME%\conf\carbon.xml" -Dwso2.registry.xml="%CARBON_HOME%\conf\registry.xml" -Dwso2.user.mgt.xml="%CARBON_HOME%\conf\user-mgt.xml" -Dwso2.transports.xml="%CARBON_HOME%\conf\mgt-transports.xml" -Djava.util.logging.config.file="%CARBON_HOME%\conf\log4j.properties" -Dcarbon.config.dir.path="%CARBON_HOME%\conf" -DNonUserCoreMode=true -DNonRegistryMode=true -Dcarbon.logs.path="%CARBON_HOME%\repository\logs" -Dcomponents.repo="%CARBON_HOME%\wso2\components\plugins" -Dcarbon.config.dir.path="%CARBON_HOME%\conf" -Dcarbon.components.dir.path="%CARBON_HOME%\wso2\components" -Dcarbon.dropins.dir.path="%CARBON_HOME%\dropins" -Dcarbon.external.lib.dir.path="%CARBON_HOME%\lib" -Dcarbon.patches.dir.path="%CARBON_HOME%\patches" -Dcarbon.internal.lib.dir.path="%CARBON_HOME%\wso2\lib" -Dconf.location="%CARBON_HOME%\conf" -Dcom.atomikos.icatch.file="%CARBON_HOME%\wso2\lib\transactions.properties" -Dei.extendedURIBasedDispatcher=org.wso2.micro.integrator.core.handlers.IntegratorStatefulHandler -Dcom.atomikos.icatch.hide_init_file_path="true" -Dorg.apache.jasper.compiler.Parser.STRICT_QUOTE_ESCAPING=false -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dcom.sun.jndi.ldap.connect.pool.authentication=simple -Dcom.sun.jndi.ldap.connect.pool.timeout=3000 -Dorg.terracotta.quartz.skipUpdateCheck=true -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8 -Dlogger.server.name="micro-integrator" -Dqpid.conf="\conf\advanced" -Dproperties.file.path=default -Djavax.xml.xpath.XPathFactory:http://java.sun.com/jaxp/xpath/dom=net.sf.saxon.xpath.XPathFactoryImpl -DavoidConfigHashRead=true -DenableReadinessProbe=true -DenableLivenessProbe=true -DenableManagementApi=true -DskipStartupExtensions=false -Dautomation.mode.seq.car.name="%CAR_NAME%" -Dlog4j2.contextSelector="org.apache.logging.log4j.core.async.AsyncLoggerContextSelector" -Dorg.ops4j.pax.logging.logReaderEnabled=false -Djsch.server_host_key=ssh-rsa,ssh-dss -Djsch.client_pubkey=ssh-rsa,ssh-dss -Dorg.ops4j.pax.logging.eventAdminEnabled=false %JAVA_VER_BASED_OPTS% %profile% -Dorg.apache.activemq.SERIALIZABLE_PACKAGES="*"
+
+:runJava
+rem echo JAVA_HOME environment variable is set to %JAVA_HOME%
+rem echo CARBON_HOME environment variable is set to %CARBON_HOME%
+"%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% org.wso2.micro.integrator.bootstrap.Bootstrap %CMD%
+if "%ERRORLEVEL%"=="121" goto runJava
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/vfs/micro-integrator.sh
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/vfs/micro-integrator.sh
@@ -1,0 +1,351 @@
+#!/bin/sh
+# micro-integrator.sh
+# ----------------------------------------------------------------------------
+#  Copyright 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# Set AXIS2_HOME. Needed for One Click JAR Download
+AXIS2_HOME="$CARBON_HOME"
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$AXIS2_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
+  PID=`cat "$CARBON_HOME"/wso2carbon.pid`
+fi
+
+# ----- Process the input command ----------------------------------------------
+args=""
+for c in $*
+do
+    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
+          CMD="--debug"
+          continue
+    elif [ "$CMD" = "--debug" ]; then
+          if [ -z "$PORT" ]; then
+                PORT=$c
+          fi
+    elif [ "$c" = "--stop" ] || [ "$c" = "-stop" ] || [ "$c" = "stop" ]; then
+          CMD="stop"
+    elif [ "$c" = "--start" ] || [ "$c" = "-start" ] || [ "$c" = "start" ]; then
+          CMD="start"
+    elif [ "$c" = "--version" ] || [ "$c" = "-version" ] || [ "$c" = "version" ]; then
+          CMD="version"
+    elif [ "$c" = "--restart" ] || [ "$c" = "-restart" ] || [ "$c" = "restart" ]; then
+          CMD="restart"
+    elif [ "$c" = "--car" ] || [ "$c" = "-car" ] || [ "$c" = "car" ]; then
+          ARGUMENT="car"
+          OPTARG="$2"
+    else
+        args="$args $c"
+    fi
+done
+
+if [ "$ARGUMENT" = "car" ]; then
+  CAR_NAME="$OPTARG"
+fi
+
+if [ "$CMD" = "--debug" ]; then
+  if [ "$PORT" = "" ]; then
+    echo " Please specify the debug port after the --debug option"
+    exit 1
+  fi
+  if [ -n "$JAVA_OPTS" ]; then
+    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
+  fi
+  CMD="RUN"
+  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  echo "Please start the remote debugging client to continue..."
+elif [ "$CMD" = "start" ]; then
+  if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
+    if  ps -p $PID > /dev/null ; then
+      echo "Process is already running"
+      exit 0
+    fi
+  fi
+  export CARBON_HOME="$CARBON_HOME"
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/bin/micro-integrator.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "stop" ]; then
+  export CARBON_HOME="$CARBON_HOME"
+  kill -term `cat "$CARBON_HOME"/wso2carbon.pid`
+  exit 0
+elif [ "$CMD" = "restart" ]; then
+  export CARBON_HOME="$CARBON_HOME"
+  kill -term `cat "$CARBON_HOME"/wso2carbon.pid`
+  process_status=0
+  pid=`cat "$CARBON_HOME"/wso2carbon.pid`
+  while [ "$process_status" -eq "0" ]
+  do
+        sleep 1;
+        ps -p$pid 2>&1 > /dev/null
+        process_status=$?
+  done
+
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/bin/micro-integrator.sh $args > /dev/null 2>&1 &
+  exit 0
+
+elif [ "$CMD" = "version" ]; then
+  cat "$CARBON_HOME"/bin/version.txt
+  cat "$CARBON_HOME"/bin/wso2carbon-version.txt
+  exit 0
+fi
+
+# ---------- Handle the SSL Issue with proper JDK version --------------------
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+   echo " Starting WSO2 MI (in unsupported JDK)"
+   echo " [ERROR] WSO2 MI is supported only between JDK 11 and JDK 17"
+   exit 0
+fi
+
+CARBON_XBOOTCLASSPATH=""
+for f in "$CARBON_HOME"/wso2/lib/xboot/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/wso2/lib/xboot/*.jar" ];then
+        CARBON_XBOOTCLASSPATH="$CARBON_XBOOTCLASSPATH":$f
+    fi
+done
+
+CARBON_CLASSPATH=""
+if [ -e "$JAVA_HOME/lib/tools.jar" ]; then
+    CARBON_CLASSPATH="$JAVA_HOME/../lib/tools.jar"
+fi
+for f in "$CARBON_HOME"/bin/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/bin/*.jar" ];then
+        CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+    fi
+done
+for t in "$CARBON_HOME"/wso2/lib/*.jar
+do
+    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+done
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  AXIS2_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
+  CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+# echo JAVA_HOME environment variable is set to $JAVA_HOME
+# echo CARBON_HOME environment variable is set to "$CARBON_HOME"
+
+cd "$CARBON_HOME"
+
+TMP_DIR="$CARBON_HOME"/tmp
+if [ -d "$TMP_DIR" ]; then
+rm -rf "$TMP_DIR"/*
+fi
+
+START_EXIT_STATUS=121
+status=$START_EXIT_STATUS
+
+if [ -z "$JVM_MEM_OPTS" ]; then
+   java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+   JVM_MEM_OPTS="-Xms256m -Xmx1024m"
+   if [ "$java_version" \< "1.8" ]; then
+      JVM_MEM_OPTS="$JVM_MEM_OPTS"
+   fi
+fi
+# echo "Using Java memory options: $JVM_MEM_OPTS"
+
+#setting up profile parameter for runtime in MB
+PROFILE_SELECTED="false"
+for i in "$@"; do
+   if echo "$i" | grep -q "Dprofile"; then
+      PROFILE_SELECTED="true"
+   fi
+done
+
+if [ "$PROFILE_SELECTED" = false ] ; then
+   NODE_PARAMS="$NODE_PARAMS -Dprofile=micro-integrator-default"
+fi
+
+#To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
+#   -Djava.rmi.server.hostname="your.IP.goes.here"
+
+JAVA_VER_BASED_OPTS=""
+
+if [ $java_version_formatted -ge 1100 ]; then
+    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED"
+fi
+
+while [ "$status" = "$START_EXIT_STATUS" ]
+do
+    $JAVACMD \
+    -Xbootclasspath/a:"$CARBON_XBOOTCLASSPATH" \
+    $JVM_MEM_OPTS \
+    -XX:+HeapDumpOnOutOfMemoryError \
+    -XX:HeapDumpPath="$CARBON_HOME/repository/logs/heap-dump.hprof" \
+    $JAVA_OPTS \
+    -Dcom.sun.management.jmxremote \
+    -classpath "$CARBON_CLASSPATH" \
+    -Djava.io.tmpdir="$CARBON_HOME/tmp" \
+    -Dcatalina.base="$CARBON_HOME/wso2/lib/tomcat" \
+    -Dwso2.server.standalone=true \
+    -Dcarbon.registry.root=/ \
+    -Djava.command="$JAVACMD" \
+    -Dqpid.conf="/conf/advanced/" \
+    $JAVA_VER_BASED_OPTS \
+    -Dcarbon.home="$CARBON_HOME" \
+    -Dlogfiles.home="$CARBON_HOME/repository/logs" \
+    -Dlogger.server.name="micro-integrator" \
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager \
+    -Dcarbon.config.dir.path="$CARBON_HOME/conf" \
+    -Dcarbon.repository.dir.path="$CARBON_HOME/repository" \
+    -Dcarbon.components.dir.path="$CARBON_HOME/wso2/components" \
+    -Dcarbon.dropins.dir.path="$CARBON_HOME/dropins" \
+    -Dcarbon.external.lib.dir.path="$CARBON_HOME/lib" \
+    -Dcarbon.patches.dir.path="$CARBON_HOME/patches" \
+    -Dcarbon.internal.lib.dir.path="$CARBON_HOME/wso2/lib" \
+    -Dei.extendedURIBasedDispatcher=org.wso2.micro.integrator.core.handlers.IntegratorStatefulHandler \
+    -Djava.util.logging.config.file="$CARBON_HOME/conf/etc/logging-bridge.properties" \
+    -Dcomponents.repo="$CARBON_HOME/wso2/components/plugins" \
+    -Dconf.location="$CARBON_HOME/conf" \
+    -Dcom.atomikos.icatch.file="$CARBON_HOME/wso2/lib/transactions.properties" \
+    -Dcom.atomikos.icatch.hide_init_file_path=true \
+    -Dorg.apache.jasper.compiler.Parser.STRICT_QUOTE_ESCAPING=false \
+    -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true \
+    -Dcom.sun.jndi.ldap.connect.pool.authentication=simple  \
+    -Dcom.sun.jndi.ldap.connect.pool.timeout=3000  \
+    -Dorg.terracotta.quartz.skipUpdateCheck=true \
+    -Djava.security.egd=file:/dev/./urandom \
+    -Dfile.encoding=UTF8 \
+    -Djava.net.preferIPv4Stack=true \
+    -DNonRegistryMode=true \
+    -DNonUserCoreMode=true \
+    -Dcom.ibm.cacheLocalHost=true \
+    -Dcarbon.use.registry.repo=false \
+    -DworkerNode=false \
+    -Dorg.apache.cxf.io.CachedOutputStream.Threshold=104857600 \
+    -Djavax.xml.xpath.XPathFactory:http://java.sun.com/jaxp/xpath/dom=net.sf.saxon.xpath.XPathFactoryImpl \
+    -DavoidConfigHashRead=true \
+    -Dproperties.file.path=default \
+    -DenableReadinessProbe=true \
+    -DenableLivenessProbe=true \
+    -DenableManagementApi=true \
+    -DskipStartupExtensions=false \
+    -Dautomation.mode.seq.car.name="$CAR_NAME" \
+    -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector \
+    -Dorg.ops4j.pax.logging.logReaderEnabled=false \
+    -Dorg.ops4j.pax.logging.eventAdminEnabled=false \
+    -Djsch.server_host_key=ssh-rsa,ssh-dss \
+    -Djsch.client_pubkey=ssh-rsa,ssh-dss \
+    $NODE_PARAMS \
+    -Dorg.apache.activemq.SERIALIZABLE_PACKAGES="*" \
+    org.wso2.micro.integrator.bootstrap.Bootstrap $*
+    status=$?
+done


### PR DESCRIPTION
## Purpose
The tescases are failing after upgrading to vfs version to com.github.mwiede 0.2.4 [1]
The RSA/SHA1 signature algorithm is disabled by default.
For legacy sftp severs jsch.server_host_key + jsch.client_pubkey properties has to set with the RSA algorithm

[1] https://github.com/wso2/wso2-synapse/pull/2066