### PR TITLE
Exclude commons-io from carbon-mediation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,12 @@
                 <groupId>org.wso2.carbon.mediation</groupId>
                 <artifactId>org.wso2.carbon.sequences</artifactId>
                 <version>${carbon.mediation.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-io.wso2</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.mediation</groupId>


### PR DESCRIPTION
## Purpose
File inbound tests are failing due to using commons-io-2.7.0.wso2v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to exclude transitive libraries, improving dependency management and preventing potential conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->