### PR TITLE
Revert "Bump org.apache.commons:commons-lang3 from 3.1 to 3.18.0 in /integration/automation-extensions"

### DIFF
--- a/integration/automation-extensions/pom.xml
+++ b/integration/automation-extensions/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <version>3.1</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>


### PR DESCRIPTION
Reverts wso2/product-micro-integrator#4265 to avoid test failures