### PR TITLE
Provide options to configure jce_provider and jsse_provider from deployment.toml

### DIFF
--- a/components/org.wso2.micro.integrator.server/src/main/java/org/wso2/micro/integrator/server/Main.java
+++ b/components/org.wso2.micro.integrator.server/src/main/java/org/wso2/micro/integrator/server/Main.java
@@ -79,6 +79,8 @@ public class Main {
     private static final String JSSE_CLASS_NAME = "org.bouncycastle.jsse.provider.BouncyCastleJsseProvider";
     private static final String SECURITY_JCE_PROVIDER = "security.jce.provider";
     private static final String FIPS_APPROVED_ONLY = "org.bouncycastle.fips.approved_only";
+    private static final String JCE_PROVIDER_NAME = "jce_provider.provider_name";
+    private static final String JSSE_PROVIDER_NAME = "jsse_provider.provider_name";
 
     public static void main(String[] args) {
 
@@ -417,28 +419,28 @@ public class Main {
     }
 
     private static void addBcProviders() {
-        String jceProvider = System.getProperty(SECURITY_JCE_PROVIDER);
-        if (jceProvider != null) {
-            if (BOUNCY_CASTLE_FIPS_PROVIDER.equals(jceProvider)) {
-                System.setProperty(FIPS_APPROVED_ONLY, "true");
-                System.setProperty("org.bouncycastle.rsa.allow_multi_use", "true");
-                setBcProviders(BC_FIPS_CLASS_NAME, jceProvider);
-            } else if (BOUNCY_CASTLE_PROVIDER.equals(jceProvider)) {
-                setBcProviders(BC_CLASS_NAME, jceProvider);
-            } else {
-                throw new RuntimeException("Unsupported JCE provider: " + jceProvider);
-            }
-        }
-    }
-
-    private static void setBcProviders(String className, String jceProvider) {
         try {
-            Security.insertProviderAt((Provider) Class.forName(className).getDeclaredConstructor().newInstance(),
+            String cryptoProviderIdentifier = getPreferredJceProviderIdentifier();
+            String cryptoProviderClass = getPreferredJceProviderClass(cryptoProviderIdentifier);
+            Security.insertProviderAt((Provider) Class.forName(cryptoProviderClass).getDeclaredConstructor().newInstance(),
                     1);
-            Security.insertProviderAt((Provider) Class.forName(JSSE_CLASS_NAME).getConstructor(String.class)
-                    .newInstance(jceProvider), 2);
-            logger.info("JCE provider: " + className + " is set properly");
-            logger.info("JSSE provider: " + JSSE_CLASS_NAME + " is set properly");
+            if (logger.isDebugEnabled()) {
+                logger.debug(cryptoProviderClass + " security provider is successfully registered in JVM.");
+            }
+            String jsseProviderIdentifier = Utils.getConfig(JSSE_PROVIDER_NAME);
+            if (jsseProviderIdentifier != null) {
+                if (BOUNCY_CASTLE_PROVIDER.equalsIgnoreCase(jsseProviderIdentifier)) {
+                    Security.insertProviderAt((Provider) Class.forName(JSSE_CLASS_NAME).getDeclaredConstructor()
+                            .newInstance(), 2);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("JSSE provider: " + JSSE_CLASS_NAME + " is set properly");
+                    }
+                } else {
+                    logger.warn("Unsupported JSSE provider specified: " + jsseProviderIdentifier +
+                            ". JSSE provider will not be set.");
+                }
+
+            }
         } catch (InstantiationException e) {
             throw new RuntimeException("Failed to instantiate the class. Ensure it has " +
                     "a public no-argument constructor.", e);
@@ -453,6 +455,49 @@ public class Main {
         } catch (ClassNotFoundException e) {
             throw new RuntimeException("The specified class could not be found. Check the " +
                     "fully qualified class name.", e);
+        }
+    }
+
+    /**
+     * This method returns the preferred JCE provider identifier to be used.
+     *
+     * @return jce provider class name
+     */
+    private static String getPreferredJceProviderIdentifier() {
+        String jceProviderIdentifier = System.getProperty(SECURITY_JCE_PROVIDER);
+        if (jceProviderIdentifier == null) {
+            jceProviderIdentifier = Utils.getConfig(JCE_PROVIDER_NAME);
+        }
+        if (jceProviderIdentifier == null) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("No JCE provider specified via system property or configuration. " +
+                        "Defaulting to " + BOUNCY_CASTLE_PROVIDER);
+            }
+            return BOUNCY_CASTLE_PROVIDER;
+        }
+        if (BOUNCY_CASTLE_FIPS_PROVIDER.equalsIgnoreCase(jceProviderIdentifier)) {
+            return BOUNCY_CASTLE_FIPS_PROVIDER;
+        }
+        if (BOUNCY_CASTLE_PROVIDER.equalsIgnoreCase(jceProviderIdentifier)) {
+            return BOUNCY_CASTLE_PROVIDER;
+        }
+        throw new RuntimeException("Unsupported JCE provider identifier: " + jceProviderIdentifier);
+    }
+
+    /**
+     * This method returns the preferred JCE provider class to be used.
+     *
+     * @return jce provider identifier name
+     */
+    private static String getPreferredJceProviderClass(String providerIdentifier) {
+        if (BOUNCY_CASTLE_FIPS_PROVIDER.equals(providerIdentifier)) {
+            System.setProperty(FIPS_APPROVED_ONLY, "true");
+            System.setProperty("org.bouncycastle.rsa.allow_multi_use", "true");
+            return BC_FIPS_CLASS_NAME;
+        } else if (BOUNCY_CASTLE_PROVIDER.equals(providerIdentifier)) {
+            return BC_CLASS_NAME;
+        } else {
+            throw new RuntimeException("Unsupported JCE provider identifier: " + providerIdentifier);
         }
     }
 }

