### PR TITLE
Fix script mediator test failures

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorInAndOutTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorInAndOutTestProxy.xml
@@ -2,7 +2,7 @@
        startOnLoad="true" trace="disable">
     <target>
         <inSequence>
-            <script language="js">var symbol = mc.getPayloadXML()..*::Code.toString();
+            <script language="rhinoJs">var symbol = mc.getPayloadXML()..*::Code.toString();
                 mc.setPayloadXML(
                 &lt;m:getQuote xmlns:m="http://services.samples"&gt;
                 &lt;m:request&gt;
@@ -17,7 +17,7 @@
             </send>
         </inSequence>
         <outSequence>
-            <script language="js">var symbol = mc.getPayloadXML()..*::symbol.toString();
+            <script language="rhinoJs">var symbol = mc.getPayloadXML()..*::symbol.toString();
                 var price = mc.getPayloadXML()..*::last.toString();
                 mc.setPayloadXML(
                 &lt;m:CheckPriceResponse xmlns:m="http://services.samples/xsd"&gt;

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorJSFromEntryTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorJSFromEntryTestProxy.xml
@@ -1,7 +1,7 @@
 <proxy xmlns="http://ws.apache.org/ns/synapse" name="scriptMediatorJSFromEntryTestProxy" transports="http">
     <target>
         <inSequence>
-            <script language="js" key="conf:/script_js/stockquoteTransform.js" function="transformRequest"/>
+            <script language="rhinoJs" key="conf:/script_js/stockquoteTransform.js" function="transformRequest"/>
             <send>
                 <endpoint>
                     <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
@@ -9,7 +9,7 @@
             </send>
         </inSequence>
         <outSequence>
-            <script language="js" key="stockQuoteJsScript" function="transformResponse"/>
+            <script language="rhinoJs" key="stockQuoteJsScript" function="transformResponse"/>
             <send/>
         </outSequence>
     </target>

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorJSInlineTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorJSInlineTestProxy.xml
@@ -1,7 +1,7 @@
 <proxy xmlns="http://ws.apache.org/ns/synapse" name="scriptMediatorJSInlineTestProxy" transports="http">
     <target>
         <inSequence>
-            <script language="js">var symbol = mc.getPayloadXML()..*::Code.toString();
+            <script language="rhinoJs">var symbol = mc.getPayloadXML()..*::Code.toString();
                 mc.setPayloadXML(
                 &lt;m:getQuote xmlns:m="http://services.samples"&gt;
                 &lt;m:request&gt;
@@ -15,7 +15,7 @@
             </send>
         </inSequence>
         <outSequence>
-            <script language="js" key="stockQuoteJsScript" function="transformResponse"/>
+            <script language="rhinoJs" key="stockQuoteJsScript" function="transformResponse"/>
             <send/>
         </outSequence>
     </target>

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorJSRetrieveFromRegistryTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorJSRetrieveFromRegistryTestProxy.xml
@@ -1,7 +1,7 @@
 <proxy xmlns="http://ws.apache.org/ns/synapse" name="scriptMediatorJSRetrieveFromRegistryTestProxy" transports="http">
     <target>
         <inSequence>
-            <script language="js" key="conf:/script_key/stockquoteTransform.js" function="transformRequest"/>
+            <script language="rhinoJs" key="conf:/script_key/stockquoteTransform.js" function="transformRequest"/>
             <send>
                 <endpoint>
                     <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
@@ -9,7 +9,7 @@
             </send>
         </inSequence>
         <outSequence>
-            <script language="js" key="conf:/script_key/stockquoteTransform.js" function="transformResponse"/>
+            <script language="rhinoJs" key="conf:/script_key/stockquoteTransform.js" function="transformResponse"/>
             <send/>
         </outSequence>
     </target>

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorJSStoredInRegistryTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorJSStoredInRegistryTestProxy.xml
@@ -1,7 +1,7 @@
 <proxy xmlns="http://ws.apache.org/ns/synapse" name="scriptMediatorJSStoredInRegistryTestProxy" transports="http">
     <target>
         <inSequence>
-            <script language="js" key="conf:/script_js/stockquoteTransform.js" function="transformRequest"/>
+            <script language="rhinoJs" key="conf:/script_js/stockquoteTransform.js" function="transformRequest"/>
             <send>
                 <endpoint>
                     <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
@@ -9,7 +9,7 @@
             </send>
         </inSequence>
         <outSequence>
-            <script language="js" key="conf:/script_js/stockquoteTransform.js" function="transformResponse"/>
+            <script language="rhinoJs" key="conf:/script_js/stockquoteTransform.js" function="transformResponse"/>
             <send/>
         </outSequence>
     </target>

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorSetPropertyWithScopeTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorSetPropertyWithScopeTestProxy.xml
@@ -3,7 +3,7 @@
     <target>
         <inSequence>
             <log level="full"/>
-            <script language="js"><![CDATA[
+            <script language="rhinoJs"><![CDATA[
             var symbol = mc.getPayloadXML()..*::Code.toString();
              mc.setProperty("axis2Property", "AXIS2_PROPERTY","axis2");
              mc.setProperty("transportProperty", "TRANSPORT_PROPERTY","transport");

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorWithIncludeOptionTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/scriptMediatorWithIncludeOptionTestProxy.xml
@@ -2,7 +2,7 @@
        startOnLoad="true" trace="disable">
     <target>
         <inSequence>
-            <script language="js" key="conf:/script_js/test54.js" function="transformReq">
+            <script language="rhinoJs" key="conf:/script_js/test54.js" function="transformReq">
                 <include key="conf:/script_js/stockquoteTransform.js"/>
             </script>
             <send>
@@ -12,7 +12,7 @@
             </send>
         </inSequence>
         <outSequence>
-            <script language="js" key="conf:/script_js/test54.js" function="transformRes">
+            <script language="rhinoJs" key="conf:/script_js/test54.js" function="transformRes">
                 <include key="conf:/script_js/stockquoteTransform.js"/>
             </script>
             <send/>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Since E4X syntax is not supported by graalVMJS, the existing e4x scripts need to utilize rhinoJs engine.

Related PR https://github.com/wso2/wso2-synapse/pull/2196