### PR TITLE
Allow java to access unsafe memory to suppress warnings

### DIFF
--- a/distribution/src/conf/wrapper.conf
+++ b/distribution/src/conf/wrapper.conf
@@ -131,4 +131,5 @@ wrapper.java.additional.50 = --add-opens=java.base/java.lang=ALL-UNNAMED
 wrapper.java.additional.51 = --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
 wrapper.java.additional.52 = --add-opens=java.base/java.net=ALL-UNNAMED
 wrapper.java.additional.53 = --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED
-wrapper.java.additional.54 = -DenableICPApi=true
+wrapper.java.additional.54 = --sun-misc-unsafe-memory-access=allow
+wrapper.java.additional.55 = -DenableICPApi=true

--- a/distribution/src/scripts/micro-integrator.bat
+++ b/distribution/src/scripts/micro-integrator.bat
@@ -211,7 +211,7 @@ if exist "%TMP_DIR%" (
 rem ---------- Add jars to classpath --c _CLASSPATH%
 
 if %JAVA_VERSION% GEQ 110 set CARBON_CLASSPATH=.\wso2\lib\*;%CARBON_CLASSPATH%
-if %JAVA_VERSION% GEQ 110 set JAVA_VER_BASED_OPTS=--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED
+if %JAVA_VERSION% GEQ 110 set JAVA_VER_BASED_OPTS=--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow
 
 rem ---------------- Setting default profile for Runtime if not parsed --------------
 

--- a/distribution/src/scripts/micro-integrator.sh
+++ b/distribution/src/scripts/micro-integrator.sh
@@ -322,7 +322,7 @@ fi
 JAVA_VER_BASED_OPTS=""
 
 if [ $java_version_formatted -ge 1100 ]; then
-    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
+    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
 fi
 
 # start diagnostic tool in background in diagnostic-tool/bin/diagnostic


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Resolves https://github.com/wso2/product-micro-integrator/issues/4673

Note: This is a temporary mitigation step to suppress the warnings. In a future JDK version, sun.misc.Unsafe will be removed completely. At that point, we have to upgrade to the latest versions of the dependencies that are currently using the above package.
Ref: https://openjdk.org/jeps/498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JVM configuration across wrapper and startup scripts to include `--sun-misc-unsafe-memory-access=allow` flag for improved memory access handling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->