### PR TITLE
Enable activate/deactivate functionality for Polling Inbound Endpoints

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRequestProcessorImpl.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRequestProcessorImpl.java
@@ -165,6 +165,10 @@ public abstract class InboundRequestProcessorImpl implements InboundRequestProce
      * Activates the Inbound Endpoint by activating any associated startup controllers
      * or resuming inbound runner threads if no startup controllers are present.
      *
+     * The decision on whether to use startup controllers (task) or inbound runner threads will depend
+     * on the coordination enabled or not.
+     * - if coordination enabled then startup controller otherwise inbound runner thread
+     *
      * <p>This method first checks if there are any startup controllers. If there are, it attempts to activate
      * each controller and sets the success flag accordingly. If no startup controllers are present, it resumes
      * any inbound runner threads that may be running. The method returns a boolean indicating whether
@@ -179,7 +183,7 @@ public abstract class InboundRequestProcessorImpl implements InboundRequestProce
         log.info("Activating the Inbound Endpoint [" + name + "].");
 
         boolean isSuccessfullyActivated = false;
-        if (!startUpControllersList.isEmpty()) {
+        if (this.coordination && !startUpControllersList.isEmpty()) {
             for (StartUpController sc : startUpControllersList) {
                 if (sc.activateTask()) {
                     isSuccessfullyActivated = true;

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/generic/GenericProcessor.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/generic/GenericProcessor.java
@@ -51,7 +51,7 @@ public class GenericProcessor extends InboundRequestProcessorImpl implements Tas
 
     public GenericProcessor(String name, String classImpl, Properties properties, long scanInterval,
                             String injectingSeq, String onErrorSeq, SynapseEnvironment synapseEnvironment,
-                            boolean coordination, boolean sequential) {
+                            boolean coordination, boolean sequential, boolean startInPauseMode) {
         this.name = name;
         this.properties = properties;
         this.interval = scanInterval;
@@ -61,6 +61,7 @@ public class GenericProcessor extends InboundRequestProcessorImpl implements Tas
         this.classImpl = classImpl;
         this.coordination = coordination;
         this.sequential = sequential;
+        this.startInPausedMode = startInPauseMode;
     }
 
     public GenericProcessor(InboundProcessorParams params) {
@@ -84,21 +85,8 @@ public class GenericProcessor extends InboundRequestProcessorImpl implements Tas
     }
 
     public void init() {
-        /*
-         * The activate/deactivate functionality is not currently implemented
-         * for this Inbound Endpoint type.
-         *
-         * Therefore, the following check has been added to immediately return if the "suspend"
-         * attribute is set to true in the inbound endpoint configuration.
-         *
-         * Note: This implementation is temporary and should be revisited and improved once
-         * the activate/deactivate capability is implemented.
-         */
-        if (startInPausedMode) {
-            log.info("Inbound endpoint [" + name + "] is currently suspended.");
-            return;
-        }
-        log.info("Inbound listener " + name + " for class " + classImpl + " starting ...");
+        log.info("Inbound listener [" + name + "] is initializing"
+                + (this.startInPausedMode ? " but will remain in suspended mode..." : "..."));
         Map<String, ClassLoader> libClassLoaders = SynapseConfiguration.getLibraryClassLoaders();
         Class c = null;
         if (libClassLoaders != null) {
@@ -179,13 +167,13 @@ public class GenericProcessor extends InboundRequestProcessorImpl implements Tas
 
     @Override
     public boolean activate() {
-
-        return false;
+        pollingConsumer.resume();
+        return super.activate();
     }
 
     @Override
     public boolean deactivate() {
-
-        return false;
+        pollingConsumer.destroy();
+        return super.deactivate();
     }
 }


### PR DESCRIPTION
## Purpose
> This PR contains the implementation changes to enable activate/deactivate functionality for custom polling inbound endpoints developed by WSO2 following guidelines[1]. 
>
> Eg:- 
> - Kafka inbound endpoint
> - AmazonSQS inbound endpoint

[1] https://mi.docs.wso2.com/en/latest/develop/customizations/creating-custom-inbound-endpoint/

## Goals
> Add activate/deactivate functionality for Polling Inbound Endpoints developed by extending GenericPollingConsumer
