### PR TITLE
Disable default access logger and utilize log4j2 for http access logs

### DIFF
--- a/distribution/src/conf/access-log.properties
+++ b/distribution/src/conf/access-log.properties
@@ -36,3 +36,5 @@ access_log_suffix=.log
 # file date format
 access_log_file_date_format=yyyy-MM-dd
 
+# enable or disable access logging to a custom file
+access_log_enable=false

--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -37,7 +37,7 @@
 
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, osgi, SERVICE_LOGFILE, API_LOGFILE, ERROR_LOGFILE, CORRELATION, OPEN_TELEMETRY
+appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, osgi, SERVICE_LOGFILE, API_LOGFILE, ERROR_LOGFILE, CORRELATION, OPEN_TELEMETRY, HTTP_ACCESS_LOGFILE
 #, syslog
 
 # CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
@@ -195,6 +195,24 @@ appender.CORRELATION.strategy.max = 20
 appender.CORRELATION.filter.threshold.type = ThresholdFilter
 appender.CORRELATION.filter.threshold.level = INFO
 
+# Appender config to HTTP access logs
+appender.HTTP_ACCESS_LOGFILE.type = RollingFile
+appender.HTTP_ACCESS_LOGFILE.name = HTTP_ACCESS_LOGFILE
+appender.HTTP_ACCESS_LOGFILE.fileName = ${sys:logfiles.home}/http_access.log
+appender.HTTP_ACCESS_LOGFILE.filePattern = ${sys:logfiles.home}/http_access_%d{yyyy-MM-dd}.log
+appender.HTTP_ACCESS_LOGFILE.layout.type = PatternLayout
+appender.HTTP_ACCESS_LOGFILE.layout.pattern = %msg%n
+appender.HTTP_ACCESS_LOGFILE.policies.type = Policies
+appender.HTTP_ACCESS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.HTTP_ACCESS_LOGFILE.policies.time.interval = 1
+appender.HTTP_ACCESS_LOGFILE.policies.time.modulate = true
+appender.HTTP_ACCESS_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.HTTP_ACCESS_LOGFILE.policies.size.size=1MB
+appender.HTTP_ACCESS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.HTTP_ACCESS_LOGFILE.strategy.max = 20
+appender.HTTP_ACCESS_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.HTTP_ACCESS_LOGFILE.filter.threshold.level = DEBUG
+
 # Uncomment the below lines to use the Syslog Appender
 #appender.syslog.type = Syslog
 #appender.syslog.name = Syslog
@@ -205,7 +223,7 @@ appender.CORRELATION.filter.threshold.level = INFO
 #appender.syslog.filter.threshold.type = ThresholdFilter
 #appender.syslog.filter.threshold.level = DEBUG
 
-loggers = AUDIT_LOG, SERVICE_LOGGER, API_LOGGER, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, \
+loggers = AUDIT_LOG, SERVICE_LOGGER, API_LOGGER, PassThroughAccess, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, \
 	  org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, \
 	  org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, \
 	  org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, \
@@ -314,6 +332,11 @@ logger.API_LOGGER.name= API_LOGGER
 logger.API_LOGGER.level = INFO
 logger.API_LOGGER.appenderRef.SERVICE_LOGFILE.ref = API_LOGFILE
 logger.API_LOGGER.additivity = false
+
+logger.PassThroughAccess.name = org.apache.synapse.transport.http.access
+logger.PassThroughAccess.level = DEBUG
+logger.PassThroughAccess.appenderRef.HTTP_ACCESS_LOGFILE.ref = HTTP_ACCESS_LOGFILE
+logger.PassThroughAccess.additivity = false
 
 logger.trace-messages.name = trace.messages
 logger.trace-messages.level = TRACE


### PR DESCRIPTION
Related to https://github.com/wso2/micro-integrator/issues/3281

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject