### PR TITLE
[WINDOWS] Change product display name for Windows service

### DIFF
--- a/distribution/src/conf/wrapper.conf
+++ b/distribution/src/conf/wrapper.conf
@@ -38,16 +38,16 @@ wrapper.logfile.maxsize=10m
 #  files are deleted.  The default value of 0 implies no limit.
 wrapper.logfile.maxfiles=10
 # Title to use when running as a console
-wrapper.console.title="WSO2 Micro Integrator"
+wrapper.console.title="WSO2 Integrator: MI"
 #********************************************************************
 # Wrapper Windows Service and Posix Daemon Properties
 #********************************************************************
 # Name of the service
 wrapper.ntservice.name=WSO2MI
 # Display name of the service
-wrapper.ntservice.displayname=WSO2 Micro Integrator ${product.version}
+wrapper.ntservice.displayname=WSO2 Integrator: MI ${product.version}
 # Description of the service
-wrapper.ntservice.description=Provides the ability to run WSO2 Micro Integrator ${product.version} as a Windows Service
+wrapper.ntservice.description=Provides the ability to run WSO2 Integrator: MI ${product.version} as a Windows Service
 #********************************************************************
 # Wrapper System Tray Properties
 #********************************************************************


### PR DESCRIPTION
## Purpose
> Add display name for windows service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product branding references from "WSO2 Micro Integrator" to "WSO2 Integrator: MI" in console display title and Windows service configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->