### PR TITLE
Clean the event list after publishing stats

### DIFF
--- a/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/main/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/services/MessageFlowReporterThread.java
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/src/main/java/org/wso2/micro/integrator/analytics/messageflow/data/publisher/services/MessageFlowReporterThread.java
@@ -86,7 +86,7 @@ public class MessageFlowReporterThread extends Thread {
     }
 
     public void run() {
-        StatisticsReportingEventHolder statisticsReportingEventHolder;
+        StatisticsReportingEventHolder statisticsReportingEventHolder = null;
         while (!shutdownRequested) {
             try {
                 statisticsReportingEventHolder = synapseEnvironmentService.getSynapseEnvironment().getMessageDataStore()
@@ -98,6 +98,11 @@ public class MessageFlowReporterThread extends Thread {
                 }
             } catch (Exception exception) {//catching throwable since this shouldn't fail
                 log.error("Error in mediation flow statistic data consumer while consuming data", exception);
+            } finally {
+                // Removing the event queue reference from the event holder to enable GC.
+                if (statisticsReportingEventHolder != null) {
+                    statisticsReportingEventHolder.clearEventQueue();
+                }
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1704,7 +1704,7 @@
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
         <com.sun.jaxb.version>2.3.0</com.sun.jaxb.version>
         <com.sun.jaxb.impl.version>2.3.1</com.sun.jaxb.impl.version>
-        <synapse.version>4.0.0-wso2v270</synapse.version>
+        <synapse.version>4.0.0-wso2v275</synapse.version>
         <imp.pkg.version.synapse>[4.0.0, 4.0.1)</imp.pkg.version.synapse>
         <carbon.mediation.version>4.7.266</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>


### PR DESCRIPTION
## Purpose
> Clean the event list after publishing the statistics. 
This removes the dangling closeEvents, which hold a reference to the synapse configuration down the line. Fixes wso2/product-micro-integrator/issues/4516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource cleanup in message flow reporting to improve system stability and prevent potential memory management issues during normal operations and error conditions.

* **Chores**
  * Updated Synapse framework dependency to the latest compatible version for improved performance and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->