### PR TITLE
Improve the stability of the ElasticStatisticsTest

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/test/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/publish/elasticsearch/ElasticStatisticsTest.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/test/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/publish/elasticsearch/ElasticStatisticsTest.java
@@ -266,8 +266,9 @@ public class ElasticStatisticsTest extends TestCase {
         event.setComponentType(StatisticsConstants.getComponentTypeToString(componentType));
         event.setFlowId(TEST_FLOW_ID);
         event.setComponentName(componentName);
-        event.setStartTime(Instant.now().toEpochMilli() - STATIC_LATENCY);
-        event.setEndTime(Instant.now().toEpochMilli());
+        long currentTime = Instant.now().toEpochMilli();
+        event.setStartTime(currentTime - STATIC_LATENCY);
+        event.setEndTime(currentTime);
         event.setDuration(event.getEndTime() - event.getStartTime());
         event.setEntryPoint("EP");
         event.setFaultCount(0);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Because of minor time differences, the ElasticStatisticsTest is failing intermittently.

```
org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.elasticsearch.ElasticStatisticsTest
[INFO] [ERROR] testEndpointAnalytics(org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.elasticsearch.ElasticStatisticsTest)  Time elapsed: 0.009 s  <<< FAILURE!
[INFO] junit.framework.AssertionFailedError: expected:<5678> but was:<5679>
[INFO] 	at org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.elasticsearch.ElasticStatisticsTest.verifyCommonPayloadFields(ElasticStatisticsTest.java:407)
[INFO] 	at org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.elasticsearch.ElasticStatisticsTest.verifyEndpointPayload(ElasticStatisticsTest.java:381)
[INFO] 	at org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.elasticsearch.ElasticStatisticsTest.verifySchema(ElasticStatisticsTest.java:291)
[INFO] 	at org.wso2.micro.integrator.analytics.messageflow.data.publisher.publish.elasticsearch.ElasticStatisticsTest.testEndpointAnalytics(ElasticStatisticsTest.java:244)
```