### PR TITLE
Include Runtime diagnostics tool into the server

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -108,6 +108,22 @@
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.mwiede</groupId>
+            <artifactId>jsch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.runtime.diagnostics</groupId>
+            <artifactId>runtime-diagnostics-tool</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -131,6 +147,15 @@
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>target</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.runtime.diagnostics</groupId>
+                                    <artifactId>runtime-diagnostics-tool</artifactId>
+                                    <version>${diagnostics.tool.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target</outputDirectory>
+                                    <destFileName>diagnostics-tool</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -191,6 +191,25 @@
         </fileSet>
 
         <fileSet>
+            <directory>target/diagnostics-tool</directory>
+            <outputDirectory>wso2mi-${pom.version}/diagnostics-tool</outputDirectory>
+            <excludes>
+                <exclude>bin/diagnostics</exclude>
+                <exclude>lib/**</exclude>
+            </excludes>
+        </fileSet>
+
+        <fileSet>
+            <directory>src/scripts/</directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/diagnostics-tool/bin
+            </outputDirectory>
+            <includes>
+                <include>**/diagnostics.sh</include>
+            </includes>
+            <fileMode>755</fileMode>
+        </fileSet>
+
+        <fileSet>
             <directory>src/conf</directory>
             <outputDirectory>wso2mi-${pom.version}/bin</outputDirectory>
             <includes>
@@ -601,6 +620,13 @@
             <fileMode>644</fileMode>
         </file>
         <file>
+            <source>src/resources/config-tool/templates/diagnostics-tool/conf/config.toml.j2</source>
+            <outputDirectory>wso2mi-${pom.version}/repository/resources/conf/templates/diagnostics-tool/conf</outputDirectory>
+            <destName>config.toml.j2</destName>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+        </file>
+        <file>
             <source>src/conf/sec.policy</source>
             <outputDirectory>wso2mi-${pom.version}/conf</outputDirectory>
             <destName>sec.policy</destName>
@@ -644,6 +670,10 @@
                 <include>org.apache.logging.log4j:log4j-jcl:jar</include>
                 <include>org.slf4j:slf4j-simple:jar</include>
                 <include>com.lmax:disruptor:jar</include>
+                <include>org.apache.commons:commons-math3:jar</include>
+                <include>commons-net:commons-net</include>
+                <include>com.github.mwiede:jsch</include>
+                <include>org.wso2.runtime.diagnostics:runtime-diagnostics-tool:jar</include>
                 <!--
                 javax jms-api need to be in class path for axis2
                 ( needs javax.jms.JMSException )

--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -692,6 +692,62 @@
   "user_store.base_dn": "dc=wso2,dc=org",
 
   "transport.jms.sender_class": "org.apache.axis2.transport.jms.JMSSender",
-  "transport.jms.listener_class": "org.apache.axis2.transport.jms.JMSListener"
-
+  "transport.jms.listener_class": "org.apache.axis2.transport.jms.JMSListener",
+  "server_configuration": {
+    "deployment_toml_path": "../conf/deployment.toml",
+    "logs_directory": "../repository/logs",
+    "updates_config_path": "../updates/config.json",
+    "diagnostic_log_file_path": "logs/diagnostics.log",
+    "carbon_log_file_path": "../repository/logs/wso2error.log",
+    "process_id_path": "../wso2carbon.pid"
+  },
+  "cpu_watcher": {
+    "enabled": "true",
+    "threshold": "80",
+    "retry_count": "2",
+    "interval": "5",
+    "action_executors": "ThreadDumper,MetricsSnapshot,ServerInfo"
+  },
+  "memory_watcher": {
+    "enabled": "true",
+    "threshold": "80",
+    "retry_count": "2",
+    "interval": "5",
+    "action_executors": "ThreadDumper,MetricsSnapshot,ServerInfo"
+  },
+  "log_watcher": {
+    "enabled": "true",
+    "interval": 0.1
+  },
+  "traffic_analyzer": {
+    "last_second_requests_enabled": "false",
+    "last_second_requests_windows_size": "300",
+    "last_second_requests_delay": "60",
+    "last_second_requests_interval": "1",
+    "last_fifteen_seconds_requests_enabled": "true",
+    "last_fifteen_seconds_requests_window_size": "100",
+    "last_fifteen_seconds_requests_delay": "4",
+    "last_fifteen_seconds_requests_interval": "15",
+    "last_minutes_requests_enabled": "true",
+    "last_minutes_requests_window_size": "100",
+    "last_minutes_requests_delay": "1",
+    "last_minutes_requests_interval": "60",
+    "notify_interval": "60"
+  },
+  "zip_file_configuration": {
+    "output_directory": "data",
+    "max_count": "20"
+  },
+  "log_pattern.patterns": [
+    {
+      "pattern.regex": "(.*)org.apache.synapse.transport.passthru(.*)",
+      "pattern.executors": "MetricsSnapshot,Netstat,OpenFileFinder,ThreadDumper,ServerInfo",
+      "pattern.reload_time": "30"
+    },
+    {
+      "pattern.regex": "(.*)org.apache.synapse(.*)",
+      "pattern.executors": "ServerInfo",
+      "pattern.reload_time": "10"
+    }
+  ]
 }

