### PR TITLE
Use forward slash when creating the CAR archive in DataMapper migration tool

### DIFF
--- a/migration/data-mapper-config-migration-service/pom.xml
+++ b/migration/data-mapper-config-migration-service/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>migration</groupId>
     <artifactId>data-mapper-config-migration-service</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <build>
         <plugins>
             <plugin>

--- a/migration/data-mapper-config-migration-service/src/main/java/org/wso2/mi/car/migration/DataMapperConfigMigrator.java
+++ b/migration/data-mapper-config-migration-service/src/main/java/org/wso2/mi/car/migration/DataMapperConfigMigrator.java
@@ -300,10 +300,12 @@ public class DataMapperConfigMigrator {
      */
     private static void addFolderToZip(String source, String folderName, ZipOutputStream zipOut) {
         try {
-            zipOut.putNextEntry(new ZipEntry(folderName + File.separator));
+            // ZIP file format uses forward slashes ("/") as directory separators regardless of the operating system
+            zipOut.putNextEntry(new ZipEntry(folderName + "/"));
             File folder = new File(source + File.separator + folderName);
             for (String fileName : Objects.requireNonNull(folder.list())) {
-                zipFile(source, folderName + File.separator + fileName, zipOut);
+                // ZIP file format uses forward slashes ("/") as directory separators regardless of the operating system
+                zipFile(source, folderName + "/" + fileName, zipOut);
             }
         } catch (IOException e) {
             exitWithError("An error occurred while adding folder " + folderName + " to car file. " + e.getMessage());


### PR DESCRIPTION
## Purpose

ZIP file format uses forward slashes ("/") as directory separators regardless of the operating system. Hence instead of File.separator we should use the forward slash, to overcome zip issues on Windows OS

## Related Issue

Migration issue https://github.com/wso2-enterprise/wso2-mi-internal/issues/856