### PR TITLE
Upgrade tomcat-juli to 11.0.18

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -93,6 +93,10 @@
             <artifactId>slf4j-simple</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-juli</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -187,6 +187,7 @@
                 <exclude>build.xml</exclude>
                 <exclude>version.txt</exclude>
                 <exclude>README.txt</exclude>
+                <exclude>tomcat-juli-*.jar</exclude>
             </excludes>
         </fileSet>
 
@@ -645,6 +646,13 @@
     </files>
 
     <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>wso2mi-${pom.version}/bin</outputDirectory>
+            <includes>
+                <include>org.apache.tomcat:tomcat-juli:jar</include>
+            </includes>
+        </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
             <outputDirectory>wso2mi-${pom.version}/wso2/lib</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -1367,6 +1367,11 @@
                 <version>${orbit.version.tomcat}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-juli</artifactId>
+                <version>${version.tomcat}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.ei</groupId>
                 <artifactId>org.wso2.micro.integrator.ndatasource.common</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
## Purpose
Avoid fetching the tomcat-juli artifact packaged via carbon-core and adding to bin directory. Instead explicitly add tomcat-juli to bin directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the required logging library is included in distribution and runtime artifacts by adding it to the project's packaging configuration so the library is present in the final bin/distribution output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->