--- a/distribution/src/resources/config-tool/templates/diagnostics-tool/conf/config.toml.j2
+++ b/distribution/src/resources/config-tool/templates/diagnostics-tool/conf/config.toml.j2
@@ -1,0 +1,143 @@
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+##############################################
+#
+# WARNING: Don't edit the file manually unless you are not using the deployment.toml file.
+#
+##############################################
+
+## This file contains the configuration parameters used by the Diagnostic tool
+
+# Server Configurations
+[server_configuration]
+deployment_toml_path = "{{server_configuration.deployment_toml_path}}"
+logs_directory = "{{server_configuration.logs_directory}}"
+updates_config_path = "{{server_configuration.updates_config_path}}"
+diagnostic_log_file_path = "{{server_configuration.diagnostic_log_file_path}}"
+carbon_log_file_path = "{{server_configuration.carbon_log_file_path}}"
+process_id_path = "{{server_configuration.process_id_path}}"
+server_name = "@product.name@"
+server_version = "@product.version@"
+
+## Action Executor Configurations
+
+# Example
+#[[action_executor_configuration]]
+#executor = "ActionExecutor"
+#reload_time = "180" # in seconds
+
+[[action_executor_configuration]]
+executor = "MemoryDumper"
+reload_time = "180"
+
+[[action_executor_configuration]]
+executor = "ThreadDumper"
+count = "5"
+delay = "2000"
+
+[[action_executor_configuration]]
+executor = "OpenFileFinder"
+
+[[action_executor_configuration]]
+executor = "Netstat"
+command = "netstat -alt"
+
+[[action_executor_configuration]]
+executor = "ServerInfo"
+
+[[action_executor_configuration]]
+executor = "MetricsSnapshot"
+
+{%for action in action_executor_configuration %}
+[[action_executor_configuration]]
+executor = "{{action.executor}}"
+{% endfor %}
+
+# Watcher Configurations
+[cpu_watcher]
+enabled = "{{cpu_watcher.enabled}}"
+threshold = "{{cpu_watcher.threshold}}"
+retry_count = "{{cpu_watcher.retry_count}}"
+interval = "{{cpu_watcher.interval}}"
+action_executors = "{{cpu_watcher.action_executors}}"
+
+[memory_watcher]
+enabled = "{{memory_watcher.enabled}}"
+threshold = "{{memory_watcher.threshold}}"
+retry_count = "{{memory_watcher.retry_count}}"
+interval = "{{memory_watcher.interval}}"
+action_executors = "{{memory_watcher.action_executors}}"
+
+[log_watcher]
+enabled = "{{log_watcher.enabled}}"
+interval = {{log_watcher.interval}}
+
+# Traffic Analyzer Configurations
+[traffic_analyzer]
+last_second_requests_enabled = "{{traffic_analyzer.last_second_requests_enabled}}"
+last_second_requests_windows_size = "{{traffic_analyzer.last_second_requests_windows_size}}"
+last_second_requests_delay = "{{traffic_analyzer.last_second_requests_delay}}"
+last_second_requests_interval = "{{traffic_analyzer.last_second_requests_interval}}"
+last_fifteen_seconds_requests_enabled = "{{traffic_analyzer.last_fifteen_seconds_requests_enabled}}"
+last_fifteen_seconds_requests_window_size = "{{traffic_analyzer.last_fifteen_seconds_requests_window_size}}"
+last_fifteen_seconds_requests_delay = "{{traffic_analyzer.last_fifteen_seconds_requests_delay}}"
+last_fifteen_seconds_requests_interval = "{{traffic_analyzer.last_fifteen_seconds_requests_interval}}"
+last_minutes_requests_enabled = "{{traffic_analyzer.last_minutes_requests_enabled}}"
+last_minutes_requests_window_size = "{{traffic_analyzer.last_minutes_requests_window_size}}"
+last_minutes_requests_delay = "{{traffic_analyzer.last_minutes_requests_delay}}"
+last_minutes_requests_interval = "{{traffic_analyzer.last_minutes_requests_interval}}"
+notify_interval = "{{traffic_analyzer.notify_interval}}"
+
+# Output data zip configurations
+[zip_file_configuration]
+output_directory = "{{zip_file_configuration.output_directory}}"
+max_count = "{{zip_file_configuration.max_count}}"
+
+# Error regex patterns and diagnosis
+{%for pattern in log_pattern.patterns %}
+[[log_pattern]]
+regex = "{{pattern.pattern.regex}}"
+executors = "{{pattern.pattern.executors}}"
+reload_time = "{{pattern.pattern.reload_time}}"
+
+{% endfor %}
+
+{% if ftp_uploader is defined %}
+## FTP Uploader configurations
+[ftp_uploader]
+enabled = "{{ftp_uploader.enabled}}"
+host = "{{ftp_uploader.host}}"
+port = "{{ftp_uploader.port}}"
+username = "{{ftp_uploader.username}}"
+password = "{{ftp_uploader.password}}"
+directory = "{{ftp_uploader.directory}}"
+{% endif %}
+
+{% if sftp_uploader is defined %}
+## SFTP Uploader configurations
+[sftp_uploader]
+enabled = "{{sftp_uploader.enabled}}"
+host = "{{sftp_uploader.host}}"
+port = "{{sftp_uploader.port}}"
+username = "{{sftp_uploader.username}}"
+password = "{{sftp_uploader.password}}"
+directory = "{{sftp_uploader.directory}}"
+known_hosts_path = "{{sftp_uploader.known_hosts_path}}"
+strict_host_key_checking = "{{sftp_uploader.strict_host_key_checking}}"
+{% endif %}

