### PR TITLE
Change the log level error to warn for the un-deploy errors where user is not required to do anything

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
@@ -797,7 +797,7 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                 }
             }
         } catch (Exception e) {
-            log.error("Error occured while deleting the synapse library import");
+            log.warn("Error occured while deleting the synapse library import");
         }
     }
 


### PR DESCRIPTION
## Purpose
$subject.
Public issue: https://github.com/wso2/micro-integrator/issues/3610

As given in the issue, the following log levels will be changed to warn

```
[2024-09-05 15:05:03,082] ERROR {SynapseAppDeployer} - Error occured while deleting the synapse library import
```