### PR TITLE
Set default quartz misfire policy to DO_NOTHING

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/AbstractQuartzTaskManager.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/AbstractQuartzTaskManager.java
@@ -338,7 +338,10 @@ public abstract class AbstractQuartzTaskManager implements TaskManager {
                                                                 CronScheduleBuilder cb) throws TaskException {
         switch (triggerInfo.getMisfirePolicy()) {
         case DEFAULT:
-            return cb;
+            // DO_NOTHING as the default behaviour of cron misfire. In a cluster scenario
+            // default behaviour can result in multiple nodes triggering the same task.
+            // We are prioritizing avoiding duplicates over missing a task execution.
+            return cb.withMisfireHandlingInstructionDoNothing();
         case IGNORE_MISFIRES:
             return cb.withMisfireHandlingInstructionIgnoreMisfires();
         case FIRE_AND_PROCEED:


### PR DESCRIPTION
Set the misfire policy to do nothing, as the task will be triggered by the task engine when the server starts and if there are any misfired tasks, they will be triggered immediately. In a cluster scenario, this can result in multiple nodes triggering the same task. We are prioritising avoiding duplicates over missing a task execution. 
Fixes wso2/product-micro-integrator/issues/4617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of scheduled task execution to prevent duplicate task runs in clustered environments when execution delays occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->