### PR TITLE
Roll back messages when inject sequence isn't deployed

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSInjectHandler.java
@@ -275,6 +275,7 @@ public class JMSInjectHandler {
                 }
             } else {
                 log.error("Sequence: " + injectingSeq + " not found");
+                return false;
             }
 
             if (isRollback(msgCtx) || isToRecover(msgCtx)) {


### PR DESCRIPTION


## Purpose
When injecting sequence isn't deployed (deployed with separate capp) the messages were consumed without roll backing. So had to set ack to false when this is happening.

Fixes: https://github.com/wso2/micro-integrator/issues/3110