### PR TITLE
Fix test failure

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA4394.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA4394.java
@@ -50,7 +50,7 @@ public class ESBJAVA4394 extends ESBIntegrationTest {
              * since we are making a soap fault in the configuration axis2 client receives axis fault.
              */
             String axisFaultMessage = axisFault.getMessage();
-            assertTrue(axisFaultMessage.contains("101503"));
+            assertTrue(axisFaultMessage.contains("101508"));
         }
     }
 


### PR DESCRIPTION
Reverts wso2/product-micro-integrator#4312

This PR was previously sent to update the ESBJAVA4394 test case to align with the fix: https://github.com/wso2/wso2-synapse/pull/2367 and assert the error code `101503` instead of `101508.`

Recently, the fix was reverted with https://github.com/wso2/wso2-synapse/pull/2414. Therefore, we are reverting the test fix to the previous state.