### PR TITLE
Add enableSettingEmptyDefaultNamespace property to Dataservice to set empty namespace in result.

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.common/src/main/java/org/wso2/micro/integrator/dataservices/common/DBConstants.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.common/src/main/java/org/wso2/micro/integrator/dataservices/common/DBConstants.java
@@ -896,6 +896,7 @@ public final class DBConstants {
         public static final String ESCAPE_NON_PRINTABLE_CHAR = "escapeNonPrintableChar";
         public static final String STRUCT_TYPE = "structType";
         public static final String SWAGGER_LOCATION = "publishSwagger";
+        public static final String ENABLE_SETTING_EMPTY_DEFAULT_NAMESPACE = "enableSettingEmptyDefaultNamespace";
     }
 
     /**

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QueryFactory.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QueryFactory.java
@@ -686,8 +686,14 @@ public class QueryFactory {
 		}
 
 		String namespace = resEl.getAttributeValue(new QName(DBSFields.DEFAULT_NAMESPACE));
-		if (namespace == null || namespace.trim().length() == 0) {
-			namespace = dataService.getDefaultNamespace();
+		if (namespace == null || namespace.trim().isEmpty()) {
+            boolean enableEmptyDefaultNamespace = Boolean.parseBoolean(resEl.getAttributeValue(
+                    new QName(DBSFields.ENABLE_SETTING_EMPTY_DEFAULT_NAMESPACE)));
+            if (enableEmptyDefaultNamespace) {
+                namespace = "";
+            } else {
+			    namespace = dataService.getDefaultNamespace();
+            }
 		}
 
         String xsltPath = resEl.getAttributeValue(new QName(DBSFields.XSLT_PATH));


### PR DESCRIPTION
fixes: https://github.com/wso2/product-micro-integrator/issues/4468


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to allow empty namespaces in query results instead of defaulting to the data service's default namespace, providing greater control over XML namespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->