### PR TITLE
Fix test failure

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA4394.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA4394.java
@@ -50,7 +50,7 @@ public class ESBJAVA4394 extends ESBIntegrationTest {
              * since we are making a soap fault in the configuration axis2 client receives axis fault.
              */
             String axisFaultMessage = axisFault.getMessage();
-            assertTrue(axisFaultMessage.contains("101508"));
+            assertTrue(axisFaultMessage.contains("101503"));
         }
     }
 


### PR DESCRIPTION
### Purpose
Update the ESBJAVA4394 test case to align with the fix: https://github.com/wso2/wso2-synapse/pull/2431

### Summary

In the test, since the request is written through the reachable first hop and the downstream side terminates later, [`endOfInput()`](https://github.com/wso2/wso2-synapse/blob/f48d933256169ae715627ea8d16c9dbac61ed89f/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java#L1095) is triggered while the state is `REQUEST_DONE`.

Previously, `endOfInput()` method only invoked `conn.close()`. As a result, [`closed()`](https://github.com/wso2/wso2-synapse/blob/f48d933256169ae715627ea8d16c9dbac61ed89f/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java#L801) method was triggered later to handle the fault while the state was still `REQUEST_DONE`. Then, `handleError()` was called with `CONNECTION_CLOSED` (base error code `101505`) and state `REQUEST_DONE` (ordinal `3`) [[1]](https://github.com/wso2/wso2-synapse/blob/f48d933256169ae715627ea8d16c9dbac61ed89f/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetHandler.java#L858-L862).

Inside `handleError()`, the final error is computed as: `finalError = baseErrorCode + state.ordinal()`[[2]](https://github.com/wso2/wso2-synapse/blob/f48d933256169ae715627ea8d16c9dbac61ed89f/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/TargetErrorHandler.java#L170-L172)

So the final error became `101508`, which was asserted in the test.


However, after changing `endOfInput()` with PR [[3]](https://github.com/wso2/wso2-synapse/pull/2431) to directly call `handleError()` with `SND_IO_ERROR` (base error code `101500`) using the same state, the base error code changed to `101500` while the state remained `REQUEST_DONE` (ordinal `3`). As a result, the final error became `101503`.

### Related PRs
https://github.com/wso2/product-micro-integrator/pull/4312 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted SOAP fault validation so the system now recognizes and reports the correct fault code (101503) in relevant failure scenarios, improving error accuracy and test alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->