### PR TITLE
Fix task duplication in a volatile environment

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/TaskEventListener.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/coordination/task/TaskEventListener.java
@@ -112,6 +112,7 @@ public class TaskEventListener extends MemberEventListener {
         ScheduledExecutorService taskScheduler = dataHolder.getTaskScheduler();
         if (taskScheduler != null) {
             LOG.info("Shutting down coordinated task scheduler scheduler since the node became unresponsive.");
+            // Shutdown the task scheduler forcefully since node became unresponsive and need to avoid task duplication.
             taskScheduler.shutdownNow();
             dataHolder.setTaskScheduler(null);
         }

--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/ClusterEventListener.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/ClusterEventListener.java
@@ -62,7 +62,7 @@ public class ClusterEventListener extends MemberEventListener {
     }
 
     @Override
-    public void reJoined(String nodeId) {
+    public void reJoined(String nodeId, RDBMSMemberEventCallBack callBack) {
         LOG.info("Re-joined the cluster successfully.");
     }
 }

--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/MemberEventListener.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/MemberEventListener.java
@@ -57,8 +57,9 @@ public abstract class MemberEventListener {
      * Invoked when the node is back to active state after being inactive.
      *
      * @param nodeId - The Id of this node
+     * @param callBack - The callback to be called when an exception is thrown
      */
-    public abstract void reJoined(String nodeId);
+    public abstract void reJoined(String nodeId, RDBMSMemberEventCallBack callBack);
 
     public String getGroupId() {
         return this.groupId;

--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSCommunicationBusContextImpl.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSCommunicationBusContextImpl.java
@@ -97,11 +97,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                 storeMembershipEventPreparedStatement.addBatch();
             }
             storeMembershipEventPreparedStatement.executeBatch();
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(StringUtil.removeCRLFCharacters(task) + " executed successfully");
@@ -218,11 +214,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatement.setString(2, nodeId);
             preparedStatement.setLong(3, System.currentTimeMillis());
             int updateCount = preparedStatement.executeUpdate();
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_ADD_MESSAGE_ID + " " + nodeId + " executed successfully");
@@ -288,11 +280,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatementForCoordinatorUpdate.setString(2, nodeId);
             preparedStatementForCoordinatorUpdate.setString(3, groupId);
             int updateCount = preparedStatementForCoordinatorUpdate.executeUpdate();
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT + "node id " + nodeId
@@ -368,11 +356,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatement.setString(1, groupId);
             preparedStatement.setLong(2, thresholdTimeLimit);
             preparedStatement.executeUpdate();
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_REMOVE_COORDINATOR + " of group " + groupId + " executed successfully");
@@ -409,11 +393,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatementForNodeUpdate.setString(2, nodeId);
             preparedStatementForNodeUpdate.setString(3, groupId);
             int updateCount = preparedStatementForNodeUpdate.executeUpdate();
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT + " of node " + nodeId + " executed successfully");
@@ -436,6 +416,21 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
         }
     }
 
+    /**
+     * Method to commit the transaction.
+     *
+     * @param connection Connection object
+     *
+     */
+    private void commitTransactionIfNotInterrupted(Connection connection) throws InterruptedException, SQLException {
+        // Check if the thread has been interrupted before committing
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException("Thread was interrupted, avoiding commit.");
+        }
+        // Commit the transaction
+        connection.commit();
+    }
+
     @Override
     public void createNodeHeartbeatEntry(String nodeId, String groupId) throws ClusterCoordinationException {
         Connection connection = null;
@@ -450,11 +445,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatement.setLong(2, System.currentTimeMillis());
             preparedStatement.setString(3, groupId);
             preparedStatement.executeUpdate();
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT + " of node " + nodeId + " executed successfully");
@@ -614,11 +605,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatement.setString(1, nodeId);
             preparedStatement.setString(2, groupId);
             preparedStatement.executeUpdate();
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT + " of node "
@@ -660,11 +647,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                 storeRemovedMembersPreparedStatement.addBatch();
             }
             storeRemovedMembersPreparedStatement.executeBatch();
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(StringUtil.removeCRLFCharacters(task) + " executed successfully");
@@ -700,11 +683,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             if (updateCount == 0) {
                 log.warn("No record was updated while marking node as not new");
             }
