### PR TITLE
Remove clear user authorization from updating hybrid roles

### DIFF
--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/hybrid/JdbcHybridRoleManager.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/hybrid/JdbcHybridRoleManager.java
@@ -730,9 +730,9 @@ public class JdbcHybridRoleManager extends HybridRoleManager {
             DatabaseUtil.closeAllConnections(dbConnection);
         }
         // Authorization cache of user should also be updated if deleted roles are involved
-        if (deletedRoles != null && deletedRoles.length > 0) {
-            userRealm.getAuthorizationManager().clearUserAuthorization(user);
-        }
+//        if (deletedRoles != null && deletedRoles.length > 0) {
+//            userRealm.getAuthorizationManager().clearUserAuthorization(user);
+//        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
Remove clear user authorization from updating hybrid roles to handle a NPE when deleting hybrid roles, since user authorization is not used in MI. 
Fixes: https://github.com/wso2/micro-integrator/issues/3651
