### PR TITLE
Fix typo in WWW-Authenticate header

### DIFF
--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/handler/BasicAuthConstants.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/handler/BasicAuthConstants.java
@@ -29,6 +29,6 @@ public class BasicAuthConstants {
     public static final String RESPONSE = "RESPONSE";
     public static final String TRUE = "true";
     public static final String NO_ENTITY_BODY = "NO_ENTITY_BODY";
-    public static final String WWW_AUTHENTICATE = "WWW_Authenticate";
+    public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
     public static final String WWW_AUTH_METHOD = "Basic realm=\"WSO2 EI\"";
 }


### PR DESCRIPTION
## Purpose
> Fix typo in WWW-Authenticate header in basicAuth.
refer https://datatracker.ietf.org/doc/html/rfc7235#section-4.1 
Fixes wso2/micro-integrator/issues/3053
