### PR TITLE
Fix incorrect default Jaeger service name in OpenTelemetry config

### DIFF
--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -85,7 +85,7 @@
   "synapse_properties.'opentelemetry.enable'": false,
   "synapse_properties.'opentelemetry.host'": "localhost",
   "synapse_properties.'opentelemetry.port'":  "14250",
-  "synapse_properties.'opentelemetry.service.name'": "WSO2-SYNAPSE",
+  "synapse_properties.'opentelemetry.service.name'": "wso2-synapse",
   "synapse_properties.'opentelemetry.class'": "org.apache.synapse.aspects.flow.statistics.tracing.opentelemetry.management.OTLPTelemetryManager",
   "synapse_properties.'opentelemetry.protocol'": "grpc",
 

--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -128,6 +128,7 @@
   "opentelemetry.class": "synapse_properties.'opentelemetry.class'",
   "opentelemetry.protocol": "synapse_properties.'opentelemetry.protocol'",
   "opentelemetry.metric.push.interval.seconds": "synapse_properties.'opentelemetry.metric.push.interval.seconds'",
+  "opentelemetry.service_name": "synapse_properties.'opentelemetry.service.name'",
 
   "opentelemetry.filtered.mediator.names": "synapse_properties.'oltp.filtered.mediator.names'",
   "opentelemetry.custom.span.header.tags": "synapse_properties.'oltp.custom.span.header.tags'",


### PR DESCRIPTION
## Summary

- Changes the default value of `opentelemetry.service.name` in `distribution/src/resources/config-tool/default.json` from `WSO2-SYNAPSE` to `wso2-synapse`.
- The bundled Grafana dashboards filter traces using `wso2-synapse` (lowercase). Since Jaeger service names are case-sensitive, the old default (`WSO2-SYNAPSE`) caused the Grafana → Jaeger trace link to find no matching service, forcing users to manually retype the name.
- This one-character-case change makes the default service name consistent with the Grafana dashboard expectations out of the box.

## Root Cause

`TelemetryConstants.SERVICE_NAME` is hard-coded as `"WSO2-SYNAPSE"`. The config-tool default was also `"WSO2-SYNAPSE"`, but the Grafana dashboard templates ship with `wso2-synapse` (lowercase) as the service-name filter. Jaeger is case-sensitive, so the mismatch breaks the Grafana → Jaeger navigation.

## Test plan

- [ ] Start MI with default `deployment.toml` (no `service_name` override).
- [ ] Verify `conf/synapse.properties` contains `opentelemetry.service.name = wso2-synapse`.
- [ ] Enable OpenTelemetry (`opentelemetry.enable = true`) and confirm spans are published to Jaeger under the service name `wso2-synapse`.
- [ ] Open the bundled Grafana dashboard and click a trace link — confirm it navigates to the correct service in Jaeger without requiring a manual name change.

Fixes #4200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated OpenTelemetry service name configuration to use lowercase format for improved consistency with naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->