### PR TITLE
Remove clear role authorization from deleteHybridRole

### DIFF
--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/hybrid/JdbcHybridRoleManager.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/hybrid/JdbcHybridRoleManager.java
@@ -775,7 +775,7 @@ public class JdbcHybridRoleManager extends HybridRoleManager {
             roleName = UserCoreUtil.addDomainToName(roleName, UserCoreConstants.INTERNAL_DOMAIN);
         }
         // also need to clear role authorization
-        userRealm.getAuthorizationManager().clearRoleAuthorization(roleName);
+        // userRealm.getAuthorizationManager().clearRoleAuthorization(roleName);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Remove clear role authorization from deleteHybridRole since role authorization is not used in MI. Fixes:https://github.com/wso2/micro-integrator/issues/3495
