### PR TITLE
Add support to cache admin user status in message context

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ApiResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ApiResource.java
@@ -100,7 +100,7 @@ public class ApiResource extends APIResource {
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     handlePost(messageContext, axisMsgCtx);
                 } else {
                     Utils.sendForbiddenFaultResponse(axisMsgCtx);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/CarbonAppResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/CarbonAppResource.java
@@ -135,7 +135,7 @@ public class CarbonAppResource extends APIResource {
             }
             case Constants.HTTP_POST: {
                 try {
-                    if (SecurityUtils.canUserEdit(userName)) {
+                    if (SecurityUtils.canUserEdit(messageContext, userName)) {
                         handlePost(performedBy, axis2MessageContext);
                     } else {
                         Utils.sendForbiddenFaultResponse(axis2MessageContext);
@@ -148,7 +148,7 @@ public class CarbonAppResource extends APIResource {
             }
             case Constants.HTTP_DELETE: {
                 try {
-                    if (SecurityUtils.canUserEdit(userName)) {
+                    if (SecurityUtils.canUserEdit(messageContext, userName)) {
                         handleDelete(performedBy, messageContext, axis2MessageContext);
                     } else {
                         Utils.sendForbiddenFaultResponse(axis2MessageContext);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
@@ -78,7 +78,7 @@ public class ConfigsResource implements MiApiResource {
                     break;
                 }
                 case Constants.HTTP_PUT: {
-                    if (SecurityUtils.canUserEdit(userName)) {
+                    if (SecurityUtils.canUserEdit(messageContext, userName)) {
                         response = handlePut(axis2MessageContext);
                     } else {
                         Utils.sendForbiddenFaultResponse(axis2MessageContext);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConnectorResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConnectorResource.java
@@ -103,7 +103,7 @@ public class ConnectorResource implements MiApiResource {
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     if (!JsonUtil.hasAJsonPayload(axis2MessageContext)) {
                         Utils.setJsonPayLoad(axis2MessageContext, Utils.createJsonErrorObject("POST method required json payload"));
                     } else {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -142,6 +142,7 @@ public class Constants {
     public static final String PASSWORD_MASKED_VALUE = "*****";
 
     public static final String USERNAME_PROPERTY = "USERNAME";
+    public static final String IS_ADMIN_USER_PROPERTY = "IS_ADMIN_USER";
 
     // Constant QNames used in the internal-apis.xml
     public static final QName NAME_ATTR = new QName("name");

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/EndpointResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/EndpointResource.java
@@ -97,7 +97,7 @@ public class EndpointResource implements MiApiResource {
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     if (!JsonUtil.hasAJsonPayload(axis2MessageContext)) {
                         Utils.setJsonPayLoad(axis2MessageContext, Utils.createJsonErrorObject("JSON payload is missing"));
                         return true;

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ExternalVaultResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ExternalVaultResource.java
@@ -69,7 +69,7 @@ public class ExternalVaultResource extends APIResource {
             if (Utils.isDoingPOST(axis2MessageContext)) {
                 String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
                 try {
-                    if (SecurityUtils.canUserEdit(userName)) {
+                    if (SecurityUtils.canUserEdit(messageContext, userName)) {
                         handleHashiCorpPost(axis2MessageContext);
                     } else {
                         Utils.sendForbiddenFaultResponse(axis2MessageContext);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/InboundEndpointResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/InboundEndpointResource.java
@@ -91,7 +91,7 @@ public class InboundEndpointResource extends APIResource {
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     handlePost(messageContext, axisMsgCtx);
                 } else {
                     Utils.sendForbiddenFaultResponse(axisMsgCtx);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LoggingResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LoggingResource.java
@@ -132,7 +132,7 @@ public class LoggingResource extends APIResource {
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     if (jsonPayload.has(Constants.LOGGING_LEVEL)) {
                         String logLevel = jsonPayload.getString(Constants.LOGGING_LEVEL);
                         if (!isValidLogLevel(logLevel)) {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LoginResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LoginResource.java
@@ -96,7 +96,7 @@ public class LoginResource implements MiApiResource {
         JWTTokenInfoDTO newToken = new JWTTokenInfoDTO(username);
         newToken.setToken(randomUUIDString);
         try {
-            if (SecurityUtils.isAdmin(username)) {
+            if (SecurityUtils.isAdmin(messageContext, username)) {
                 newToken.setScope(AuthConstants.JWT_TOKEN_ADMIN_SCOPE);
             } else {
                 newToken.setScope(AuthConstants.JWT_TOKEN_DEFAULT_SCOPE);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/MessageProcessorResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/MessageProcessorResource.java
@@ -113,7 +113,7 @@ public class MessageProcessorResource extends APIResource {
         } else if (Utils.isDoingPOST(axis2MessageContext)) {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     if (!JsonUtil.hasAJsonPayload(axis2MessageContext)) {
                         return false;
                     }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/MetaDataResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/MetaDataResource.java
@@ -72,7 +72,7 @@ public class MetaDataResource implements MiApiResource {
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     if (!JsonUtil.hasAJsonPayload(axis2MessageContext)) {
                         Utils.setJsonPayLoad(axis2MessageContext, Utils.createJsonErrorObject("JSON payload is missing."));
                         return true;

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ProxyServiceResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ProxyServiceResource.java
@@ -106,7 +106,7 @@ public class ProxyServiceResource extends APIResource {
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     if (!JsonUtil.hasAJsonPayload(axis2MessageContext)) {
                         Utils.setJsonPayLoad(axis2MessageContext, Utils.createJsonErrorObject("JSON payload is missing"));
                         return true;

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryContentResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryContentResource.java
@@ -117,7 +117,11 @@ public class RegistryContentResource implements MiApiResource {
         } else {
             try {
                 axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
-                if (SecurityUtils.isAdmin(messageContext.getProperty(USERNAME_PROPERTY).toString())) {
+                String username = Utils.getStringPropertyFromMessageContext(messageContext, USERNAME_PROPERTY);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Processing registry " + httpMethod + " request for user: " + username);
+                }
+                if (username != null && SecurityUtils.isAdmin(messageContext, username)) {
                     switch (httpMethod) {
                     case HTTP_POST:
                         handlePost(messageContext, axis2MessageContext, registryPath, validatedPath);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java
@@ -104,7 +104,12 @@ public class RegistryPropertiesResource implements MiApiResource {
         case HTTP_POST:
             try {
                 axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
-                if (SecurityUtils.isAdmin(messageContext.getProperty(USERNAME_PROPERTY).toString())) {
+                String username = Utils.getStringPropertyFromMessageContext(messageContext, USERNAME_PROPERTY);
+                if (username != null && SecurityUtils.isAdmin(messageContext, username)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Admin user '" + username + "' authorized to POST registry properties at: "
+                                + registryPath);
+                    }
                     handlePost(messageContext, axis2MessageContext, registryPath, validatedPath);
                 } else {
                     Utils.sendForbiddenFaultResponse(axis2MessageContext);
@@ -118,7 +123,12 @@ public class RegistryPropertiesResource implements MiApiResource {
         case HTTP_DELETE:
             try {
                 axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
-                if (SecurityUtils.isAdmin(messageContext.getProperty(USERNAME_PROPERTY).toString())) {
+                String username = Utils.getStringPropertyFromMessageContext(messageContext, USERNAME_PROPERTY);
+                if (username != null && SecurityUtils.isAdmin(messageContext, username)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Admin user '" + username + "' authorized to DELETE registry properties at: "
+                                + registryPath);
+                    }
                     handleDelete(messageContext, axis2MessageContext, registryPath, validatedPath);
                 } else {
                     Utils.sendForbiddenFaultResponse(axis2MessageContext);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/SequenceResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/SequenceResource.java
@@ -85,7 +85,7 @@ public class SequenceResource extends APIResource {
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     handlePost(messageContext, axisMsgCtx);
                 } else {
                     Utils.sendForbiddenFaultResponse(axisMsgCtx);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/TaskResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/TaskResource.java
@@ -102,7 +102,7 @@ public class TaskResource extends APIResource {
             org.apache.axis2.context.MessageContext axisMsgCtx =
                     ((Axis2MessageContext) messageContext).getAxis2MessageContext();
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(messageContext, userName)) {
                     handlePost(messageContext, axisMsgCtx);
                 } else {
                     Utils.sendForbiddenFaultResponse(axisMsgCtx);

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/TemplateResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/TemplateResource.java
@@ -102,7 +102,7 @@ public class TemplateResource extends APIResource {
             JSONObject response;
             String userName = (String) msgCtx.getProperty(USERNAME_PROPERTY);
             try {
-                if (SecurityUtils.canUserEdit(userName)) {
+                if (SecurityUtils.canUserEdit(msgCtx, userName)) {
                     JsonObject payload = Utils.getJsonPayload(axis2MsgCtx);
                     if (payload.has(TEMPLATE_TYPE_PARAM)) {
                         templateTypeParam = payload.get(TEMPLATE_TYPE_PARAM).getAsString();

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandler.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandler.java
@@ -80,13 +80,28 @@ public class AuthorizationHandler extends AuthorizationHandlerAdapter {
             try {
                 return processAuthorizationWithCarbonUserStore(userName);
             } catch (UserStoreException e) {
-                LOG.error("Error while authenticating with carbon user store", e);
+                LOG.error("Error while authorizing with carbon user store", e);
                 return false;
             }
         } else {
             //Uses in memory user store
             return processAuthorizationWithFileBasedUserStore(userName);
         }
+    }
+
+    @Override
+    protected Boolean authorize(String userName, MessageContext messageContext) {
+        // Delegate to single-arg overload to obtain admin status
+        Boolean isAdmin = authorize(userName);
+
+        // Set IS_ADMIN_USER property for the logged-in user to optimize subsequent admin checks
+        if (messageContext != null) {
+            messageContext.setProperty(Constants.IS_ADMIN_USER_PROPERTY, isAdmin);
+        } else {
+            LOG.warn("MessageContext is null; cannot set admin user property.");
+        }
+
+        return isAdmin;
     }
 
     /**

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandlerAdapter.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/AuthorizationHandlerAdapter.java
@@ -60,7 +60,7 @@ public abstract class AuthorizationHandlerAdapter extends SecurityHandlerAdapter
         }
 
         if (Objects.nonNull(userName)) {
-            if (authorize(userName)) {
+            if (authorize(userName, messageContext)) {
                 return true;
             } else {
                 SecurityUtils.setStatusCode(messageContext, AuthConstants.SC_FORBIDDEN);
@@ -74,10 +74,27 @@ public abstract class AuthorizationHandlerAdapter extends SecurityHandlerAdapter
     }
 
     /**
-     * Executes the authentication logic relevant to the handler.
+     * Executes the authorization logic relevant to the handler.
+     * Default implementation calls authorize(String) for backward compatibility.
+     * Implementations should override this method if they need to set properties in the MessageContext
+     * (e.g., IS_ADMIN_USER_PROPERTY if checking admin status).
      *
      * @param userName user name of the logged in user
-     * @return Boolean authenticated
+     * @param messageContext the message context where properties can be set
+     * @return Boolean authorized
+     */
+    protected Boolean authorize(String userName, MessageContext messageContext) {
+        // Default implementation calls the original method for backward compatibility
+        return authorize(userName);
+    }
+
+    /**
+     * Executes the authorization logic relevant to the handler.
+     * This method is called by the default implementation of authorize(String, MessageContext).
+     * Legacy implementations should implement this method.
+     *
+     * @param userName user name of the logged in user
+     * @return Boolean authorized
      */
     protected abstract Boolean authorize(String userName);
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityUtils.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/security/handler/SecurityUtils.java
@@ -20,6 +20,8 @@ package org.wso2.micro.integrator.management.apis.security.handler;
 
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.commons.crypto.CryptoConstants;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
@@ -35,6 +37,8 @@ import java.util.Map;
 import javax.xml.namespace.QName;
 
 public class SecurityUtils {
+
+    private static final Log LOG = LogFactory.getLog(SecurityUtils.class);
 
     /**
      * Returns the transport header map of a given axis2 message context.
@@ -109,17 +113,71 @@ public class SecurityUtils {
     /**
      * Method to assert if a user is an admin.
      *
+     * Note: For better performance, use isAdmin(MessageContext, String) when MessageContext is available,
+     * as it can leverage the IS_ADMIN_USER property set by authentication/authorization handlers.
+     *
      * @param username the user to be validated as an admin
      * @return true if the admin role is assigned to the user
      * @throws UserStoreException if any error occurs while retrieving the user store manager or reading the user realm
      *                            configuration
      */
     public static boolean isAdmin(String username) throws UserStoreException {
+        // Early null check to prevent NPEs in user store methods
+        if (username == null) {
+            return false;
+        }
+        // Fall back to user store check
         if (isFileBasedUserStoreEnabled()) {
             return FileBasedUserStoreManager.getUserStoreManager().isAdmin(username);
         } else {
             return MicroIntegratorSecurityUtils.isAdmin(username);
         }
+    }
+
+    /**
+     * Method to assert if a user is an admin, with support for generic IS_ADMIN_USER property.
+     * This method first checks if the IS_ADMIN_USER property is set in the MessageContext
+     * (which can be set by any authentication/authorization handler such as ICP JWT, OAuth, etc.).
+     * If not set, it falls back to the regular user store lookup.
+     *
+     * SECURITY: The cached property only applies to the logged-in user. If checking a different user,
+     * this method will fall back to user store query.
+     *
+     * @param messageContext the message context that may contain the IS_ADMIN_USER property
+     * @param username the user to be validated as an admin
+     * @return true if the admin role is assigned to the user or if IS_ADMIN_USER property is true
+     * @throws UserStoreException if any error occurs while retrieving the user store manager or reading the user realm
+     *                            configuration
+     */
+    public static boolean isAdmin(MessageContext messageContext, String username) throws UserStoreException {
+        // Early null check to prevent NPEs in user store methods
+        if (username == null) {
+            return false;
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Checking admin status for user: " + username);
+        }
+        // First check if IS_ADMIN_USER property is set by authentication handler
+        if (messageContext != null) {
+            Object isAdminProperty = messageContext.getProperty(Constants.IS_ADMIN_USER_PROPERTY);
+            if (Boolean.TRUE.equals(isAdminProperty)) {
+                // SECURITY: Only use cached property if checking the logged-in user
+                Object loggedInUserObj = messageContext.getProperty(Constants.USERNAME_PROPERTY);
+                if (loggedInUserObj != null) {
+                    String loggedInUser = loggedInUserObj.toString();
+                    if (username.equals(loggedInUser)) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Admin status retrieved from cached IS_ADMIN_USER property for user: "
+                                    + username);
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // Fall back to regular user store check
+        return isAdmin(username);
     }
 
     /**
@@ -145,6 +203,28 @@ public class SecurityUtils {
         if (userName == null) {
             return true;
         }
-        return isAdmin(userName) || !isNonAdminUsersReadOnly();
+        // Return true if non-admin users can edit, or if user is admin (short-circuits to avoid unnecessary lookup)
+        return !isNonAdminUsersReadOnly() || isAdmin(userName);
+    }
+
+    /**
+     * Determines if the specified user has permission to edit, with support for generic IS_ADMIN_USER property.
+     * This method first checks if the IS_ADMIN_USER property is set in the MessageContext
+     * (which can be set by any authentication/authorization handler such as ICP JWT, OAuth, etc.).
+     *
+     * Admin users always have edit permissions. For non-admin users, the edit permission depends
+     * on the configuration: if make_non_admin_users_read_only == true, they cannot edit; otherwise, they can.
+     *
+     * @param messageContext the message context that may contain the IS_ADMIN_USER property
+     * @param userName the name of the user to check for edit permissions
+     * @return {@code true} if the user has edit permissions, {@code false} otherwise
+     * @throws UserStoreException if there is an error accessing the user store
+     */
+    public static boolean canUserEdit(MessageContext messageContext, String userName) throws UserStoreException {
+        if (userName == null) {
+            return true;
+        }
+        // Return true if non-admin users can edit, or if user is admin (short-circuits to avoid unnecessary lookup)
+        return !isNonAdminUsersReadOnly() || isAdmin(messageContext, userName);
     }
 }


### PR DESCRIPTION
  ## Purpose

Add support to cache admin user status in message context for Management API.

Current Issues:
  - Every call to SecurityUtils.isAdmin(username) triggers a user store query
  - Significant performance overhead on high-traffic systems
  - Cannot support external authentication mechanisms (ICP JWT, OAuth) that determine
  admin status from JWT claims

 ## Goals

  Implement a generic caching mechanism to:
  1. Enable admin status determination from JWT claims for external authentication systems
  2.  Reduce redundant user store queries
  3. Improve request processing performance
  4. Maintain backward compatibility with existing authorization handlers

 ## Approach

  Introduced an IS_ADMIN_USER_PROPERTY in MessageContext that caches admin status during
  request authorization:

 ### Request Flow

  Authentication → Authorization (sets IS_ADMIN_USER_PROPERTY) → Resource methods (use 
  cached value)

 ### Security Considerations

  - Property is request-scoped (MessageContext is unique per request)
  - Username validation ensures cached property only applies to logged-in user
  - Falls back to user store query if property not set or username mismatch
  - Only Boolean.TRUE accepted as admin status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Management APIs now use the request context for authorization checks, standardizing permission evaluation across endpoints.

* **New Features**
  * Per-request admin evaluation with caching to streamline permission decisions and reduce repeated lookups.

* **Chore**
  * Added a request-scoped admin flag to support the new per-request authorization flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->