--- a/components/org.wso2.micro.integrator.server/src/main/java/org/wso2/micro/integrator/server/util/Utils.java
+++ b/components/org.wso2.micro.integrator.server/src/main/java/org/wso2/micro/integrator/server/util/Utils.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.micro.integrator.server.util;
 
+import org.apache.commons.lang.StringUtils;
+import org.wso2.config.mapper.ConfigParser;
 import org.wso2.micro.integrator.server.LauncherConstants;
 
 import java.io.BufferedInputStream;
@@ -755,6 +757,23 @@ public class Utils {
             }
         }
         return properties;
+    }
+
+    /**
+     * getConfig is a convenience method to get a config value from the parsed configs
+     *
+     * @param configName - name of the config to be retrieved
+     * @return the config value as a String, or null if not found or empty
+     */
+    public static String getConfig(String configName) {
+        Object configValue = ConfigParser.getParsedConfigs().get(configName);
+        if (configValue != null) {
+            String trimmedValue = configValue.toString().trim();
+            if (StringUtils.isNotBlank(trimmedValue)) {
+                return trimmedValue;
+            }
+        }
+        return null;
     }
 
 }

--- a/distribution/src/conf/ciphertool.bat
+++ b/distribution/src/conf/ciphertool.bat
@@ -82,6 +82,16 @@ echo Using CARBON_HOME:   %CARBON_HOME%
 echo Using JAVA_HOME:    %JAVA_HOME%
 set _RUNJAVA="%JAVA_HOME%\bin\java"
 
-%_RUNJAVA% %JAVA_OPTS% -Dcarbon.home="%CARBON_HOME%" -Dcarbon.config.dir.path="%CARBON_HOME%\conf" -Dorg.wso2.CipherTransformation="RSA/ECB/OAEPwithSHA1andMGF1Padding" -cp "%CARBON_CLASSPATH%" org.wso2.ciphertool.CipherTool %*
+rem Check if -Dsymmetric is passed as an argument
+set CIPHER_TRANSFORMATION=
+set CMD_ARGS=
+for %%a in (%*) do (
+    if "%%a"=="-Dsymmetric" (
+        set CIPHER_TRANSFORMATION=-Dorg.wso2.CipherTransformation="RSA/ECB/OAEPwithSHA1andMGF1Padding"
+    )
+    set "CMD_ARGS=!CMD_ARGS! "%%~a""
+)
+
+%_RUNJAVA% %JAVA_OPTS% -Dcarbon.home="%CARBON_HOME%" -Dcarbon.config.dir.path="%CARBON_HOME%\conf" %CIPHER_TRANSFORMATION% -cp "%CARBON_CLASSPATH%" org.wso2.ciphertool.CipherTool !CMD_ARGS!
 endlocal
 :end

--- a/distribution/src/conf/ciphertool.sh
+++ b/distribution/src/conf/ciphertool.sh
@@ -123,4 +123,14 @@ if $cygwin; then
 fi
 
 # ----- Execute The Requested Command -----------------------------------------
-$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -Dcarbon.config.dir.path="$CARBON_HOME"/conf -Dorg.wso2.CipherTransformation="RSA/ECB/OAEPwithSHA1andMGF1Padding" -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool $*
+
+# Check if -Dsymmetric is passed as an argument
+CIPHER_TRANSFORMATION=""
+for arg in "$@"; do
+  if [ "$arg" = "-Dsymmetric" ]; then
+    CIPHER_TRANSFORMATION="-Dorg.wso2.CipherTransformation=RSA/ECB/OAEPwithSHA1andMGF1Padding"
+    break
+  fi
+done
+
+$JAVA_HOME/bin/java -Dcarbon.home="$CARBON_HOME" -Dcarbon.config.dir.path="$CARBON_HOME"/conf $CIPHER_TRANSFORMATION -classpath "$CARBON_CLASSPATH" org.wso2.ciphertool.CipherTool "$@"

--- a/distribution/src/conf/etc/logging-bridge.properties
+++ b/distribution/src/conf/etc/logging-bridge.properties
@@ -60,3 +60,4 @@ java.util.logging.ConsoleHandler.filter = org.wso2.micro.integrator.bootstrap.lo
 # messages:
 #com.xyz.foo.level = SEVERE
 org.wso2.micro.integrator.server.util.PatchUtils.level = FINE
+org.bouncycastle.jsse.level = WARNING

--- a/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
+++ b/distribution/src/resources/config-tool/templates/conf/carbon.xml.j2
@@ -617,4 +617,10 @@
     {% if jce_provider.provider_name is defined %}
         <JCEProvider>{{jce_provider.provider_name}}</JCEProvider>
     {% endif %}
+    <!-- Configure JSSE provider -->
+    {% if jsse_provider.provider_name is defined %}
+        <JSSEProvider>
+            <ProviderName>{{jsse_provider.provider_name}}</ProviderName>
+        </JSSEProvider>
+    {% endif %}
 </Server>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Related to https://github.com/wso2/product-micro-integrator/issues/4582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configuration keys to specify JCE provider and an optional JSSE provider; JCE selection is FIPS-aware and JSSE applied only when explicitly configured.
  * Configuration templates updated to emit optional JSSE provider block.

* **Chores**
  * Added trimmed-config helper and expanded error handling.
  * Added debug logging around provider setup and a JSSE-specific logging level.
  * Cipher tool scripts updated so the transformation flag is opt-in via an argument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->