### PR TITLE
Add dependencies to fix test environment initalization failure of tests-mediator-2 module

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/pom.xml
+++ b/integration/mediation-tests/tests-mediator-2/pom.xml
@@ -424,5 +424,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Purpose
> This change enable smooth run of mediation integration tests for both JDK 17 and JDK 21.

Related Task : https://github.com/wso2/micro-integrator/issues/3684