### PR TITLE
Fix correlation error logs masking underlying database errors [master]

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBUtils.java
@@ -74,6 +74,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -275,6 +277,24 @@ public class DBUtils {
     /** pre-fetch the OMFactory */
     static {
         omFactory = OMAbstractFactory.getOMFactory();
+    }
+
+    /**
+     * Recursively unwraps common reflective wrapper exceptions to reveal the original cause.
+     * This method traverses through {@link InvocationTargetException} and
+     * {@link UndeclaredThrowableException} instances until the root cause is found.
+     *
+     * @param e the throwable to unwrap
+     * @return the root cause if {@code e} is wrapped, or {@code e} itself if not
+     */
+    public static Throwable unwrap(Throwable e) {
+        if (log.isDebugEnabled()) {
+            log.debug("Unwrapping throwable: " + e.getClass().getName());
+        }
+        if (e instanceof InvocationTargetException || e instanceof UndeclaredThrowableException) {
+            return unwrap(e.getCause());
+        }
+        return e;
     }
 
     public static XMLOutputFactory getXMLOutputFactory() {

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/SQLQuery.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/SQLQuery.java
@@ -56,6 +56,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.math.BigDecimal;
 import java.sql.Array;
 import java.sql.Blob;
@@ -83,6 +85,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+
+import static org.wso2.micro.integrator.dataservices.core.DBUtils.unwrap;
 
 /**
  * This class represents an SQL query in a data service.
@@ -805,6 +809,7 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
             throw new DataServiceFault(e, FaultCodes.INCOMPATIBLE_PARAMETERS_ERROR,
                                        "Error in 'SQLQuery.processPreNormalQuery': " + e.getMessage());
         } catch (Throwable e) {
+            e = unwrap(e);
             isError = true;
             throw new DataServiceFault(e, FaultCodes.DATABASE_ERROR,
                                        "Error in 'SQLQuery.processPreNormalQuery': " + e.getMessage());


### PR DESCRIPTION
## Purpose
When correlation is enabled, database methods are invoked using Java reflection. As a result, any exception thrown during method execution is first wrapped in an `InvocationTargetException`. If the original method does not handle this exception, it is further wrapped in an `UndeclaredThrowableException`, leading to a double-wrapped exception scenario.

To address this, we introduced a recursive unwrapping mechanism to ensure that the root cause is correctly identified and propagated, even in cases where exceptions are nested multiple levels deep.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4383 