-            // Before committing, check if the thread was interrupted
-            if (Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException("Thread was interrupted, avoiding commit.");
-            }
-            connection.commit();
+            commitTransactionIfNotInterrupted(connection);
             isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW + " of node "

--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSCommunicationBusContextImpl.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSCommunicationBusContextImpl.java
@@ -80,9 +80,11 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     public void storeMembershipEvent(String changedMember, String groupId, List<String> clusterNodes,
                                      int membershipEventType) throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement storeMembershipEventPreparedStatement = null;
         String task = "Storing membership event: " + membershipEventType + " for member: " + changedMember
-                      + " in group " + groupId;
+                + " in group " + groupId;
         try {
             connection = getConnection();
             storeMembershipEventPreparedStatement = connection
@@ -95,15 +97,27 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                 storeMembershipEventPreparedStatement.addBatch();
             }
             storeMembershipEventPreparedStatement.executeBatch();
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
             connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(StringUtil.removeCRLFCharacters(task) + " executed successfully");
             }
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, task);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + task);
+
             throw new ClusterCoordinationException("Error storing membership change: " + membershipEventType +
-                                                   " for member: " + changedMember + " in group " + groupId, e);
+                    " for member: " + changedMember + " in group " + groupId, e);
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, task);
+                log.warn("Transaction rolled back for task: " + task);
+            }
             close(storeMembershipEventPreparedStatement, task);
             close(connection, task);
         }
@@ -193,6 +207,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     @Override
     public boolean createCoordinatorEntry(String nodeId, String groupId) throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement preparedStatement = null;
         try {
             connection = getConnection();
@@ -202,15 +218,26 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatement.setString(2, nodeId);
             preparedStatement.setLong(3, System.currentTimeMillis());
             int updateCount = preparedStatement.executeUpdate();
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
             connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_ADD_MESSAGE_ID + " " + nodeId + " executed successfully");
             }
             return updateCount != 0;
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, RDBMSConstantUtils.TASK_ADD_MESSAGE_ID);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_ADD_MESSAGE_ID);
             return false;
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, RDBMSConstantUtils.TASK_ADD_MESSAGE_ID);
+                log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_ADD_MESSAGE_ID);
+            }
             close(preparedStatement, RDBMSConstantUtils.TASK_ADD_MESSAGE_ID);
             close(connection, RDBMSConstantUtils.TASK_ADD_MESSAGE_ID);
         }
@@ -250,6 +277,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     public boolean updateCoordinatorHeartbeat(String nodeId, String groupId, long currentHeartbeatTime)
             throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement preparedStatementForCoordinatorUpdate = null;
         try {
             connection = getConnection();
@@ -259,18 +288,29 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatementForCoordinatorUpdate.setString(2, nodeId);
             preparedStatementForCoordinatorUpdate.setString(3, groupId);
             int updateCount = preparedStatementForCoordinatorUpdate.executeUpdate();
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
             connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT + "node id " + nodeId
-                          + " executed successfully");
+                        + " executed successfully");
             }
             return updateCount != 0;
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT);
             throw new ClusterCoordinationException("Error occurred while "
                                                    + RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT
                                                    + ". instance ID: " + nodeId + " group ID: " + groupId, e);
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT);
+                log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT);
+            }
             close(preparedStatementForCoordinatorUpdate, RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT);
             close(connection, RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT);
         }
@@ -318,6 +358,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     public void removeCoordinator(String groupId, int heartbeatMaxAge, long currentHeartbeatTime)
             throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement preparedStatement = null;
         try {
             connection = getConnection();
@@ -326,14 +368,26 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatement.setString(1, groupId);
             preparedStatement.setLong(2, thresholdTimeLimit);
             preparedStatement.executeUpdate();
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
+            connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_REMOVE_COORDINATOR + " of group " + groupId + " executed successfully");
             }
-            connection.commit();
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, RDBMSConstantUtils.TASK_REMOVE_COORDINATOR);
-            throw new ClusterCoordinationException("Error occurred while " + RDBMSConstantUtils.TASK_REMOVE_COORDINATOR, e);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_REMOVE_COORDINATOR);
+            throw new ClusterCoordinationException("Error occurred while "
+                    + RDBMSConstantUtils.TASK_REMOVE_COORDINATOR, e);
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, RDBMSConstantUtils.TASK_REMOVE_COORDINATOR);
+                log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_REMOVE_COORDINATOR);
+            }
             close(preparedStatement, RDBMSConstantUtils.TASK_REMOVE_COORDINATOR);
             close(connection, RDBMSConstantUtils.TASK_REMOVE_COORDINATOR);
         }
