### PR TITLE
Add group and class details for tasks in ICP heartbeat

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/ICPHeartBeatComponent.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/ICPHeartBeatComponent.java
@@ -1331,9 +1331,9 @@ public class ICPHeartBeatComponent {
                             taskClass = desc.getTaskImplClassName();
                         }
                     }
-                } catch (Exception ignored) {
+                } catch (Exception ex) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Error retrieving task details for task: " + name, ignored);
+                        log.debug("Error retrieving task details for task: " + name, ex);
                     }
                     // If repository lookup fails, leave taskGroup and taskClass null
                 }


### PR DESCRIPTION
## Purpose

Adds the missing group and class details for tasks to the heartbeat sent to ICP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when task repository lookup fails; task-related fields now safely default to empty values and failures are logged.

* **Refactor**
  * Payload field renamed from "taskGroup" to "group".
  * Added a new "class" field exposing the task implementation class; payloads now consistently include "group" and "class" (empty strings when unknown).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->