### PR TITLE
Implement Enable and Disable Stats for Artifacts Using Management API

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ApiResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ApiResource.java
@@ -159,8 +159,8 @@ public class ApiResource extends APIResource {
                 JSONObject info = new JSONObject();
                 info.put(API_NAME, apiName);
                 if (api != null) {
-                    response = Utils.handleTracing(performedBy, Constants.AUDIT_LOG_TYPE_API_TRACE, Constants.APIS,
-                                                   info, api.getAspectConfiguration(), apiName, axisMsgCtx);
+                    response = Utils.handleResourceStateChange(performedBy, Constants.AUDIT_LOG_TYPE_API_STATE_CHANGE,
+                                                   info, api.getAspectConfiguration(), apiName, axisMsgCtx, payload);
                 } else {
                     response = Utils.createJsonError("Specified API ('" + apiName + "') not found", axisMsgCtx,
                             Constants.BAD_REQUEST);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -152,6 +152,7 @@ public class Constants {
 
     // tracing constants
     static final String TRACE = "trace";
+    static final String STATISTICS = "statistics";
     static final String ENABLE = "enable";
     static final String DISABLE = "disable";
 
@@ -170,12 +171,12 @@ public class Constants {
     public static final String AUDIT_LOG_TYPE_CARBON_APPLICATION = "carbon_application";
     public static final String AUDIT_LOG_TYPE_CONNECTOR = "connector";
 
-    public static final String AUDIT_LOG_TYPE_API_TRACE = "api_trace";
-    public static final String AUDIT_LOG_TYPE_PROXY_SERVICE_TRACE = "proxy_service_trace";
-    public static final String AUDIT_LOG_TYPE_INBOUND_ENDPOINT_TRACE = "inbound_endpoint_trace";
-    public static final String AUDIT_LOG_TYPE_SEQUENCE_TEMPLATE_TRACE = "sequence_template_trace";
-    public static final String AUDIT_LOG_TYPE_SEQUENCE_TRACE = "sequence_trace";
-    public static final String AUDIT_LOG_TYPE_ENDPOINT_TRACE = "endpoint_trace";
+    public static final String AUDIT_LOG_TYPE_API_STATE_CHANGE = "api_";
+    public static final String AUDIT_LOG_TYPE_PROXY_SERVICE_STATE_CHANGE = "proxy_service_";
+    public static final String AUDIT_LOG_TYPE_INBOUND_ENDPOINT_STATE_CHANGE = "inbound_endpoint_";
+    public static final String AUDIT_LOG_TYPE_SEQUENCE_TEMPLATE_STATE_CHANGE = "sequence_template_";
+    public static final String AUDIT_LOG_TYPE_SEQUENCE_STATE_CHANGE = "sequence_";
+    public static final String AUDIT_LOG_TYPE_ENDPOINT_STATE_CHANGE = "endpoint_";
     public static final String AUDIT_LOG_TYPE_REGISTRY_RESOURCE = "registry_resource";
     public static final String AUDIT_LOG_TYPE_REGISTRY_RESOURCE_PROPERTIES = "registry_resource_properties";
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/EndpointResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/EndpointResource.java
@@ -106,7 +106,7 @@ public class EndpointResource implements MiApiResource {
                     if (payload.has(Constants.NAME) && payload.has(STATUS)) {
                         changeEndpointStatus(performedBy, axis2MessageContext, synapseConfiguration, payload);
                     } else {
-                        handleTracing(performedBy, payload, messageContext, axis2MessageContext);
+                        handleStateChange(performedBy, payload, messageContext, axis2MessageContext);
                     }
                 } else {
                     Utils.sendForbiddenFaultResponse(axis2MessageContext);
@@ -134,7 +134,7 @@ public class EndpointResource implements MiApiResource {
         setResponseBody(searchResultList, messageContext);
     }
 
-    private void handleTracing(String performedBy, JsonObject payload, MessageContext msgCtx,
+    private void handleStateChange(String performedBy, JsonObject payload, MessageContext msgCtx,
                                org.apache.axis2.context.MessageContext axisMsgCtx) {
 
         JSONObject response;
@@ -148,10 +148,10 @@ public class EndpointResource implements MiApiResource {
                             .getAspectConfiguration();
                     JSONObject info = new JSONObject();
                     info.put(ENDPOINT_NAME, endpointName);
-                    response = Utils.handleTracing(performedBy, Constants.AUDIT_LOG_TYPE_ENDPOINT_TRACE,
-                            Constants.ENDPOINTS, info, aspectConfiguration, endpointName, axisMsgCtx);
+                    response = Utils.handleResourceStateChange(performedBy, Constants.AUDIT_LOG_TYPE_ENDPOINT_STATE_CHANGE,
+                            info, aspectConfiguration, endpointName, axisMsgCtx, payload);
                 } else {
-                    response = Utils.createJsonError("Tracing is not supported for this endpoint", axisMsgCtx,
+                    response = Utils.createJsonError("Tracing/Statistics is not supported for this endpoint", axisMsgCtx,
                             Constants.BAD_REQUEST);
                 }
             } else {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/InboundEndpointResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/InboundEndpointResource.java
@@ -138,9 +138,9 @@ public class InboundEndpointResource extends APIResource {
                     if (payload.has(STATUS)) {
                         response = handleStatusUpdate(inboundEndpoint, performedBy, info, msgCtx, payload);
                     } else {
-                        response = Utils.handleTracing(performedBy, Constants.AUDIT_LOG_TYPE_INBOUND_ENDPOINT_TRACE,
-                                Constants.INBOUND_ENDPOINTS, info,
-                                inboundEndpoint.getAspectConfiguration(), inboundName, axisMsgCtx);
+                        response = Utils.handleResourceStateChange(performedBy, Constants.AUDIT_LOG_TYPE_INBOUND_ENDPOINT_STATE_CHANGE,
+                                info,
+                                inboundEndpoint.getAspectConfiguration(), inboundName, axisMsgCtx, payload);
                     }
 
                 } else {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ProxyServiceResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ProxyServiceResource.java
@@ -178,9 +178,9 @@ public class ProxyServiceResource extends APIResource {
             SynapseConfiguration configuration = msgCtx.getConfiguration();
             ProxyService proxyService = configuration.getProxyService(proxyName);
             if (proxyService != null) {
-                response = Utils.handleTracing(performedBy, Constants.AUDIT_LOG_TYPE_PROXY_SERVICE_TRACE,
-                                               Constants.PROXY_SERVICES, info, proxyService.getAspectConfiguration(),
-                                               proxyName, axisMsgCtx);
+                response = Utils.handleResourceStateChange(performedBy, Constants.AUDIT_LOG_TYPE_PROXY_SERVICE_STATE_CHANGE,
+                                               info, proxyService.getAspectConfiguration(),
+                                               proxyName, axisMsgCtx, payload);
             } else {
                 response = Utils.createJsonError("Specified proxy ('" + proxyName + "') not found", axisMsgCtx,
                                                  Constants.BAD_REQUEST);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/SequenceResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/SequenceResource.java
@@ -145,9 +145,9 @@ public class SequenceResource extends APIResource {
                     }
                     JSONObject info = new JSONObject();
                     info.put(SEQUENCE_NAME, seqName);
-                    response = Utils.handleTracing(performedBy, Constants.AUDIT_LOG_TYPE_SEQUENCE_TRACE,
-                                                   Constants.SEQUENCES, info, sequence.getAspectConfiguration(),
-                                                   seqName, axisMsgCtx);
+                    response = Utils.handleResourceStateChange(performedBy, Constants.AUDIT_LOG_TYPE_SEQUENCE_STATE_CHANGE,
+                                                   info, sequence.getAspectConfiguration(),
+                                                   seqName, axisMsgCtx, payload);
                 } else {
                     response = Utils.createJsonError("Specified sequence ('" + seqName + "') not found", axisMsgCtx,
                             Constants.BAD_REQUEST);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/TemplateResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/TemplateResource.java
@@ -109,7 +109,7 @@ public class TemplateResource extends APIResource {
                     }
                     if (payload.has(Constants.NAME) && SEQUENCE_TEMPLATE_TYPE.equals(templateTypeParam)) {
                         String seqTempName = payload.get(Constants.NAME).getAsString();
-                        response = handleTracing(seqTempName, msgCtx, axis2MsgCtx);
+                        response = handleStateChange(seqTempName, msgCtx, axis2MsgCtx, payload);
                     } else {
                         response = Utils.createJsonError("Unsupported operation", axis2MsgCtx, Constants.BAD_REQUEST);
                     }
@@ -128,8 +128,8 @@ public class TemplateResource extends APIResource {
         return true;
     }
 
-    private JSONObject handleTracing(String seqTempName, MessageContext msgCtx,
-                                     org.apache.axis2.context.MessageContext axisMsgCtx) {
+    private JSONObject handleStateChange(String seqTempName, MessageContext msgCtx,
+                                     org.apache.axis2.context.MessageContext axisMsgCtx, JsonObject payload) {
 
         JSONObject response;
         SynapseConfiguration configuration = msgCtx.getConfiguration();
@@ -142,9 +142,9 @@ public class TemplateResource extends APIResource {
             JSONObject info = new JSONObject();
             info.put(SEQUENCE_NAME, seqTempName);
             info.put(SEQUENCE_TYPE, SEQUENCE_TEMPLATE_TYPE);
-            response = Utils.handleTracing(performedBy, Constants.AUDIT_LOG_TYPE_SEQUENCE_TEMPLATE_TRACE,
-                                           Constants.SEQUENCE_TEMPLATE, info, sequenceTemplate.getAspectConfiguration(),
-                                           seqTempName, axisMsgCtx);
+            response = Utils.handleResourceStateChange(performedBy, Constants.AUDIT_LOG_TYPE_SEQUENCE_TEMPLATE_STATE_CHANGE,
+                                           info, sequenceTemplate.getAspectConfiguration(),
+                                           seqTempName, axisMsgCtx, payload);
         } else {
             response = Utils.createJsonError("Specified sequence template ('" + seqTempName + "') not found",
                     axisMsgCtx, Constants.BAD_REQUEST);

--- a/integration/management-api-tests/src/test/java/org/wso2/micro/integrator/api/AuditLogTestCase.java
+++ b/integration/management-api-tests/src/test/java/org/wso2/micro/integrator/api/AuditLogTestCase.java
@@ -127,6 +127,29 @@ public class AuditLogTestCase extends ESBIntegrationTest {
     }
 
     @Test(groups = {"wso2.esb" }, priority = 3,
+            description = "Test proxy service enable/disable statistics log")
+    public void testProxyServiceStatistics() throws IOException, InterruptedException, AutomationFrameworkException {
+        if (!isManagementApiAvailable) {
+            Awaitility.await().pollInterval(50, TimeUnit.MILLISECONDS).atMost(DEFAULT_TIMEOUT, TimeUnit.SECONDS).
+                    until(isManagementApiAvailable());
+        }
+        String endpoint = "https://" + hostName + ":" + (DEFAULT_INTERNAL_API_HTTPS_PORT + portOffset) + "/management/"
+                + "proxy-services";
+        SimpleHttpClient client = new SimpleHttpClient();
+        HttpResponse response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testProxy\",\"statistics\": \"enable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"enabled\",\"type\":\"proxy_service_statistics\",\"info\":\"{\\\"proxyName\\\":\\\"testProxy\\\"}\"}", 120));
+
+        response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testProxy\",\"statistics\": \"disable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"disabled\",\"type\":\"proxy_service_statistics\",\"info\":\"{\\\"proxyName\\\":\\\"testProxy\\\"}\"}", 120));
+    }
+
+    @Test(groups = {"wso2.esb" }, priority = 3,
           description = "Test activate/deactivate endpoint")
     public void testEndpoint() throws IOException, InterruptedException, AutomationFrameworkException {
         if (!isManagementApiAvailable) {
@@ -161,6 +184,29 @@ public class AuditLogTestCase extends ESBIntegrationTest {
     }
 
     @Test(groups = {"wso2.esb" }, priority = 3,
+            description = "Test enable disable endpoint statistics")
+    public void testEndpointStatistics() throws IOException, InterruptedException, AutomationFrameworkException {
+        if (!isManagementApiAvailable) {
+            Awaitility.await().pollInterval(50, TimeUnit.MILLISECONDS).atMost(DEFAULT_TIMEOUT, TimeUnit.SECONDS).
+                    until(isManagementApiAvailable());
+        }
+        String endpoint = "https://" + hostName + ":" + (DEFAULT_INTERNAL_API_HTTPS_PORT + portOffset) + "/management/"
+                + "endpoints";
+        SimpleHttpClient client = new SimpleHttpClient();
+        HttpResponse response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testEndpoint\",\"statistics\": \"enable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"enabled\",\"type\":\"endpoint_statistics\",\"info\":\"{\\\"endpointName\\\":\\\"testEndpoint\\\"}\"}", 120));
+
+        response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testEndpoint\",\"statistics\": \"disable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"disabled\",\"type\":\"endpoint_statistics\",\"info\":\"{\\\"endpointName\\\":\\\"testEndpoint\\\"}\"}", 120));
+    }
+
+    @Test(groups = {"wso2.esb" }, priority = 3,
           description = "Test enable disable API trace")
     public void testAPITrace() throws IOException, InterruptedException, AutomationFrameworkException {
         if (!isManagementApiAvailable) {
@@ -175,6 +221,29 @@ public class AuditLogTestCase extends ESBIntegrationTest {
                                                                            response.getStatusLine().getStatusCode() +
                                                                            " returned. Expected status code is 200");
         Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"enabled\",\"type\":\"api_trace\",\"info\":\"{\\\"apiName\\\":\\\"testApi\\\"}\"}", 120));
+    }
+
+    @Test(groups = {"wso2.esb" }, priority = 3,
+            description = "Test enable disable API statistics")
+    public void testAPIStatistics() throws IOException, InterruptedException, AutomationFrameworkException {
+        if (!isManagementApiAvailable) {
+            Awaitility.await().pollInterval(50, TimeUnit.MILLISECONDS).atMost(DEFAULT_TIMEOUT, TimeUnit.SECONDS).
+                    until(isManagementApiAvailable());
+        }
+        String endpoint = "https://" + hostName + ":" + (DEFAULT_INTERNAL_API_HTTPS_PORT + portOffset) + "/management/"
+                + "apis";
+        SimpleHttpClient client = new SimpleHttpClient();
+        HttpResponse response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testApi\",\"statistics\": \"enable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"enabled\",\"type\":\"api_statistics\",\"info\":\"{\\\"apiName\\\":\\\"testApi\\\"}\"}", 120));
+
+        response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testApi\",\"statistics\": \"disable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"disabled\",\"type\":\"api_statistics\",\"info\":\"{\\\"apiName\\\":\\\"testApi\\\"}\"}", 120));
     }
 
     @Test(groups = {"wso2.esb" }, priority = 3,
@@ -195,6 +264,29 @@ public class AuditLogTestCase extends ESBIntegrationTest {
     }
 
     @Test(groups = {"wso2.esb" }, priority = 3,
+            description = "Test enable disable sequence statistics")
+    public void testSequenceStatistics() throws IOException, InterruptedException, AutomationFrameworkException {
+        if (!isManagementApiAvailable) {
+            Awaitility.await().pollInterval(50, TimeUnit.MILLISECONDS).atMost(DEFAULT_TIMEOUT, TimeUnit.SECONDS).
+                    until(isManagementApiAvailable());
+        }
+        String endpoint = "https://" + hostName + ":" + (DEFAULT_INTERNAL_API_HTTPS_PORT + portOffset) + "/management/"
+                + "sequences";
+        SimpleHttpClient client = new SimpleHttpClient();
+        HttpResponse response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testSequence\",\"statistics\": \"enable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"enabled\",\"type\":\"sequence_statistics\",\"info\":\"{\\\"sequenceName\\\":\\\"testSequence\\\"}\"}", 120));
+
+        response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testSequence\",\"statistics\": \"disable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"disabled\",\"type\":\"sequence_statistics\",\"info\":\"{\\\"sequenceName\\\":\\\"testSequence\\\"}\"}", 120));
+    }
+
+    @Test(groups = {"wso2.esb" }, priority = 3,
           description = "Test enable disable inbound endpoint trace")
     public void testInboundEndpointTrace() throws IOException, InterruptedException, AutomationFrameworkException {
         if (!isManagementApiAvailable) {
@@ -212,6 +304,29 @@ public class AuditLogTestCase extends ESBIntegrationTest {
     }
 
     @Test(groups = {"wso2.esb" }, priority = 3,
+            description = "Test enable disable inbound endpoint statistics")
+    public void testInboundEndpointStatistics() throws IOException, InterruptedException, AutomationFrameworkException {
+        if (!isManagementApiAvailable) {
+            Awaitility.await().pollInterval(50, TimeUnit.MILLISECONDS).atMost(DEFAULT_TIMEOUT, TimeUnit.SECONDS).
+                    until(isManagementApiAvailable());
+        }
+        String endpoint = "https://" + hostName + ":" + (DEFAULT_INTERNAL_API_HTTPS_PORT + portOffset) + "/management/"
+                + "inbound-endpoints";
+        SimpleHttpClient client = new SimpleHttpClient();
+        HttpResponse response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testInboundEndpoint\",\"statistics\": \"enable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"enabled\",\"type\":\"inbound_endpoint_statistics\",\"info\":\"{\\\"inboundEndpointName\\\":\\\"testInboundEndpoint\\\"}\"}", 120));
+
+        response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testInboundEndpoint\",\"statistics\": \"disable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"disabled\",\"type\":\"inbound_endpoint_statistics\",\"info\":\"{\\\"inboundEndpointName\\\":\\\"testInboundEndpoint\\\"}\"}", 120));
+    }
+
+    @Test(groups = {"wso2.esb" }, priority = 3,
           description = "Test enable disable sequence template trace")
     public void testSequenceTemplateTrace() throws IOException, InterruptedException, AutomationFrameworkException {
         if (!isManagementApiAvailable) {
@@ -226,6 +341,29 @@ public class AuditLogTestCase extends ESBIntegrationTest {
                                                                            response.getStatusLine().getStatusCode() +
                                                                            " returned. Expected status code is 200");
         Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"enabled\",\"type\":\"sequence_template_trace\",\"info\":\"{\\\"sequenceName\\\":\\\"testSequenceTemplate\\\",\\\"sequenceType\\\":\\\"sequence\\\"}\"}", 120));