@@ -343,6 +397,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     public boolean updateNodeHeartbeat(String nodeId, String groupId, long currentHeartbeatTime)
             throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement preparedStatementForNodeUpdate = null;
 
         try {
@@ -353,16 +409,28 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatementForNodeUpdate.setString(2, nodeId);
             preparedStatementForNodeUpdate.setString(3, groupId);
             int updateCount = preparedStatementForNodeUpdate.executeUpdate();
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
             connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT + " of node " + nodeId + " executed successfully");
             }
             return updateCount != 0;
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT);
-            throw new ClusterCoordinationException("Error occurred while " + RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT
-                                                   + ". Node ID: " + nodeId + "and Group ID : " + groupId, e);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT);
+            throw new ClusterCoordinationException("Error occurred while "
+                    + RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT + ". Node ID: " + nodeId + "and Group ID : "
+                    + groupId, e);
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT);
+                log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT);
+            }
             close(preparedStatementForNodeUpdate, RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT);
             close(connection, RDBMSConstantUtils.TASK_UPDATE_NODE_HEARTBEAT);
         }
@@ -371,6 +439,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     @Override
     public void createNodeHeartbeatEntry(String nodeId, String groupId) throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement preparedStatement = null;
         try {
             connection = getConnection();
@@ -380,15 +450,27 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatement.setLong(2, System.currentTimeMillis());
             preparedStatement.setString(3, groupId);
             preparedStatement.executeUpdate();
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
             connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT + " of node " + nodeId + " executed successfully");
             }
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT);
-            throw new ClusterCoordinationException("Error occurred while " + RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT
-                                                   + ". Node ID: " + nodeId + " group ID " + groupId, e);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT);
+            throw new ClusterCoordinationException("Error occurred while "
+                    + RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT
+                    + ". Node ID: " + nodeId + " group ID " + groupId, e);
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT);
+                log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT);
+            }
             close(preparedStatement, RDBMSConstantUtils.TASK_UPDATE_COORDINATOR_HEARTBEAT);
             close(connection, RDBMSConstantUtils.TASK_CREATE_NODE_HEARTBEAT);
         }
@@ -522,6 +604,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     @Override
     public void removeNode(String nodeId, String groupId) throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement preparedStatement = null;
         try {
             connection = getConnection();
@@ -530,16 +614,27 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             preparedStatement.setString(1, nodeId);
             preparedStatement.setString(2, groupId);
             preparedStatement.executeUpdate();
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
             connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT + " of node "
-                          + StringUtil.removeCRLFCharacters(nodeId) + " executed successfully");
+                        + StringUtil.removeCRLFCharacters(nodeId) + " executed successfully");
             }
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT);
             throw new ClusterCoordinationException("error occurred while "
-                                                   + RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT, e);
+                    + RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT, e);
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT);
+                log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT);
+            }
             close(preparedStatement, RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT);
             close(connection, RDBMSConstantUtils.TASK_REMOVE_NODE_HEARTBEAT);
         }
@@ -549,6 +644,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     public void insertRemovedNodeDetails(String removedMember, String groupId, List<String> clusterNodes)
             throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement storeRemovedMembersPreparedStatement = null;
         String task = "Storing removed member: " + removedMember + " in group " + groupId;
         try {
@@ -563,15 +660,26 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                 storeRemovedMembersPreparedStatement.addBatch();
             }
             storeRemovedMembersPreparedStatement.executeBatch();
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
             connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(StringUtil.removeCRLFCharacters(task) + " executed successfully");
             }
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, task);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + task);
             throw new ClusterCoordinationException(
                     "Error storing removed member: " + removedMember + " in group " + groupId, e);
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, task);
+                log.warn("Transaction rolled back for task: " + task);
+            }
             close(storeRemovedMembersPreparedStatement, task);
             close(connection, task);
         }
