### PR TITLE
Remove JaegerTelemetryManager references and replace with OTLPTelemetryManager

### DIFF
--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -86,7 +86,7 @@
   "synapse_properties.'opentelemetry.host'": "localhost",
   "synapse_properties.'opentelemetry.port'":  "14250",
   "synapse_properties.'opentelemetry.service.name'": "WSO2-SYNAPSE",
-  "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.JaegerTelemetryManager",
+  "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.OTLPTelemetryManager",
   "synapse_properties.'opentelemetry.protocol'": "grpc",
 
   "synapse_properties.'analytics.enabled'": false,

--- a/distribution/src/resources/config-tool/deployment-full.toml
+++ b/distribution/src/resources/config-tool/deployment-full.toml
@@ -888,7 +888,7 @@ enable = false
 host="localhost"
 port="14250"
 service_name="WSO2-SYNAPSE"
-class="org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.JaegerTelemetryManager"
+class="org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.OTLPTelemetryManager"
 
 ###################################   Database configurations   ###################################
 [[datasource]]

--- a/distribution/src/resources/config-tool/infer.json
+++ b/distribution/src/resources/config-tool/infer.json
@@ -170,9 +170,6 @@
     }
   },
   "opentelemetry.type": {
-    "jaeger": {
-      "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.JaegerTelemetryManager"
-    },
     "zipkin": {
       "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.ZipkinTelemetryManager"
     },


### PR DESCRIPTION
# Purpose
The main change is replacing the Jaeger telemetry manager class with the OTLP telemetry manager class in configuration files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated telemetry backend configuration from Jaeger to OTLP (OpenTelemetry Protocol).
  * Removed deprecated Jaeger telemetry configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->