### PR TITLE
Move Inbound Endpoint Listeners Startup to StartupFinalizer

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/ServiceBusInitializer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/ServiceBusInitializer.java
@@ -48,7 +48,6 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.wso2.carbon.inbound.endpoint.EndpointListenerLoader;
 import org.wso2.carbon.securevault.SecretCallbackHandlerService;
 import org.wso2.config.mapper.ConfigParser;
 import org.wso2.micro.application.deployer.CarbonApplication;
@@ -241,8 +240,6 @@ public class ServiceBusInitializer {
             bndCtx.registerService(SynapseRegistrationsService.class.getName(), synRegistrationsSvc, null);
             /*configCtxSvc.getServerConfigContext().setProperty(ConfigurationManager.CONFIGURATION_MANAGER,
                     configurationManager);*/
-            // Start Inbound Endpoint Listeners
-            EndpointListenerLoader.loadListeners();
             String injectCarName = System.getProperty(ServiceBusConstants.AUTOMATION_MODE_CAR_NAME_SYSTEM_PROPERTY);
             if (injectCarName != null && !injectCarName.isEmpty()) {
                 String sequenceName = getMainSequenceName(injectCarName);

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/StartupFinalizer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/StartupFinalizer.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
+import org.wso2.carbon.inbound.endpoint.EndpointListenerLoader;
 import org.wso2.micro.core.ServerStatus;
 import org.wso2.micro.integrator.initializer.utils.ConfigurationHolder;
 
@@ -77,6 +78,9 @@ public class StartupFinalizer {
 
         // Init and start axis2 transports
         listenerManager.startSystem(configCtx);
+
+        // Start Inbound Endpoint Listeners
+        EndpointListenerLoader.loadListeners();
 
         /*listerManagerServiceRegistration =
                 bundleContext.registerService(ListenerManager.class.getName(), listenerManager, null);*/


### PR DESCRIPTION
## Purpose
Move Inbound Endpoint Listeners Startup to `StartupFinalizer`. 
Fixes:https://github.com/wso2/micro-integrator/issues/3571