@@ -580,6 +688,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     @Override
     public void markNodeAsNotNew(String nodeId, String groupId) throws ClusterCoordinationException {
         Connection connection = null;
+        boolean isRolledBack = false; // Flag to track if rollback has occurred
+        boolean isTransactionSuccessful = false;
         PreparedStatement preparedStatement = null;
         try {
             connection = getConnection();
@@ -590,15 +700,27 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             if (updateCount == 0) {
                 log.warn("No record was updated while marking node as not new");
             }
+            // Before committing, check if the thread was interrupted
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("Thread was interrupted, avoiding commit.");
+            }
             connection.commit();
+            isTransactionSuccessful = true;
             if (log.isDebugEnabled()) {
                 log.debug(RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW + " of node "
-                          + StringUtil.removeCRLFCharacters(nodeId) + " executed successfully");
+                        + StringUtil.removeCRLFCharacters(nodeId) + " executed successfully");
             }
-        } catch (SQLException e) {
+        } catch (SQLException | InterruptedException e) {
             rollback(connection, RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW);
-            throw new ClusterCoordinationException("Error occurred while " + RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW, e);
+            isRolledBack = true; // Mark as rolled back
+            log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW);
+            throw new ClusterCoordinationException("Error occurred while "
+                    + RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW, e);
         } finally {
+            if (!isTransactionSuccessful && !isRolledBack && Thread.currentThread().isInterrupted()) {
+                rollback(connection, RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW);
+                log.warn("Transaction rolled back for task: " + RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW);
+            }
             close(preparedStatement, RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW);
             close(connection, RDBMSConstantUtils.TASK_MARK_NODE_NOT_NEW);
         }
