### PR TITLE
Run ServiceCatalog Executor in a single thread by default

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -120,7 +120,7 @@ public class CappDeployer extends AbstractDeployer {
         if (ServiceCatalogUtils.isServiceCatalogEnabled()) {
             serviceCatalogConfiguration = ServiceCatalogUtils.readConfiguration(secretCallbackHandlerService);
             serviceCatalogExecutor = Executors.newFixedThreadPool(
-                    ServiceCatalogUtils.getExecutorThreadCount(serviceCatalogConfiguration, 10));
+                    ServiceCatalogUtils.getExecutorThreadCount(serviceCatalogConfiguration, 1));
         }
     }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This is to avoid unwanted intermittent issues when deploying multiple CApps. If anyone needs multi-threads to deploy capps, they can configure in deployment.toml to increase the value.