+    }
+
+    @Test(groups = {"wso2.esb" }, priority = 3,
+            description = "Test enable disable sequence template statistics")
+    public void testSequenceTemplateStatistics() throws IOException, InterruptedException, AutomationFrameworkException {
+        if (!isManagementApiAvailable) {
+            Awaitility.await().pollInterval(50, TimeUnit.MILLISECONDS).atMost(DEFAULT_TIMEOUT, TimeUnit.SECONDS).
+                    until(isManagementApiAvailable());
+        }
+        String endpoint = "https://" + hostName + ":" + (DEFAULT_INTERNAL_API_HTTPS_PORT + portOffset) + "/management/"
+                + "templates";
+        SimpleHttpClient client = new SimpleHttpClient();
+        HttpResponse response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testSequenceTemplate\", \"type\": \"sequence\",\"statistics\": \"enable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"enabled\",\"type\":\"sequence_template_statistics\",\"info\":\"{\\\"sequenceName\\\":\\\"testSequenceTemplate\\\",\\\"sequenceType\\\":\\\"sequence\\\"}\"}", 120));
+
+        response = client.doPost(endpoint, getHeaderMap(), "{\"name\": \"testSequenceTemplate\", \"type\": \"sequence\",\"statistics\": \"disable\"}", "application/json");
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode(), "Invalid response status " +
+                response.getStatusLine().getStatusCode() +
+                " returned. Expected status code is 200");
+        Assert.assertTrue(carbonLogReader.checkForLog("{\"performedBy\":\"admin\",\"action\":\"disabled\",\"type\":\"sequence_template_statistics\",\"info\":\"{\\\"sequenceName\\\":\\\"testSequenceTemplate\\\",\\\"sequenceType\\\":\\\"sequence\\\"}\"}", 120));
     }
 
     @Test(groups = {"wso2.esb" }, priority = 3,


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-micro-integrator/issues/4602
We cannot enable/disable stats for the artifacts using the dashboard or management API, even though this is available for tracing. This is to implement the same functionality for statistics. 

## Approach
Implement the same functionality as tracing state changing to the statistics. Add `handleResourceStateChange` method in the Utils class to handle state changes accordingly. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for statistics tracking and logging for APIs, proxy services, endpoints, sequences, inbound endpoints, and sequence templates.

* **Bug Fixes / Improvements**
  * Audit logging now records resource state changes (enable/disable statistics) rather than trace events for managed components.

* **Tests**
  * Added tests validating statistics enable/disable logging across all managed components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->