@@ -725,7 +847,9 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     private void rollback(Connection connection, String task) {
         if (connection != null) {
             try {
-                connection.rollback();
+                if (!connection.isClosed()) {
+                    connection.rollback();
+                }
             } catch (SQLException e) {
                 log.warn("Rollback failed on " + StringUtil.removeCRLFCharacters(task), e);
             }

--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSCoordinationStrategy.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSCoordinationStrategy.java
@@ -131,7 +131,8 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         }
         this.heartbeatMaxRetryInterval = heartBeatInterval * heartbeatMaxRetry;
         this.heartbeatWarningMargin = heartbeatMaxRetryInterval * 0.75;
-        this.maxDBReadTime = (long) (heartbeatWarningMargin / 30);
+        // maxDBReadTime is set to 1/10th of the heartbeatWarningMargin as for the max possible number of db calls
+        this.maxDBReadTime = (long) (heartbeatWarningMargin / 10);
         this.inactiveIntervalAfterUnresponsive = heartbeatMaxRetryInterval * 2L;
 
         ThreadFactory namedThreadFactory = new ThreadFactoryBuilder().setPriority(7)

--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSCoordinationStrategy.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSCoordinationStrategy.java
@@ -33,9 +33,14 @@ import org.wso2.micro.integrator.ndatasource.common.DataSourceException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.sql.DataSource;
 
 import static org.wso2.micro.integrator.coordination.util.RDBMSConstantUtils.CLUSTER_CONFIG;
@@ -64,10 +69,21 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
      * This is used to give the user a warning when the heartbeat interval exceeds the limit.
      */
     private double heartbeatWarningMargin;
+
+    /**
+     * Maximum time taken to read from the database.
+     */
+    private long maxDBReadTime;
+
     /**
      * Heartbeat retry interval.
      */
     private int heartbeatMaxRetry;
+
+    /**
+     * Interval after which a node is considered inactive after being unresponsive.
+     */
+    private long inactiveIntervalAfterUnresponsive;
 
     /**
      * Thread executor used to run the coordination algorithm.
@@ -115,6 +131,8 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         }
         this.heartbeatMaxRetryInterval = heartBeatInterval * heartbeatMaxRetry;
         this.heartbeatWarningMargin = heartbeatMaxRetryInterval * 0.75;
+        this.maxDBReadTime = (long) (heartbeatWarningMargin / 30);
+        this.inactiveIntervalAfterUnresponsive = heartbeatMaxRetryInterval * 2L;
 
         ThreadFactory namedThreadFactory = new ThreadFactoryBuilder().setPriority(7)
                                                                      .setNameFormat("RDBMSCoordinationStrategy-%d").build();
@@ -123,7 +141,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         this.localNodeId = getNodeId();
         this.communicationBusContext = communicationBusContext;
         this.rdbmsMemberEventProcessor = new RDBMSMemberEventProcessor(localNodeId, localGroupId,
-                (int) heartbeatWarningMargin, communicationBusContext);
+                (int) heartbeatWarningMargin, communicationBusContext, maxDBReadTime);
     }
 
     /**
@@ -266,6 +284,16 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         rdbmsMemberEventProcessor.addEventListener(memberEventListener);
     }
 
+    /**
+     * Marks the specified node as unresponsive.
+     *
+     * @param nodeId  the ID of the node to be marked as unresponsive
+     * @param groupId the ID of the group to which the node belongs
+     */
+    public void setUnresponsiveness(String nodeId, String groupId) {
+        rdbmsMemberEventProcessor.setMemberUnresponsiveIfNeeded(nodeId, groupId, true);
+    }
+
     private String getNodeId() {
 
         String nodeId = System.getProperty(NODE_ID);
@@ -364,6 +392,11 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         private String localGroupId;
 
         /**
+         * Executor service used to communicate with the database.
+         */
+        private ExecutorService dbCommunicatorExecutor = Executors.newSingleThreadExecutor();
+
+        /**
          * Constructor.
          *
          * @param nodeId           - node ID of the current node
@@ -399,6 +432,12 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                         performCoordinatorTask(currentHeartbeatTime, timeTakenForCoordinatorTasks);
                         break;
                 }
+                if (rdbmsMemberEventProcessor.isMemberUnresponsive()) {
+                    log.info("Initiating unresponsive member recovery process for node " + localNodeId);
+                    rdbmsMemberEventProcessor.setMemberUnresponsiveIfNeeded(localNodeId, localGroupId
+                            , false);
+                    rdbmsMemberEventProcessor.setMemberRejoined(localNodeId, localGroupId);
+                }
                 long clusterTaskEndingTime = System.currentTimeMillis();
                 if (log.isDebugEnabled() && clusterTaskEndingTime - currentHeartbeatTime > 1000) {
                     log.debug("Cluster task took " +
@@ -430,9 +469,38 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                 }
                 // We are catching throwable to avoid subsequent executions getting suppressed
             } catch (Throwable e) {
-                log.error("Error detected while running coordination algorithm. Node became a "
-                          + NodeState.MEMBER + " node in group " + localGroupId, e);
                 currentNodeState = NodeState.MEMBER;
+                try {
+                    // Sleep for the duration of the inactiveIntervalAfterUnresponsive to allow time for the database to
+                    // recover and give other nodes to take over the coordinator role and/or remove the node from the
+                    // group.
+                    Thread.sleep(inactiveIntervalAfterUnresponsive);
+                } catch (InterruptedException ex) {
+                    // ignore
+                }
+            }
+        }
+
+        /**
+         * Perform DB operations with a timeout.
+         *
+         * @param task the callable task to be performed
+         * @param <T>  the return type of the task
+         * @return the result of the task
+         * @throws ClusterCoordinationException if the task execution takes more time than the max DB timeout interval
+         */
+        public <T> T performDBOperationsWithTimeout(Callable<T> task) throws ClusterCoordinationException {
+            Future<T> future = dbCommunicatorExecutor.submit(task);
+            try {
+                return future.get(maxDBReadTime, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                try {
+                    future.cancel(true); // Cancel the task if it exceeds the max DB timeout interval
+                } catch (Exception ex) {
+                    //ignore
+                }
+                throw new ClusterCoordinationException("Database connection turned unresponsive. "
+                        + "Please increase the heartbeat interval or verify the database connection.", e);
             }
         }
 
@@ -446,18 +514,43 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                 throws ClusterCoordinationException, InterruptedException {
             long taskStartTime = System.currentTimeMillis();
             long taskEndTime;
-            updateNodeHeartBeat(currentHeartbeatTime);
+            try {
+                performDBOperationsWithTimeout(() -> {
+                    updateNodeHeartBeat(currentHeartbeatTime);
+                    return null;
+                });
+            } catch (ClusterCoordinationException e) {
+                handleDatabaseDelay(localNodeId, localGroupId, e, "Error updating node heartbeat.");
+                throw e;
+            }
             taskEndTime = System.currentTimeMillis();
             timeTakenForMemberTasks[0] = taskEndTime - taskStartTime;
             taskStartTime = taskEndTime;
-            boolean coordinatorValid = communicationBusContext.checkIfCoordinatorValid(localGroupId, localNodeId,
-                                                                                       heartbeatMaxRetryInterval, currentHeartbeatTime);
+            boolean coordinatorValid;
+            try {
+                coordinatorValid = performDBOperationsWithTimeout(() ->
+                        communicationBusContext.checkIfCoordinatorValid
+                                (localGroupId, localNodeId, heartbeatMaxRetryInterval, currentHeartbeatTime)
+                );
+            } catch (ClusterCoordinationException e) {
+                handleDatabaseDelay(localNodeId, localGroupId, e, "Error checking if coordinator is valid.");
+                throw e;
+            }
             taskEndTime = System.currentTimeMillis();
             timeTakenForMemberTasks[1] = taskEndTime - taskStartTime;
             if (!coordinatorValid) {
                 taskStartTime = taskEndTime;
-                communicationBusContext.removeCoordinator(localGroupId, heartbeatMaxRetryInterval,
-                                                          currentHeartbeatTime);
+                try {
+                    performDBOperationsWithTimeout(() -> {
+                        communicationBusContext.removeCoordinator(localGroupId, heartbeatMaxRetryInterval
+                                , currentHeartbeatTime);
+                        return null;
+                    });
+                } catch (ClusterCoordinationException e) {
+                    handleDatabaseDelay(localNodeId, localGroupId, e, "Error removing coordinator for group "
+                            + localGroupId);
+                    throw e;
+                }
                 taskEndTime = System.currentTimeMillis();
                 timeTakenForMemberTasks[2] = taskEndTime - taskStartTime;
                 taskStartTime = taskEndTime;
@@ -492,17 +585,49 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
             // Try to update the coordinator heartbeat
             long taskStartTime = System.currentTimeMillis();
             long taskEndTime;
-            boolean stillCoordinator = communicationBusContext.
-                                                                      updateCoordinatorHeartbeat(localNodeId, localGroupId, currentHeartbeatTime);
+            boolean stillCoordinator;
+            try {
+                stillCoordinator = performDBOperationsWithTimeout(() ->
+                        communicationBusContext.updateCoordinatorHeartbeat
+                                (localNodeId, localGroupId, currentHeartbeatTime));
+            } catch (ClusterCoordinationException e) {
+                handleDatabaseDelay(localNodeId, localGroupId, e,
+                        "Error updating coordinator heartbeat in LEADER_STATUS_TABLE due to database delay."
+                                + " Stopping coordinated tasks for this node. Please increase the heartbeat interval or"
+                                + " verify the database connection.");
+                throw e;
+            }
             taskEndTime = System.currentTimeMillis();
             timeTakenForCoordinatorTasks[0] = taskEndTime - taskStartTime;
             taskStartTime = taskEndTime;
             if (stillCoordinator) {
-                updateNodeHeartBeat(currentHeartbeatTime);
+                try {
+                    performDBOperationsWithTimeout(() -> {
+                        updateNodeHeartBeat(currentHeartbeatTime);
+                        return null;
+                    });
+                } catch (ClusterCoordinationException e) {
+                   handleDatabaseDelay(localNodeId, localGroupId, e,
+                           "Error updating node heartbeat in CLUSTER_NODE_STATUS_TABLE due to database delay."
+                                   + " Stopping coordinated tasks for this node. Please increase the heartbeat interval"
+                                   + " or verify the database connection.");
+                    throw e;
+                }
                 taskEndTime = System.currentTimeMillis();
                 timeTakenForCoordinatorTasks[1] = taskEndTime - taskStartTime;
                 taskStartTime = taskEndTime;
-                List<NodeDetail> allNodeInformation = communicationBusContext.getAllNodeData(localGroupId);
+
+                List<NodeDetail> allNodeInformation;
+                try {
+                    allNodeInformation = performDBOperationsWithTimeout(() ->
+                            communicationBusContext.getAllNodeData(localGroupId));
+                } catch (ClusterCoordinationException e) {
+                    handleDatabaseDelay(localNodeId, localGroupId, e, "Error retrieving all node data from"
+                            + " LEADER_STATUS_TABLE and CLUSTER_NODE_STATUS_TABLE due to database delay."
+                            + " Stopping coordinated tasks for this node. Please increase the heartbeat interval or"
+                            + " verify the database connection.");
+                   throw e;
+                }
                 taskEndTime = System.currentTimeMillis();
                 timeTakenForCoordinatorTasks[2] = taskEndTime - taskStartTime;
                 taskStartTime = taskEndTime;
@@ -537,14 +662,47 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                     removedNodes.add(nodeId);
                     allActiveNodeIds.remove(nodeId);
                     removedNodeDetails.add(nodeDetail);
-                    communicationBusContext.removeNode(nodeId, localGroupId);
+                    try {
+                        performDBOperationsWithTimeout(() -> {
+                            communicationBusContext.removeNode(nodeId, localGroupId);
+                            return null;
+                        });
+                    } catch (ClusterCoordinationException e) {
+                        handleDatabaseDelay(nodeId, localGroupId, e, "Error removing node " + nodeId
+                                + " from group " + localGroupId + " due to database delay.");
+                        throw e;
+                    }
                 } else if (nodeDetail.isNewNode()) {
                     newNodes.add(nodeId);
-                    communicationBusContext.markNodeAsNotNew(nodeId, localGroupId);
+                    try {
+                        performDBOperationsWithTimeout(() -> {
+                            communicationBusContext.markNodeAsNotNew(nodeId, localGroupId);
+                            return null;
+                        });
+                    } catch (ClusterCoordinationException e) {
+                        handleDatabaseDelay(nodeId, localGroupId, e, "Error marking node as not"
+                                + " new for nodeId: " + nodeId + " in group: " + localGroupId);
+                        throw e;
+
+                    }
                 }
             }
+
             notifyAddedMembers(newNodes, allActiveNodeIds);
             notifyRemovedMembers(removedNodes, allActiveNodeIds, removedNodeDetails);
+        }
+
+        /**
+         * Handles the database delay.
+         *
+         * @param nodeId      node ID of the current node
+         * @param groupId group ID of the current group
+         * @param e           exception occurred
+         * @param logMessage  log message
+         */
+        private void handleDatabaseDelay(String nodeId, String groupId, Exception e, String logMessage) {
+            log.warn(logMessage + " Make task Sleep for the duration of : " + inactiveIntervalAfterUnresponsive , e);
+            setUnresponsiveness(nodeId, groupId);
         }
 
         /**
@@ -559,8 +717,17 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                     log.debug("Member added " + StringUtil.removeCRLFCharacters(newNode) + "to group " +
                               StringUtil.removeCRLFCharacters(localGroupId));
                 }
-                rdbmsMemberEventProcessor.notifyMembershipEvent(newNode, localGroupId, allActiveNodeIds,
-                                                                MemberEventType.MEMBER_ADDED);
+                try {
+                    performDBOperationsWithTimeout(() -> {
+                        rdbmsMemberEventProcessor.notifyMembershipEvent(newNode, localGroupId, allActiveNodeIds,
+                                MemberEventType.MEMBER_ADDED);
+                        return null;
+                    });
+                } catch (ClusterCoordinationException e) {
+                    handleDatabaseDelay(newNode, localGroupId, e
+                            , "Error notifying membership event for new node " + newNode);
+                    throw e;
+                }
             }
         }
 
@@ -572,8 +739,17 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          */
         private void storeRemovedMemberDetails(List<String> allActiveNodeIds, List<NodeDetail> removedNodeDetails) {
             for (NodeDetail nodeDetail : removedNodeDetails) {
-                communicationBusContext.insertRemovedNodeDetails(nodeDetail.getNodeId(), nodeDetail.getGroupId(),
-                                                                 allActiveNodeIds);
+                try {
+                    performDBOperationsWithTimeout(() -> {
+                        communicationBusContext.insertRemovedNodeDetails(nodeDetail.getNodeId()
+                                , nodeDetail.getGroupId(), allActiveNodeIds);
+                        return null;
+                    });
+                } catch (ClusterCoordinationException e) {
+                    handleDatabaseDelay(nodeDetail.getNodeId(), nodeDetail.getGroupId(), e
+                            , "Error inserting removed node details for node " + nodeDetail.getNodeId());
+                    throw e;
+                }
             }
         }
 
@@ -591,8 +767,17 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                     log.debug("Member removed " + StringUtil.removeCRLFCharacters(removedNode) + "from group "
                               + StringUtil.removeCRLFCharacters(localGroupId));
                 }
-                rdbmsMemberEventProcessor.notifyMembershipEvent(removedNode, localGroupId, allActiveNodeIds,
-                                                                MemberEventType.MEMBER_REMOVED);
+                try {
+                    performDBOperationsWithTimeout(() -> {
+                        rdbmsMemberEventProcessor.notifyMembershipEvent(removedNode, localGroupId, allActiveNodeIds,
+                                MemberEventType.MEMBER_REMOVED);
+                        return null;
+                    });
+                } catch (ClusterCoordinationException e) {
+                    handleDatabaseDelay(removedNode, localGroupId, e
+                            , "Error notifying membership event for removed node " + removedNode);
+                    throw e;
+                }
             }
         }
 
