### PR TITLE
Add faulty capp info to management APIs

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/CarbonApplication.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/CarbonApplication.java
@@ -33,6 +33,8 @@ public class CarbonApplication {
     private boolean deploymentCompleted;
     private String mainSequence;
     private ClassLoader classLoader;
+    private String errorMessage;
+    private String faultStackTrace;
 
     private ApplicationConfiguration appConfig;
 
@@ -112,6 +114,22 @@ public class CarbonApplication {
 
     public void setMainSequence(String mainSequence) {
         this.mainSequence = mainSequence;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getFaultStackTrace() {
+        return faultStackTrace;
+    }
+
+    public void setFaultStackTrace(String faultStackTrace) {
+        this.faultStackTrace = faultStackTrace;
     }
 
 }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/CarbonAppResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/CarbonAppResource.java
@@ -69,7 +69,6 @@ import javax.mail.util.ByteArrayDataSource;
 import javax.xml.namespace.QName;
 
 import static org.wso2.micro.integrator.management.apis.Constants.BAD_REQUEST;
-import static org.wso2.micro.integrator.management.apis.Constants.LIST;
 import static org.wso2.micro.integrator.management.apis.Constants.NOT_FOUND;
 import static org.wso2.micro.integrator.management.apis.Constants.SEARCH_KEY;
 import static org.wso2.micro.integrator.management.apis.Constants.USERNAME_PROPERTY;
@@ -80,11 +79,14 @@ public class CarbonAppResource extends APIResource {
     private static final String MULTIPART_FORMDATA_DATA_TYPE = "multipart/form-data";
     private static final String CAPP_NAME = "name";
     private static final String CAPP_FILE_NAME = "cAppFileName";
+    private static final String FAULT_PATH_SUFFIX = "/fault";
     // HTTP method types supported by the resource
+    private final String urlTemplate;
     private Set<String> methods;
 
     public CarbonAppResource(String urlTemplate){
         super(urlTemplate);
+        this.urlTemplate = urlTemplate;
         methods = new HashSet<>();
         methods.add(Constants.HTTP_GET);
         methods.add(Constants.HTTP_POST);
@@ -116,9 +118,13 @@ public class CarbonAppResource extends APIResource {
         String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
         switch (httpMethod) {
             case Constants.HTTP_GET: {
+                String cappName = Utils.getPathParameter(messageContext, CAPP_NAME);
                 String param = Utils.getQueryParameter(messageContext, "carbonAppName");
                 String searchKey = Utils.getQueryParameter(messageContext, SEARCH_KEY);
-                if (Objects.nonNull(param)) {
+                if (Objects.nonNull(cappName)
+                        && urlTemplate.endsWith(FAULT_PATH_SUFFIX)) {
+                    populateFaultyCarbonAppData(messageContext, cappName);
+                } else if (Objects.nonNull(param)) {
                     String acceptHeader = (String) SecurityUtils.getHeaders(axis2MessageContext)
                                                                 .get(HTTPConstants.HEADER_ACCEPT);
                     if (Constants.MEDIA_TYPE_APPLICATION_OCTET_STREAM.equals(acceptHeader)) {
@@ -200,6 +206,9 @@ public class CarbonAppResource extends APIResource {
             }
             for (CarbonApplication faultyApp : faultyAppList) {
                 JSONObject appObject = convertCarbonAppToJsonObject(faultyApp);
+                if (faultyApp.getErrorMessage() != null) {
+                    appObject.put("errorMessage", faultyApp.getErrorMessage());
+                }
                 jsonBody.getJSONArray(Constants.FAULTY_LIST).put(appObject);
             }
         }
@@ -378,6 +387,33 @@ public class CarbonAppResource extends APIResource {
                     CAPP_NAME + " parameter in the path", axisMsgCtx, BAD_REQUEST);
             Utils.setJsonPayLoad(axisMsgCtx, jsonResponse);
         }
+    }
+
+    private void populateFaultyCarbonAppData(MessageContext messageContext, String cappName) {
+
+        org.apache.axis2.context.MessageContext axis2MessageContext =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+
+        CarbonApplication faultyApp = CappDeployer.getFaultyCAppObjects().stream()
+                .filter(app -> cappName.equals(app.getAppName()))
+                .findFirst().orElse(null);
+
+        if (Objects.isNull(faultyApp)) {
+            Utils.setJsonPayLoad(axis2MessageContext,
+                    Utils.createJsonError("Faulty carbon application not found for the given name.",
+                            axis2MessageContext, NOT_FOUND));
+            return;
+        }
+
+        String errorMessage = faultyApp.getErrorMessage() != null ? faultyApp.getErrorMessage() : "";
+        String stackTrace = faultyApp.getFaultStackTrace() != null ? faultyApp.getFaultStackTrace() : "";
+
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put(Constants.NAME, faultyApp.getAppName());
+        jsonBody.put(Constants.VERSION, faultyApp.getAppVersion());
+        jsonBody.put("errorMessage", errorMessage);
+        jsonBody.put("faultStackTrace", stackTrace);
+        Utils.setJsonPayLoad(axis2MessageContext, jsonBody);
     }
 
     private void populateCarbonAppList(MessageContext messageContext) {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/CarbonAppResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/CarbonAppResource.java
@@ -119,6 +119,7 @@ public class CarbonAppResource extends APIResource {
         switch (httpMethod) {
             case Constants.HTTP_GET: {
                 String cappName = Utils.getPathParameter(messageContext, CAPP_NAME);
+                log.debug("Processing GET request for carbon application. Path parameter: " + cappName);
                 String param = Utils.getQueryParameter(messageContext, "carbonAppName");
                 String searchKey = Utils.getQueryParameter(messageContext, SEARCH_KEY);
                 if (Objects.nonNull(cappName)
@@ -399,8 +400,9 @@ public class CarbonAppResource extends APIResource {
                 .findFirst().orElse(null);
 
         if (Objects.isNull(faultyApp)) {
+        if (Objects.isNull(faultyApp)) {
+            log.warn("Faulty carbon application not found for name: " + cappName);
             Utils.setJsonPayLoad(axis2MessageContext,
-                    Utils.createJsonError("Faulty carbon application not found for the given name.",
                             axis2MessageContext, NOT_FOUND));
             return;
         }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -28,6 +28,7 @@ public class Constants {
     public static final String PREFIX_APIS = "/apis";
     public static final String PREFIX_CARBON_APPS = "/applications";
     public static final String PATH_PARAM_CARBON_APP_NAME = "/" + "{name}";
+    public static final String PATH_PARAM_CARBON_APP_FAULT = PATH_PARAM_CARBON_APP_NAME + "/fault";
     public static final String PREFIX_ENDPOINTS = "/endpoints";
     public static final String PREFIX_INBOUND_ENDPOINTS = "/inbound-endpoints";
     public static final String PREFIX_PROXY_SERVICES = "/proxy-services";

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementInternalApi.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementInternalApi.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.inbound.endpoint.internal.http.api.InternalAPIHandler;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_CARBON_APP_FAULT;
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_CARBON_APP_NAME;
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_EXTERNAL_VAULT_NAME;
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_ROLE;
@@ -82,6 +83,7 @@ public class ManagementInternalApi implements InternalAPI {
         resourcesList.add(new ProxyServiceResource(PREFIX_PROXY_SERVICES));
         resourcesList.add(new CarbonAppResource(PREFIX_CARBON_APPS));
         resourcesList.add(new CarbonAppResource(PREFIX_CARBON_APPS + PATH_PARAM_CARBON_APP_NAME));
+        resourcesList.add(new CarbonAppResource(PREFIX_CARBON_APPS + PATH_PARAM_CARBON_APP_FAULT));
         resourcesList.add(new TaskResource(PREFIX_TASKS));
         resourcesList.add(new SequenceResource(PREFIX_SEQUENCES));
         resourcesList.add(new DataServiceResource(PREFIX_DATA_SERVICES));

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -56,6 +56,8 @@ import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -332,6 +334,10 @@ public class CappDeployer extends AbstractDeployer {
         undeployCarbonApp(currentApp, axisConfig);
         // Validate synapse config to remove half added swagger definitions in the case of a faulty CAPP.
         SynapseConfigUtils.getSynapseConfiguration(SUPER_TENANT_DOMAIN_NAME).validateSwaggerTable();
+        currentApp.setErrorMessage(e.getMessage());
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        currentApp.setFaultStackTrace(sw.toString());
         faultyCAppObjects.add(currentApp);
         faultyCapps.add(cAppName);
     }


### PR DESCRIPTION
## Purpose
- Update the management API get capps call to have the error message for faulty capps as `errorMessage `.

```
{
    "activeCount": 1,
    "faultyCount": 1,
    "activeList": [
        {
            "name": "data-service-proj",
            "version": "1.0.0",
            "artifacts": [
                {
                    "name": "ds",
                    "type": "dataservice"
                },
                {
                    "name": "config",
                    "type": "property"
                }
            ]
        }
    ],
    "totalCount": 2,
    "faultyList": [
        {
            "name": "test-capp",
            "errorMessage": "API deployment from the file : /Users/dedunukarunarathne/Documents/RRT/4.5.0/wso2mi-4.5.0/tmp/carbonapps/-1234/1776747633502test-capp_1.0.0.car/FaultyAPI_1.0.0/FaultyAPI-1.0.0.xml : Failed.",
            "version": "1.0.0",
            "artifacts": [
                {
                    "name": "FaultyAPI",
                    "type": "api"
                },
                {
                    "name": "ib-2-inboundSequence",
                    "type": "sequence"
                },
                {
                    "name": "http-1-inboundErrorSequence",
                    "type": "sequence"
                },
                {
                    "name": "http-1-inboundSequence",
                    "type": "sequence"
                },
                {
                    "name": "ib-2-inboundErrorSequence",
                    "type": "sequence"
                },
                {
                    "name": "config",
                    "type": "property"
                }
            ]
        }
    ]
}
```

- Introduce a path parameter to get the fault information, including the stack trace of a faulty-capp.

Request
```
curl --location 'https://localhost:9164/management/applications/test-capp/fault' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer  <TOKEN>'
```
Response
```
{
    "name": "test-capp",
    "errorMessage": "API deployment from the file : /Users/dedunukarunarathne/Documents/RRT/4.5.0/wso2mi-4.5.0/tmp/carbonapps/-1234/1776747633502test-capp_1.0.0.car/FaultyAPI_1.0.0/FaultyAPI-1.0.0.xml : Failed.",
    "version": "1.0.0",
    "faultStackTrace": "<STACK_TRACE>"
}
```

Related issue: https://github.com/wso2/product-integrator-mi/issues/4800