### PR TITLE
Register mediators in on-cache-hit sequence

### DIFF
--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -419,17 +419,25 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                         + "sequence : " + onCacheHitRef);
             }
             ContinuationStackManager.updateSeqContinuationState(synCtx, getMediatorPosition());
-            SequenceMediator onCacheHitSeq = (SequenceMediator) synCtx.getSequence(onCacheHitRef);
+            Mediator onCacheHitMediator = synCtx.getSequence(onCacheHitRef);
+            if (onCacheHitMediator == null) {
+                handleException("Sequence named '" + onCacheHitRef + "' does not exist", synCtx);
+            }
 
-            // Handle coverage tracking for referenced sequence in unit tests mode
-            String originalArtifactKey = CoverageUtils.handleCoverageForReferencedSequence(
-                    synCtx, onCacheHitSeq, onCacheHitRef);
+            // Handle coverage tracking for referenced sequence in unit tests mode,
+            if (onCacheHitMediator instanceof SequenceMediator) {
+                SequenceMediator onCacheHitSeq = (SequenceMediator) onCacheHitMediator;
+                String originalArtifactKey = CoverageUtils.handleCoverageForReferencedSequence(
+                        synCtx, onCacheHitSeq, onCacheHitRef);
 
-            try {
-                onCacheHitSeq.mediate(synCtx);
-            } finally {
-                // Restore original artifact key for unit test coverage
-                CoverageUtils.restoreCoverageArtifactKey(synCtx, originalArtifactKey);
+                try {
+                    onCacheHitMediator.mediate(synCtx);
+                } finally {
+                    // Restore original artifact key for unit test coverage
+                    CoverageUtils.restoreCoverageArtifactKey(synCtx, originalArtifactKey);
+                }
+            } else {
+                onCacheHitMediator.mediate(synCtx);
             }
 
         } else {


### PR DESCRIPTION
## Purpose
> Register mediators in on-cache-hit sequence

Fixes: https://github.com/wso2/product-micro-integrator/issues/4682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache mediator now exposes on-cache-hit sequences to tooling, enabling visibility and management of cache-hit behavior from the UI.
  * Tooling can enumerate on-cache-hit child sequences for improved configuration and inspection.

* **Bug Fixes**
  * Preserves test-coverage state when delegating to on-cache-hit sequences, ensuring accurate coverage reporting after cache-hit execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->