@@ -605,9 +790,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
             try {
                 this.currentNodeState = tryToElectSelfAsCoordinator(currentHeartbeatTime);
             } catch (ClusterCoordinationException e) {
-                log.error("Error occurred. Current node became a " + NodeState.MEMBER + " node in group " +
-                          localGroupId + ". " + e.getMessage(), e);
-                this.currentNodeState = NodeState.MEMBER;
+                throw e;
             }
         }
 
@@ -620,11 +803,27 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         private NodeState tryToElectSelfAsCoordinator(long currentHeartbeatTime)
                 throws ClusterCoordinationException {
             NodeState nodeState;
-            boolean electedAsCoordinator = communicationBusContext.createCoordinatorEntry(localNodeId, localGroupId);
+            boolean electedAsCoordinator;
+            try {
+                electedAsCoordinator = performDBOperationsWithTimeout(()
+                        -> communicationBusContext.createCoordinatorEntry(localNodeId, localGroupId));
+            } catch (ClusterCoordinationException e) {
+                handleDatabaseDelay(localNodeId, localGroupId, e,
+                        "Error occurred while trying to elect self as coordinator for group " + localGroupId);
+                throw e;
+            }
             if (electedAsCoordinator) {
                 log.info("Elected current node (nodeID: " + localNodeId + ") as the coordinator for the group " +
                          localGroupId);
-                List<NodeDetail> allNodeInformation = communicationBusContext.getAllNodeData(localGroupId);
+                List<NodeDetail> allNodeInformation;
+                try {
+                    allNodeInformation = performDBOperationsWithTimeout(()
+                            -> communicationBusContext.getAllNodeData(localGroupId));
+                } catch (ClusterCoordinationException e) {
+                    handleDatabaseDelay(localNodeId, localGroupId, e
+                            , "Error retrieving all node data from the database.");
+                    throw e;
+                }
                 findAddedRemovedMembers(allNodeInformation, currentHeartbeatTime);
                 nodeState = NodeState.COORDINATOR;
                 // notify nodes about coordinator change
@@ -632,8 +831,17 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                 for (NodeDetail nodeDetail : allNodeInformation) {
                     nodeIdentifiers.add(nodeDetail.getNodeId());
                 }
-                rdbmsMemberEventProcessor.notifyMembershipEvent(localNodeId, localGroupId, nodeIdentifiers,
-                                                                MemberEventType.COORDINATOR_CHANGED);
+               try {
+                   performDBOperationsWithTimeout(() -> {
+                       rdbmsMemberEventProcessor.notifyMembershipEvent(localNodeId, localGroupId, nodeIdentifiers,
+                               MemberEventType.COORDINATOR_CHANGED);
+                       return null;
+                   });
+               } catch (ClusterCoordinationException e) {
+                   handleDatabaseDelay(localNodeId, localGroupId, e
+                           , "Error notifying membership event for coordinator change.");
+                   throw e;
+               }
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Election resulted in current node becoming a " + NodeState.MEMBER

--- a/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSMemberEventCallBack.java
+++ b/components/org.wso2.micro.integrator.coordination/src/main/java/org/wso2/micro/integrator/coordination/RDBMSMemberEventCallBack.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.micro.integrator.coordination;
+
+public interface RDBMSMemberEventCallBack {
+    void onExceptionThrown(String nodeId, Throwable e);
+}


### PR DESCRIPTION
## Purpose
This fix ensures robust handling of database delays without introducing task duplication (compromising availability over consistency) By introducing a timeout for each db event and disabling tasks on timeouts also stopping adding or removing members in a db connection turbulence is present.

Fixes: https://github.com/wso2/micro-integrator/issues/3463