### PR TITLE
Update maven bundle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Please follow the steps below to build WSO2 Micro Integrator from the source cod
 2. Run the maven command `mvn clean install` from the root directory of the repository.
 3. The generated Micro Integrator distribution can be found at `micro-integrator/distribution/target/wso2mi-<version>.zip`.
 
+Please note that the product can be build using only JDK 11 but the integration tests can be run in either JDK 11 or 17.
+
 #### Building the Docker image
 
 You can build the Docker image for the Micro Integrator by setting the `docker.skip` system property to `false` when running the

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Please follow the steps below to build WSO2 Micro Integrator from the source cod
 2. Run the maven command `mvn clean install` from the root directory of the repository.
 3. The generated Micro Integrator distribution can be found at `micro-integrator/distribution/target/wso2mi-<version>.zip`.
 
-Please note that the product can be build using only JDK 11 but the integration tests can be run in either JDK 11 or 17.
-
 #### Building the Docker image
 
 You can build the Docker image for the Micro Integrator by setting the `docker.skip` system property to `false` when running the

--- a/pom.xml
+++ b/pom.xml
@@ -1920,7 +1920,7 @@
         <version.geronimo.jta.spec>1.1</version.geronimo.jta.spec>
         <quartz.orbit.version>2.3.2.wso2v1</quartz.orbit.version>
         <!-- Maven bundle plugin -->
-        <maven.bundle.plugin.version>3.3.0</maven.bundle.plugin.version>
+        <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
         <apache.http.nio.version>4.4.15.wso2v1</apache.http.nio.version>
         <wso2.caching.version>4.0.3</wso2.caching.version>
         <apache.http.protocol.version>4.4.14.wso2v1</apache.http.protocol.version>


### PR DESCRIPTION
## Purpose
When using an OpenJDK version newer than 11.0.19, build of module `components/mediation/data-publishers/org.wso2.micro.integrator.observability` (and maybe others) fails with exception message `ZipException : Invalid CEN header`. 

## Goals
This PR attempts to make MI build with newer JDKs (both Java 11 and 17).

## Approach
Use a newer bundle plugin that uses an updated version of BND that does not produce the invalid header that newer JDK versions complain about.

## Documentation
* BND produced invalid jars without anyone noticing, because nobody seemed to care for a particular header: https://github.com/bndtools/bnd/issues/4507
* A new version of bnd was included in maven bundle plugin, version 5.1.5: https://issues.apache.org/jira/browse/FELIX-6622
* Java introduced validation of a particular ZIP64 header: https://bugs.openjdk.org/browse/JDK-8314891
* From now on, builds of wso2 microintegrator will fail when using a newer patch release of Java 11
* Then the exception message was improved with some additional details about the error: https://bugs.openjdk.org/browse/JDK-8313765
* wso2server.bat introduced options "-Djdk.util.zip.disableZip64ExtraFieldValidation=true -Djdk.nio.zipfs.allowDotZipEntry=true" to avoid this error on start-up (https://github.com/wso2/carbon-kernel/pull/3644), but nothing seems to have changed on micro integrator

## Related PRs
* https://github.com/wso2/carbon-kernel/pull/3644