### PR TITLE
Fix all carbon_home files deleted after tmp folder deletion and restart

### DIFF
--- a/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/serviceCatalog/micro-integrator.bat
+++ b/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/serviceCatalog/micro-integrator.bat
@@ -166,10 +166,12 @@ cd %CARBON_HOME%
 
 rem ------------------ Remove tmp folder on startup -----------------------------
 set TMP_DIR=%CARBON_HOME%\tmp
-cd "%TMP_DIR%"
-del *.* /s /q > nul
-FOR /d %%G in ("*.*") DO rmdir %%G /s /q
-cd ..
+if exist "%TMP_DIR%" (
+    cd "%TMP_DIR%"
+    del *.* /s /q > nul
+    FOR /d %%G in ("*.*") DO rmdir %%G /s /q
+    cd ..
+)
 
 rem ---------- Add jars to classpath --c _CLASSPATH%
 


### PR DESCRIPTION
## Purpose
Fix all carbon_home files being deleted after tmp folder deletion and restart. 
Fixes:https://github.com/wso2/micro-integrator/issues/3145

