### PR TITLE
Fix management API not returning the content of the data service when elements attribute in not configured

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QuerySerializer.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QuerySerializer.java
@@ -194,7 +194,10 @@ public class QuerySerializer {
 			resEl.addAttribute(DBSFields.OUTPUT_TYPE, DBSFields.RDF, null);
 			resEl.addAttribute(DBSFields.RDF_BASE_URI, result.getRDFBaseURI(), null);
 		} else {
-			resEl.addAttribute(DBSFields.ELEMENT, result.getElementName(), null);
+			String elementName = result.getElementName();
+			if (elementName != null) {
+				resEl.addAttribute(DBSFields.ELEMENT, elementName, null);
+			}
 			String rowName = result.getRowName();
 			if (rowName != null) {
 				resEl.addAttribute(DBSFields.ROW_NAME, rowName, null);


### PR DESCRIPTION
**Purpose:**

Fix management API not returning the content of the data service when elements attribute in not configured in the data service. 
The deployment is validated only if the query is called and the management API does not validate the configuration during query serialization. Therefore, during query serialization the elements attribute is considered as optional. 

Fixes: https://github.com/wso2/micro-integrator/issues/3291

