### PR TITLE
[master] Fix FAT CAR deployment issue in Windows 

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/AppDeployerUtils.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/AppDeployerUtils.java
@@ -84,6 +84,7 @@ public final class AppDeployerUtils {
 	private static final String LOCAL_REGISTRY_PREFIX = "local:";
 	private static final String RESOURCES_PREFIX = "resources:";
 	public static final String DEPENDENCIES_DIR = "dependencies/";
+	public static final String DEPENDENCIES_DIR_NAME = "dependencies";
 
 	private AppDeployerUtils() {
 		// hide utility class

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/utils/DeployerUtil.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/utils/DeployerUtil.java
@@ -226,11 +226,17 @@ public class DeployerUtil {
      * @return A list of `CAppDescriptor` objects corresponding to the provided CApp files.
      */
     public static List<CAppDescriptor> getCAppDescriptors(File[] cAppFiles) throws DeploymentException {
+        if (log.isDebugEnabled()) {
+            log.debug("Processing " + cAppFiles.length + " CApp files for descriptors");
+        }
         List<CAppDescriptor> cAppDescriptors = new ArrayList<>();
         for (File cAppFile : cAppFiles) {
             // Skip virtual paths for nested CARs inside a FAT CAR archive
             // (e.g. "outerApp.car/dependencies/innerApp.car" on Unix or "outerApp.car\dependencies\innerApp.car" on Windows)
             if (cAppFile.getPath().contains(AppDeployerUtils.DEPENDENCIES_DIR_NAME + File.separator)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Skipping nested CAR file: " + cAppFile.getPath());
+                }
                 continue;
             }
             CAppDescriptor descriptor = new CAppDescriptor(cAppFile);

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/utils/DeployerUtil.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/utils/DeployerUtil.java
@@ -228,7 +228,9 @@ public class DeployerUtil {
     public static List<CAppDescriptor> getCAppDescriptors(File[] cAppFiles) throws DeploymentException {
         List<CAppDescriptor> cAppDescriptors = new ArrayList<>();
         for (File cAppFile : cAppFiles) {
-            if (cAppFile.getPath().contains(AppDeployerUtils.DEPENDENCIES_DIR)) {
+            // Skip virtual paths for nested CARs inside a FAT CAR archive
+            // (e.g. "outerApp.car/dependencies/innerApp.car" on Unix or "outerApp.car\dependencies\innerApp.car" on Windows)
+            if (cAppFile.getPath().contains(AppDeployerUtils.DEPENDENCIES_DIR_NAME + File.separator)) {
                 continue;
             }
             CAppDescriptor descriptor = new CAppDescriptor(cAppFile);

--- a/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/utils/DeployerUtilTest.java
+++ b/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/utils/DeployerUtilTest.java
@@ -19,6 +19,8 @@
 package org.wso2.micro.integrator.initializer.utils;
 
 import org.apache.axis2.deployment.DeploymentException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +46,7 @@ import static org.wso2.micro.integrator.initializer.utils.Constants.DOUBLE_UNDER
 
 public class DeployerUtilTest {
 
+    private static final Log log = LogFactory.getLog(DeployerUtilTest.class);
     private File tempDir;
 
     public static File createCarFile(File dir, String carFileName) throws IOException {
@@ -73,6 +76,7 @@ public class DeployerUtilTest {
                                         String groupId, String artifactId, String version,
                                         String depGroupId, String depArtifactId, String depVersion) throws Exception {
 
+        log.info("Creating FAT CAR file: " + fatCarName + "  with dependency: " + depCarName);
         // Build the nested dependency CAR bytes in memory
         byte[] depCarBytes;
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -88,6 +92,7 @@ public class DeployerUtilTest {
             depZos.closeEntry();
             depZos.finish();
             depCarBytes = baos.toByteArray();
+            log.debug("Created dependency CAR in memory, size: " + depCarBytes.length + " bytes");
         }
 
         // Build the outer FAT CAR

--- a/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/utils/DeployerUtilTest.java
+++ b/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/utils/DeployerUtilTest.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -64,6 +65,57 @@ public class DeployerUtilTest {
         return carFile;
     }
 
+    /**
+     * Creates a FAT CAR file containing a nested dependency CAR under dependencies dir.
+     * The outer FAT CAR has fatCarEnabled=true in its descriptor.xml.
+     */
+    public static File createFatCarFile(File dir, String fatCarName, String depCarName,
+                                        String groupId, String artifactId, String version,
+                                        String depGroupId, String depArtifactId, String depVersion) throws Exception {
+
+        // Build the nested dependency CAR bytes in memory
+        byte[] depCarBytes;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ZipOutputStream depZos = new ZipOutputStream(baos)) {
+            depZos.putNextEntry(new ZipEntry("descriptor.xml"));
+            String depDescriptor = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project>\n<id>"
+                    + depGroupId + DOUBLE_UNDERSCORE + depArtifactId + DOUBLE_UNDERSCORE + depVersion
+                    + "</id>\n<dependencies>\n</dependencies>\n</project>";
+            depZos.write(depDescriptor.getBytes());
+            depZos.closeEntry();
+            depZos.putNextEntry(new ZipEntry("artifacts.xml"));
+            depZos.write(new byte[0]);
+            depZos.closeEntry();
+            depZos.finish();
+            depCarBytes = baos.toByteArray();
+        }
+
+        // Build the outer FAT CAR
+        File fatCarFile = new File(dir, fatCarName);
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(fatCarFile))) {
+            // descriptor.xml with fatCarEnabled=true and one dependency
+            zos.putNextEntry(new ZipEntry("descriptor.xml"));
+            String depRef = "<dependency groupId=\"" + depGroupId + "\" artifactId=\"" + depArtifactId
+                    + "\" version=\"" + depVersion + "\" type=\"car\"/>";
+            String descriptor = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project>\n<id>"
+                    + groupId + DOUBLE_UNDERSCORE + artifactId + DOUBLE_UNDERSCORE + version
+                    + "</id>\n<fatCarEnabled>true</fatCarEnabled>\n<dependencies>\n"
+                    + depRef + "\n</dependencies>\n</project>";
+            zos.write(descriptor.getBytes());
+            zos.closeEntry();
+
+            // Embed the dependency CAR under dependencies/
+            zos.putNextEntry(new ZipEntry("dependencies/" + depCarName));
+            zos.write(depCarBytes);
+            zos.closeEntry();
+
+            zos.putNextEntry(new ZipEntry("artifacts.xml"));
+            zos.write(new byte[0]);
+            zos.closeEntry();
+        }
+        return fatCarFile;
+    }
+
     public static void writeDescriptorToExistingCarFile(File carFile, String groupId, String artifactId, String version,
                                                         String... dependencies) throws Exception {
 
@@ -98,6 +150,45 @@ public class DeployerUtilTest {
             file.delete();
         }
         tempDir.delete();
+    }
+
+    @Test
+    public void testGetCAppDescriptorsWithFatCar() throws Exception {
+
+        File fatCarFile = createFatCarFile(tempDir, "beta1_1.0.0.car", "beta2-1.0.0.car",
+                "com.example", "beta1", "1.0.0",
+                "com.example", "beta2", "1.0.0");
+
+        List<CAppDescriptor> descriptors = DeployerUtil.getCAppDescriptors(new File[]{fatCarFile});
+
+        assertEquals("Should have 2 descriptors: outer FAT CAR and its nested dependency", 2, descriptors.size());
+        assertTrue(descriptors.stream().anyMatch(d -> "com.example__beta1__1.0.0".equals(d.getCAppId())));
+        assertTrue(descriptors.stream().anyMatch(d -> "com.example__beta2__1.0.0".equals(d.getCAppId())));
+    }
+
+    @Test
+    public void testGetCAppDescriptorsSkipsNestedCARPathsInsideFatCAR() throws Exception {
+        // This test simulates what CappDeployer.sort() does: it creates a synthetic File path
+        // for the nested CAR (path traverses through the outer .car file as if it were a directory).
+        // getCAppDescriptors must skip such synthetic paths to avoid duplicate processing.
+
+        File fatCarFile = createFatCarFile(tempDir, "beta1_1.0.0.car", "beta2-1.0.0.car",
+                "com.example", "beta1", "1.0.0",
+                "com.example", "beta2", "1.0.0");
+
+        // Simulate the synthetic dependency path that sort() creates
+        // (e.g., /tmp/.../beta1_1.0.0.car/dependencies/beta2-1.0.0.car on Unix,
+        //        C:\...\beta1_1.0.0.car\dependencies\beta2-1.0.0.car on Windows)
+        File syntheticDependencyPath = new File(fatCarFile.getAbsolutePath()
+                + File.separator + "dependencies" + File.separator + "beta2-1.0.0.car");
+
+        List<CAppDescriptor> descriptors = DeployerUtil.getCAppDescriptors(
+                new File[]{fatCarFile, syntheticDependencyPath});
+
+        // Should still be 2 descriptors (the synthetic path must be skipped, not processed again)
+        assertEquals("Synthetic nested CAR path must be skipped; expected 2 descriptors", 2, descriptors.size());
+        assertTrue(descriptors.stream().anyMatch(d -> "com.example__beta1__1.0.0".equals(d.getCAppId())));
+        assertTrue(descriptors.stream().anyMatch(d -> "com.example__beta2__1.0.0".equals(d.getCAppId())));
     }
 
     @Test

--- a/distribution/src/scripts/micro-integrator.bat
+++ b/distribution/src/scripts/micro-integrator.bat
@@ -44,7 +44,13 @@ goto end
 rem ----- Only set CARBON_HOME if not already set ----------------------------
 :checkServer
 rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
-SET CARBON_HOME=%~sdp0..
+pushd "%~sdp0.."
+if errorlevel 1 (
+    SET "CARBON_HOME=%~sdp0.."
+) else (
+    SET "CARBON_HOME=%CD%"
+    popd
+)
 SET curDrive=%cd:~0,1%
 SET wsasDrive=%CARBON_HOME:~0,1%
 if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:

--- a/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/hotdeployment/test/Log4j2ConfigsHotDeploymentTestCase.java
+++ b/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/hotdeployment/test/Log4j2ConfigsHotDeploymentTestCase.java
@@ -81,6 +81,7 @@ public class Log4j2ConfigsHotDeploymentTestCase extends ESBIntegrationTest {
     }
 
     private void deployLog4j2ConfigWithWireLogs() throws Exception {
+        log.info("Deploying log4j2 configuration with wire logs enabled");
         String log4jFile = SOURCE_DIR + "log4j2withWire.properties";
         File destFile = new File(SERVER_CONF_DIR + "log4j2.properties");
         FileUtils.copyFile(new File(log4jFile), destFile, false);
@@ -89,6 +90,7 @@ public class Log4j2ConfigsHotDeploymentTestCase extends ESBIntegrationTest {
     }
 
     private void undeployLog4j2ConfigWithWireLogs() throws Exception {
+        log.info("Reverting log4j2 configuration to default (wire logs disabled)");
         String log4jFile = SOURCE_DIR + "log4j2.properties";
         File destFile = new File(SERVER_CONF_DIR + "log4j2.properties");
         FileUtils.copyFile(new File(log4jFile), destFile, false);


### PR DESCRIPTION
## Purpose
This PR will introduce the following changes:

- Nested CAR apps inside FAT CAR are skipped properly without considering again
- Add tests for skipping nested CARs inside FAT CAR
- Set CARBON_HOME without path traversals, because it causes `Zip Slip Blocked` error during nested CApp extraction
- Add deploy/undeploy logs to Log4j2ConfigsHotDeploymentTestCase

Fixes: https://github.com/wso2/product-micro-integrator/issues/4739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested dependency path handling inside composite archives to prevent double-processing; improved startup script path resolution on Windows.

* **Tests**
  * Added tests and a helper to validate composite archives with embedded dependencies and ensure synthetic/nested paths are skipped.

* **Chores**
  * Added informational/debug logging around descriptor processing and hot-deployment config steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->