### PR TITLE
Fix registry not honoring cache expiration

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -449,12 +449,14 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
 
     private long getLastModifiedTimestamp(String filePath, URLConnection urlc) {
         Long lastModifiedFromMap = getResourceLastModifiedEntry(filePath);
+        Long urlLastModified = urlc.getLastModified(); // Get the last modified timestamp from urlc
         Long timestamp;
-        if (lastModifiedFromMap != null) {
+        if (lastModifiedFromMap != null && lastModifiedFromMap > urlLastModified) {
             timestamp = lastModifiedFromMap;
         } else {
-            timestamp = urlc.getLastModified();
+            timestamp = urlLastModified;
         }
+
         Long lastModifiedPropertiesFromMap = getResourceLastModifiedEntry(filePath + ".properties");
         if (lastModifiedPropertiesFromMap != null && lastModifiedPropertiesFromMap > timestamp) {
             timestamp = lastModifiedPropertiesFromMap;


### PR DESCRIPTION

## Purpose
The registry entries after cache expiration haven't been updated in the run time. The issue was that even though the expiration was detected the version of the new registry entry was returned as same as the old one then we returned the old value instead of changed value. This is because we have returned the saved time of file creation rather than the actual file modified time as the version.

Fixes: https://github.com/wso2/micro-integrator/issues/3083