### PR TITLE
Avoid retaining current result set

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/SQLQuery.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/SQLQuery.java
@@ -1087,7 +1087,7 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
                 break;
             }
             try {
-                resultAndNoUpdateCount = stmt.getMoreResults(Statement.KEEP_CURRENT_RESULT);
+                resultAndNoUpdateCount = stmt.getMoreResults();
             } catch (SQLException e) {
                 /*
                  * for some DBMS, this will throw an unsupported feature


### PR DESCRIPTION
The current ResultSet does not need to be retained at this point since it will be empty. If a ResultSet were found, the loop would break immediately. Passing `Statement.KEEP_CURRENT_RESULT` to `stmt.getMoreResults()` causes the following error in MSSQL:

```
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: This operation is not supported.
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDriverError(SQLServerException.java:248)
	at com.microsoft.sqlserver.jdbc.SQLServerException.throwNotSupportedException(SQLServerException.java:442)
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.getMoreResults(SQLServerStatement.java:2398)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.apache.tomcat.jdbc.pool.StatementFacade$StatementProxy.invoke(StatementFacade.java:118)
	at jdk.proxy7/jdk.proxy7.$Proxy46.getMoreResults(Unknown Source)
	at org.wso2.micro.integrator.dataservices.core.description.query.SQLQuery.getFirstRSOfStoredProc(SQLQuery.java:1088)
	at org.wso2.micro.integrator.dataservices.core.description.query.SQLQuery.processPreStoredProcQuery(SQLQuery.java:956)
	... 21 more
```