### PR TITLE
Fix SqlQuery type mismatching issue

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/SQLQuery.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/SQLQuery.java
@@ -151,7 +151,7 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
 
     private boolean timeConvertEnabled = true;
 
-    private static QueryType sqlQueryType;
+    private QueryType sqlQueryType;
 
     /**
      * thread local variable to keep the ordinal of the ref cursor if there is any
@@ -2571,7 +2571,7 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
         return sqlQueryType = sqlQueryType(query);
     }
 
-    public static QueryType sqlQueryType(String sqlQuery) {
+    public QueryType sqlQueryType(String sqlQuery) {
 
         String query;
         try {


### PR DESCRIPTION

## Purpose
We have used a static variable to keep Sql Query type hence when more than one DataServices is deployed the query type becomes inconsistent. Fix this by removing the static context.

Fixes: https://github.com/wso2/api-manager/issues/2520
