### PR TITLE
Revert "Bump org.apache.tomcat.embed:tomcat-embed-core from 7.0.93 to 9.0.113 in /integration"

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -785,7 +785,7 @@
         <org.apache.cxf.version>3.5.9</org.apache.cxf.version>
         <org.codehaus.jackson.version>1.9.12</org.codehaus.jackson.version>
         <org.springframework.ws.wso2.version>3.1.0.wso2v1</org.springframework.ws.wso2.version>
-        <org.apache.tomcat>9.0.113</org.apache.tomcat>
+        <org.apache.tomcat>7.0.93</org.apache.tomcat>
         <org.springframework.version>4.1.5.RELEASE</org.springframework.version>
         <com.google.code.gson.version>2.13.2</com.google.code.gson.version>
         <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
Reverts wso2/product-micro-integrator#4718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated embedded Tomcat dependency version in integration module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->