### PR TITLE
Remove java.io, java.net from script mediator block list

### DIFF
--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -97,7 +97,7 @@
 
   "synapse_properties.'limit_java_class_access_in_scripts.enable'": true,
   "synapse_properties.'limit_java_class_access_in_scripts.list_type'": "BLOCK_LIST",
-  "synapse_properties.'limit_java_class_access_in_scripts.class_prefixes'": "java.lang.System,java.lang.Runtime,java.io,java.nio,java.net",
+  "synapse_properties.'limit_java_class_access_in_scripts.class_prefixes'": "java.lang.System,java.lang.Runtime",
 
   "passthru_properties.'http.socket.timeout'": "180000",
   "passthru_properties.'worker_pool_size_core'": "400",


### PR DESCRIPTION
## Purpose

Remove java.io, java.net from script mediator block list