### PR TITLE
Fix: Return empty list instead of error when registry resource has no properties

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java
@@ -199,8 +199,7 @@ public class RegistryPropertiesResource implements MiApiResource {
                     jsonBody.getJSONArray(Constants.LIST).put(propertyObject);
                 }
             } else {
-                jsonBody = new JSONObject();
-                jsonBody.put(LIST, "Error while fetching properties");
+                jsonBody = Utils.createJSONList(0);
             }
         }
         Utils.setJsonPayLoad(axis2MessageContext, jsonBody);


### PR DESCRIPTION
## Summary

- **Issue:** https://github.com/wso2/product-micro-integrator/issues/4767
- When a registry resource exists but has no associated `.properties` file, `getResourceProperties()` returns `null`.
- The code was treating this `null` as an error, returning `{"list":"Error while fetching properties"}` instead of an empty list.
- Fix: when `propertiesList` is `null`, return `Utils.createJSONList(0)` to produce `{"count":0,"list":[]}`.

## Root Cause

In `RegistryPropertiesResource.populateRegistryProperties()`, the `else` branch (triggered when `getResourceProperties()` returns `null`) was constructing an error JSON object instead of an empty list. A `null` return from `getResourceProperties()` simply means no `.properties` metadata file exists for the resource — it is not an error condition.

## Change

**File:** `components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/RegistryPropertiesResource.java`

```diff
-                jsonBody = new JSONObject();
-                jsonBody.put(LIST, "Error while fetching properties");
+                jsonBody = Utils.createJSONList(0);
```

## Test plan

- [x] Created a registry resource (`testfolder/sampletext.txt`) with no `.properties` file.
- [x] Called `GET /management/registry-resources/properties?path=registry/governance/mi-resources/testfolder/sampletext.txt`.
- [x] Confirmed response is `{"count":0,"list":[]}` (empty list, not error string).
- [x] Confirmed non-existent resource path still returns proper error: `{"Error":"Can not find the registry: ..."}`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated registry properties endpoint to return an empty list instead of an error message when property retrieval fails, providing more consistent API behavior across integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->