### PR TITLE
Improve deployment, undeployment and lookup of collections in Registry

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
@@ -57,6 +57,7 @@ public class MicroIntegratorRegistryConstants {
     public static final char URL_SEPARATOR_CHAR = '/';
     public static final String URL_SEPARATOR = "/";
     public static final String PROPERTY_EXTENTION = ".properties";
+    public static final String COLLECTION_PROPERTY_EXTENTION = ".collections" + PROPERTY_EXTENTION;
 
     public static final String DEFAULT_MEDIA_TYPE = "text/plain";
 

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/test/java/org/wso2/micro/integrator/registry/TestMicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/test/java/org/wso2/micro/integrator/registry/TestMicroIntegratorRegistry.java
@@ -124,6 +124,46 @@ public class TestMicroIntegratorRegistry {
     }
 
     @Test
+    public void testRegistryPropertiesDeploymentAndLookup() throws IOException {
+
+        String filePath = "gov:/custom/payload/template.json";
+        String content = "{\"Hello\":\"World\"}";
+        Properties properties = new Properties();
+        properties.setProperty("token", "12345");
+        properties.setProperty("owner", "John");
+        microIntegratorRegistry.addNewNonEmptyResource(filePath, false, "application/json", content, properties);
+
+        File resourceFile = Paths.get(governanceRegistry.toString(), "custom", "payload", "template.json").toFile();
+        File propertiesFile = Paths.get(governanceRegistry.toString(), "custom", "payload", "template.json.properties").toFile();
+        Assert.assertTrue("template.json file should be created", resourceFile.exists());
+        Assert.assertTrue("template.json.properties file should be created", propertiesFile.exists());
+
+        Properties readProperties = microIntegratorRegistry.getResourceProperties(filePath);
+        Assert.assertEquals("Properties should be as expected", "12345", readProperties.getProperty("token"));
+        Assert.assertEquals("Properties should be as expected", "John", readProperties.getProperty("owner"));
+
+    }
+
+    @Test
+    public void testRegistryCollectionPropertiesDeploymentAndLookup() throws IOException {
+
+        String filePath = "gov:/custom/folder";
+        Properties properties = new Properties();
+        properties.setProperty("token", "12345");
+        properties.setProperty("owner", "John");
+        microIntegratorRegistry.addNewNonEmptyResource(filePath, true, "application/json", "", properties);
+
+        File propertiesFile = Paths.get(governanceRegistry.toString(), "custom", "folder.collections.properties").toFile();
+        Assert.assertTrue("folder.collection.properties file should be created", propertiesFile.exists());
+
+        Properties readProperties = microIntegratorRegistry.getResourceProperties(filePath);
+        Assert.assertEquals("Properties should be as expected", "12345", readProperties.getProperty("token"));
+        Assert.assertEquals("Properties should be as expected", "John", readProperties.getProperty("owner"));
+
+        microIntegratorRegistry.delete(filePath);
+    }
+
+    @Test
     public void testRegistryResourceReadWithEmptyMediaType() {
         OMNode omNode = microIntegratorRegistry.lookup("conf:/custom/QueueName");
         Assert.assertEquals("File content should be as expected","ordersQueue", ((OMTextImpl) omNode).getText().trim());

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -229,6 +229,7 @@ public class Constants {
     public static final String DEFAULT_MEDIA_TYPE = "text/plain";
     public static final String MEDIA_TYPE_KEY = "mediaType";
     public static final String PROPERTY_EXTENSION = ".properties";
+    public static final String COLLECTIONS_PROPERTY_EXTENSIONS = ".collections.properties";
     public static final String VALUE_KEY = "value";
     public static final String REGISTRY_RESOURCE_NAME = "registryResourceName";
     public static final String REGISTRY_PROPERTY_NAME = "propertyName";

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java
@@ -52,7 +52,6 @@ import static org.wso2.micro.integrator.management.apis.Constants.HTTP_POST;
 import static org.wso2.micro.integrator.management.apis.Constants.INTERNAL_SERVER_ERROR;
 import static org.wso2.micro.integrator.management.apis.Constants.LIST;
 import static org.wso2.micro.integrator.management.apis.Constants.NAME;
-import static org.wso2.micro.integrator.management.apis.Constants.PROPERTY_EXTENSION;
 import static org.wso2.micro.integrator.management.apis.Constants.REGISTRY_PATH;
 import static org.wso2.micro.integrator.management.apis.Constants.REGISTRY_PROPERTY_NAME;
 import static org.wso2.micro.integrator.management.apis.Constants.REGISTRY_RESOURCE_NAME;
@@ -61,6 +60,7 @@ import static org.wso2.micro.integrator.management.apis.Constants.VALUE_KEY;
 import static org.wso2.micro.integrator.management.apis.Utils.getRegistryPathPrefix;
 import static org.wso2.micro.integrator.management.apis.Utils.getResourceName;
 import static org.wso2.micro.integrator.management.apis.Utils.isRegistryExist;
+import static org.wso2.micro.integrator.management.apis.Utils.isRegistryResourcePropertyExist;
 import static org.wso2.micro.integrator.management.apis.Utils.validatePath;
 
 /**
@@ -241,7 +241,7 @@ public class RegistryPropertiesResource implements MiApiResource {
         String pathWithPrefix = getRegistryPathPrefix(validatedPath);
         if (Objects.nonNull(pathWithPrefix)) {
             if (isRegistryExist(validatedPath, messageContext) &&
-                    isRegistryExist(validatedPath + PROPERTY_EXTENSION, messageContext)) {
+                    isRegistryResourcePropertyExist(validatedPath, messageContext)) {
                 jsonBody = postRegistryProperties(messageContext, axis2MessageContext, pathWithPrefix);
             } else if (isRegistryExist(validatedPath, messageContext)) {
                 jsonBody = postNewRegistryProperties(messageContext, axis2MessageContext, pathWithPrefix);
@@ -463,7 +463,7 @@ public class RegistryPropertiesResource implements MiApiResource {
         if (Objects.nonNull(propertyName)) {
             String pathWithPrefix = getRegistryPathPrefix(validatedPath);
             if (Objects.nonNull(pathWithPrefix)) {
-                if (isRegistryExist(validatedPath + PROPERTY_EXTENSION, messageContext)) {
+                if (isRegistryResourcePropertyExist(validatedPath, messageContext)) {
                     jsonBody = deleteRegistryProperty(messageContext, axis2MessageContext, pathWithPrefix,
                             propertyName);
                 } else {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Utils.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Utils.java
@@ -64,6 +64,7 @@ import java.util.Objects;
 import java.util.Properties;
 
 import static org.wso2.micro.integrator.management.apis.Constants.BAD_REQUEST;
+import static org.wso2.micro.integrator.management.apis.Constants.COLLECTIONS_PROPERTY_EXTENSIONS;
 import static org.wso2.micro.integrator.management.apis.Constants.CONFIGURATION_REGISTRY_PATH;
 import static org.wso2.micro.integrator.management.apis.Constants.CONFIGURATION_REGISTRY_PREFIX;
 import static org.wso2.micro.integrator.management.apis.Constants.FILE;
@@ -73,6 +74,7 @@ import static org.wso2.micro.integrator.management.apis.Constants.GOVERNANCE_REG
 import static org.wso2.micro.integrator.management.apis.Constants.INTERNAL_SERVER_ERROR;
 import static org.wso2.micro.integrator.management.apis.Constants.LOCAL_REGISTRY_PATH;
 import static org.wso2.micro.integrator.management.apis.Constants.LOCAL_REGISTRY_PREFIX;
+import static org.wso2.micro.integrator.management.apis.Constants.PROPERTY_EXTENSION;
 import static org.wso2.micro.integrator.management.apis.Constants.REGISTRY_ROOT_PATH;
 import static org.wso2.micro.integrator.management.apis.Constants.USERNAME_PROPERTY;
 import static org.wso2.micro.integrator.registry.MicroIntegratorRegistryConstants.URL_SEPARATOR;
@@ -546,6 +548,36 @@ public class Utils {
         try {
             File file = new File(resolvedPath);
             return file.exists();
+        } catch (Exception e) {
+            LOG.error("Error occurred while checking the existence of the registry", e);
+            return false;
+        }
+    }
+
+    /**
+     * This method checks whether a registry resource property exists or not.
+     *
+     * @param registryPath    Registry path
+     * @param messageContext  Message context
+     * @return                Boolean output indicating the existence of the registry resource property
+     */
+    public static boolean isRegistryResourcePropertyExist(String registryPath,
+                                                          MessageContext messageContext) {
+        MicroIntegratorRegistry microIntegratorRegistry =
+                (MicroIntegratorRegistry) messageContext.getConfiguration().getRegistry();
+        String regRoot = microIntegratorRegistry.getRegRoot();
+        String resolvedPath = formatPath(regRoot + File.separator + registryPath);
+        try {
+            File file = new File(resolvedPath);
+            if (file.exists()) {
+                if (file.isDirectory()) {
+                    return isRegistryExist(registryPath + COLLECTIONS_PROPERTY_EXTENSIONS, messageContext);
+                } else {
+                    return isRegistryExist(registryPath + PROPERTY_EXTENSION, messageContext);
+                }
+            } else {
+                return false;
+            }
         } catch (Exception e) {
             LOG.error("Error occurred while checking the existence of the registry", e);
             return false;

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
@@ -262,6 +262,21 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
                                                                        resource.getFileName());
             lightweightRegistry.delete(resourcePath);
         }
+
+        // get collections
+        List<RegistryConfig.Collection> collections = registryConfig.getCollections();
+        for (RegistryConfig.Collection collection : collections) {
+            String directoryPath = registryConfig.getExtractedPath() + File.separator + AppDeployerConstants.RESOURCES_DIR
+                    + File.separator + collection.getDirectory();
+            // check whether the file exists
+            File file = new File(directoryPath);
+            if (!file.exists()) {
+                // the file is already deleted.
+                continue;
+            }
+            String directoryRegistryPath = createRegistryPath(collection.getPath());
+            lightweightRegistry.delete(directoryRegistryPath);
+        }
     }
 
     /**


### PR DESCRIPTION
$subject
Resolves https://github.com/wso2/micro-integrator/issues/3196 

Currently, Registry collection's properties are looked up inside the collection folder. But they are deployed in parallel to the folder. This fix will improve the way we deploy and lookup collection properties. Also, this will undeploy collection and properties when car file is undeployed.