--- a/distribution/src/scripts/diagnostics.sh
+++ b/distribution/src/scripts/diagnostics.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# diagnostics.sh
+# ----------------------------------------------------------------------------
+#  Copyright 2024 WSO2, LLC. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRGDIR=`dirname "$PRG"`
+BASEDIR=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+# Reset the REPO variable. If you need to influence this use the environment setup file.
+REPO=
+
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  Darwin*) darwin=true
+           if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+		   if [ -z "$JAVA_HOME" ]; then
+		      if [ -x "/usr/libexec/java_home" ]; then
+			      JAVA_HOME=`/usr/libexec/java_home`
+			  else
+			      JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+			  fi
+           fi
+           ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# If a specific java binary isn't specified search for the standard 'java' binary
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=`which java`
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." 1>&2
+  echo "  We cannot execute $JAVACMD" 1>&2
+  exit 1
+fi
+
+TMP_DIR="$BASEDIR"/temp
+if [ -d "$TMP_DIR" ]; then
+  rm -rf "$TMP_DIR"/*
+fi
+
+if [ -z "$REPO" ]
+then
+  REPO="$BASEDIR"/../wso2/lib
+fi
+
+CLASSPATH="$BASEDIR"/conf:"$REPO"/*
+
+ENDORSED_DIR=
+if [ -n "$ENDORSED_DIR" ] ; then
+  CLASSPATH=$BASEDIR/$ENDORSED_DIR/*:$CLASSPATH
+fi
+
+if [ -n "$CLASSPATH_PREFIX" ] ; then
+  CLASSPATH=$CLASSPATH_PREFIX:$CLASSPATH
+fi
+
+if [ -z "$JVM_MEM_OPTS" ]; then
+   java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+   JVM_MEM_OPTS="-Xms32m -Xmx128m"
+   if [ "$java_version" \< "1.8" ]; then
+      JVM_MEM_OPTS="$JVM_MEM_OPTS"
+   fi
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$HOME" ] && HOME=`cygpath --path --windows "$HOME"`
+  [ -n "$BASEDIR" ] && BASEDIR=`cygpath --path --windows "$BASEDIR"`
+  [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
+fi
+
+exec "$JAVACMD" $JAVA_OPTS  \
+$JVM_MEM_OPTS \
+  -classpath "$CLASSPATH" \
+  -Dapp.name="runtime-diagnostics" \
+  -Dapp.pid="$$" \
+  -Dapp.repo="$REPO" \
+  -Dapp.home="$BASEDIR" \
+  -Dbasedir="$BASEDIR" \
+  org.wso2.diagnostics.DiagnosticsApp \
+  "$@"

--- a/distribution/src/scripts/micro-integrator.sh
+++ b/distribution/src/scripts/micro-integrator.sh
@@ -283,6 +283,16 @@ if [ $java_version_formatted -ge 1100 ]; then
     JAVA_VER_BASED_OPTS="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED"
 fi
 
+# start diagnostic tool in background in diagnostic-tool/bin/diagnostic
+"$CARBON_HOME"/diagnostics-tool/bin/diagnostics.sh &
+diagnostic_tool_pid=$!
+
+# trap signals so we can shutdown the diagnostic tool
+cleanup() {
+    kill "$diagnostic_tool_pid"
+}
+trap 'cleanup' EXIT INT
+
 while [ "$status" = "$START_EXIT_STATUS" ]
 do
     $JAVACMD \

--- a/pom.xml
+++ b/pom.xml
@@ -837,6 +837,28 @@
                 <version>${orbit.version.commons.lang}</version>
             </dependency>
 
+            <!-- Diagnostic Server Dependencies -->
+            <dependency>
+                <groupId>org.wso2.runtime.diagnostics</groupId>
+                <artifactId>runtime-diagnostics-tool</artifactId>
+                <version>${diagnostics.tool.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-math3</artifactId>
+                <version>${commons.math.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>${commons.net.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.mwiede</groupId>
+                <artifactId>jsch</artifactId>
+                <version>${jsch.version}</version>
+            </dependency>
+
             <!-- Crypto Service Feature Dependencies-->
             <dependency>
                 <groupId>org.wso2.carbon.crypto</groupId>
@@ -1685,6 +1707,12 @@
 
         <!-- Transaction Counter -->
         <counter.org.wso2.integration.transaction.version>1.1.0</counter.org.wso2.integration.transaction.version>
+
+        <!-- Diagnostic Tool -->
+        <commons.math.version>3.6.1</commons.math.version>
+        <commons.net.version>3.10.0</commons.net.version>
+        <diagnostics.tool.version>1.0.14</diagnostics.tool.version>
+        <jsch.version>0.2.16</jsch.version>
 
         <config.mapper.version>1.0.20</config.mapper.version>
         <javax.xml.parsers.import.pkg.version>[0.0.0, 1.0.0)</javax.xml.parsers.import.pkg.version>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject
Resolves: https://github.com/wso2/micro-integrator/issues/2985

Currently, APIM and MI are sharing the synapse runtime for transport and message mediation. In error scenarios, it is time-consuming to gather all the information to investigate the issue. This PR is about implementing a tool that helps to generate the required data for troubleshooting issues quickly. 

The Readme guide can be used to get an understanding of the tool. https://github.com/wso2/runtime-diagnostic-tool/blob/main/README.md The configurations are added by default. Once you start the server, the tool will be started as a second process and monitor the server. The diagnostics logs can be found inside <MI-HOME>/diagnostics-tool/logs. The output zip files are stored inside <MI-HOME>/diagnostics-tool/data.

High level Architecture can be found below.

<img width="767" alt="Screenshot 2024-03-05 at 17 34 16" src="https://github.com/wso2/product-apim/assets/17047910/4486bdec-de4f-4438-a160-6e38e67aff34">

There are different watcher threads running in the Diagnostic tool which monitors the server performance and logs. Once an anomaly/error log is detected, the configured Action Executors will be executed and the data will be stored in a Zip file. If a PostAction Executor (FTP, SFTP) is configured, the zip file will be uploaded to the configured location.