### PR TITLE
Add integration test for PayloadFactory $n-in-variable-values bug (Issue #4623)

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/payload/factory/PayloadFactorySynapseExpressionTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/payload/factory/PayloadFactorySynapseExpressionTestCase.java
@@ -176,6 +176,32 @@ public class PayloadFactorySynapseExpressionTestCase extends ESBIntegrationTest 
         assertEquals(responseJSON, expectedJSON, "Response payload mismatched");
     }
 
+    /**
+     * Issue #4623: PayloadFactory default template must not throw IllegalArgumentException when a
+     * variable value contains $ followed by a digit (e.g. Java stack traces such as
+     * NativeWorkerPool$1.run or ThreadPoolExecutor$Worker).
+     */
+    @Test(groups = {"wso2.esb"}, description =
+            "Testing PayloadFactory with dollar sign followed by digit in variable values (Issue 4623)")
+    public void testPayloadFactoryWithDollarSignInVariableValues() throws IOException {
+
+        String expectedResponse = "{" +
+                "\"errorClass\":\"java.util.concurrent.ThreadPoolExecutor\"," +
+                "\"errorCode\":\"500\"," +
+                "\"message\":\"Internal Server Error\"," +
+                "\"detail\":\"ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\"," +
+                "\"exception\":\"NativeWorkerPool$1.run(NativeWorkerPool.java:206)\"" +
+                "}";
+
+        String serviceURL = getMainSequenceURL() + "synapseExpressionPayload/dollar-in-vars";
+        HttpResponse httpResponse = httpClient.doGet(serviceURL, null);
+        String responsePayload = httpClient.getResponsePayload(httpResponse);
+        Assert.assertNotNull(responsePayload, "Response payload must not be null — server likely threw IllegalArgumentException");
+        JsonElement responseJSON = JsonParser.parseString(responsePayload);
+        JsonElement expectedJSON = JsonParser.parseString(expectedResponse);
+        assertEquals(responseJSON, expectedJSON, "Variable values containing $ were not preserved correctly");
+    }
+
     @Test(groups = {"wso2.esb"}, description = "Testing Payload factory mediator with Freemarker template")
     public void testPayloadFactoryFreemarker() throws IOException {
 

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/synapse_expressions_payload_factory.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/synapse_expressions_payload_factory.xml
@@ -98,6 +98,26 @@
         <faultSequence>
         </faultSequence>
     </resource>
+    <!-- Issue #4623: variables whose runtime value contains $ followed by a digit -->
+    <resource methods="GET" uri-template="/dollar-in-vars">
+        <inSequence>
+            <variable name="ERR_CLASS" value="java.util.concurrent.ThreadPoolExecutor"/>
+            <variable name="ERR_CODE" value="500"/>
+            <variable name="ERR_MESSAGE" value="Internal Server Error"/>
+            <variable name="ERR_DETAIL" value="ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)"/>
+            <variable name="ERR_EXCEPTION" value="NativeWorkerPool$1.run(NativeWorkerPool.java:206)"/>
+            <payloadFactory media-type="json">
+                <format><![CDATA[{
+                    "errorClass": "${vars.ERR_CLASS}",
+                    "errorCode": "${vars.ERR_CODE}",
+                    "message": "${vars.ERR_MESSAGE}",
+                    "detail": "${vars.ERR_DETAIL}",
+                    "exception": "${vars.ERR_EXCEPTION}"
+                }]]></format>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+    </resource>
     <resource methods="POST GET" uri-template="/payload-freemarker">
         <inSequence>
             <variable name="user_name" value="123" type="INTEGER"/>


### PR DESCRIPTION
## Summary

- Adds an integration test (`testPayloadFactoryWithDollarSignInVariableValues`) to `PayloadFactorySynapseExpressionTestCase` that reproduces the bug reported in #4623.
- Adds a matching Synapse API resource (`/dollar-in-vars`) in `synapse_expressions_payload_factory.xml` that sets variables whose values contain `$` followed by digits (simulating Java stack traces).
- The test verifies that the `PayloadFactory` mediator with `template-type="default"` correctly embeds literal `$n` strings without throwing `IllegalArgumentException`.

Depends on fix PR: wso2/wso2-synapse#2527
Fixes: #4623

## Issue Analysis

### Issue Analysis — [Issue #4623]: PayloadFactory default template throws java.lang.IllegalArgumentException when there's a $

#### Classification
- **Type:** Bug
- **Severity Assessment:** High — affects any user whose variable values contain `$` followed by a digit (e.g., stack traces, Java class names like `NativeWorkerPool$1`, `ThreadPoolExecutor$Worker`).
- **Affected Component(s):** `wso2-synapse` — `RegexTemplateProcessor` (`org.apache.synapse.mediators.transform.pfutils.RegexTemplateProcessor`)
- **Affected Feature(s):** PayloadFactory Mediator with `template-type="default"` (Synapse Expression / `${vars.*}` syntax)

#### Reproducibility
- **Reproducible:** Yes
- **Steps Executed:**
  1. Deployed API with `<payloadFactory media-type="json" template-type="default">` referencing variables whose values contain `NativeWorkerPool$1.run`, `ThreadPoolExecutor$Worker.run`.
  2. Sent `GET /test-payload`.
- **Actual Behavior:** Server returned `202 Accepted` with empty body; `IllegalArgumentException: Illegal group reference` in logs from `RegexTemplateProcessor.replace()`.

#### Root Cause Analysis
`Matcher.appendReplacement()` interprets `$n` in replacement strings as capture-group back-references. Fix (wso2/wso2-synapse#2527): wrap all replacement values with `Matcher.quoteReplacement()`.

## Test plan
- [x] New resource `/dollar-in-vars` added to `synapse_expressions_payload_factory.xml`
- [x] `testPayloadFactoryWithDollarSignInVariableValues()` added to `PayloadFactorySynapseExpressionTestCase`
- [x] Verified manually against patched server — HTTP 200 with correct literal `$1` strings in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for payload factory with special characters in variable values
  * Added test endpoint to verify correct handling of special characters in variable interpolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->