### PR TITLE
Add management API to delete a logger configuration

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LoggingResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LoggingResource.java
@@ -21,6 +21,7 @@ package org.wso2.micro.integrator.management.apis;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.PropertiesConfigurationLayout;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.logging.log4j.Level;
@@ -45,6 +46,7 @@ import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -86,6 +88,7 @@ public class LoggingResource extends APIResource {
         Set<String> methods = new HashSet<>();
         methods.add(Constants.HTTP_GET);
         methods.add(Constants.HTTP_METHOD_PATCH);
+        methods.add(Constants.HTTP_DELETE);
         return methods;
     }
 
@@ -128,6 +131,47 @@ public class LoggingResource extends APIResource {
                     Utils.setJsonPayLoad(axis2MessageContext, jsonBody);
                 }
                 return true;
+            }
+        } else if (httpMethod.equals(Constants.HTTP_DELETE)) {
+            String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
+            String loggerName = Utils.getQueryParameter(messageContext, Constants.LOGGER_NAME);
+            loggerName = loggerName == null ? null : loggerName.trim();
+            try {
+                if (SecurityUtils.canUserEdit(userName)) {
+                    if (StringUtils.isNotEmpty(loggerName)) {
+                        if (Constants.ROOT_LOGGER.equals(loggerName)) {
+                            this.jsonBody = this.createJsonError("Root logger cannot be deleted", "",
+                                    Constants.FORBIDDEN, axis2MessageContext);
+                        } else {
+                            try {
+                                String performedBy = Constants.ANONYMOUS_USER;
+                                if (userName != null) {
+                                    performedBy = userName;
+                                }
+
+                                if (this.isLoggerExist(loggerName)) {
+                                    this.jsonBody = this.deleteLoggerData(performedBy, axis2MessageContext, loggerName);
+                                } else {
+                                    this.jsonBody = this.createJsonError("Specified logger name ('"
+                                            + loggerName + "') not found", "", axis2MessageContext);
+                                }
+                            } catch (IOException exception) {
+                                this.jsonBody = this.createJsonError("Exception while deleting logger "
+                                                + "configuration ", exception, axis2MessageContext);
+                            }
+                        }
+                    } else {
+                        this.jsonBody = this.createJsonError("Logger name is missing for delete action", "",
+                                axis2MessageContext);
+                    }
+                } else {
+                    jsonBody = createJsonError("User is not authorized to delete logger configurations", "",
+                            Constants.FORBIDDEN, axis2MessageContext);
+                }
+            } catch (UserStoreException e) {
+                log.error("Error occurred while retrieving the user data", e);
+                jsonBody = createJsonError("Error occurred while retrieving the user data", e,
+                        axis2MessageContext);
             }
         } else {
             String userName = (String) messageContext.getProperty(USERNAME_PROPERTY);
@@ -178,8 +222,8 @@ public class LoggingResource extends APIResource {
                         jsonBody = createJsonError("Log level is missing", "", axis2MessageContext);
                     }
                 } else {
-                    Utils.sendForbiddenFaultResponse(axis2MessageContext);
-                    jsonBody = createJsonError("User is not Authorized to edit", "", axis2MessageContext);
+                    jsonBody = createJsonError("User is not Authorized to edit", "",
+                            Constants.FORBIDDEN, axis2MessageContext);
                 }
             } catch (UserStoreException e) {
                 log.error("Error occurred while retrieving the user data", e);
@@ -188,6 +232,94 @@ public class LoggingResource extends APIResource {
         }
         Utils.setJsonPayLoad(axis2MessageContext, jsonBody);
         return true;
+    }
+
+    private JSONObject deleteLoggerData(String userName, org.apache.axis2.context.MessageContext axis2MessageContext,
+                                        String loggerName) {
+        try {
+            this.loadConfigs();
+
+            List<String> keysToDelete = getLogConfigEntriesToDelete(loggerName);
+
+            // 2. Now perform the bulk delete safely
+            for (String key : keysToDelete) {
+                this.config.clearProperty(key);
+            }
+
+            String currentLoggers = (String) this.config.getProperty(LOGGERS_PROPERTY);
+            if (currentLoggers != null) {
+                String formatted = getFormattedLoggersString(loggerName, currentLoggers);
+                this.config.setProperty(LOGGERS_PROPERTY, formatted);
+            }
+
+            // 4. Persist and Audit
+            this.applyConfigs();
+            this.jsonBody.put(Constants.MESSAGE, "Successfully deleted logger for ('" + loggerName + "')");
+
+            JSONObject info = new JSONObject();
+            info.put(Constants.LOGGER_NAME, loggerName);
+            AuditLogger.logAuditMessage(userName, "", Constants.AUDIT_LOG_ACTION_DELETED, info);
+
+        } catch (IOException | ConfigurationException exception) {
+            this.jsonBody = this.createJsonError("Exception while deleting logger data ", exception, axis2MessageContext);
+        }
+
+        return this.jsonBody;
+    }
+
+    private static String getFormattedLoggersString(String loggerName, String currentLoggers) {
+
+        // 1. Split into a List, trimming and ignoring empty spaces/backslashes
+        // This regex [\\s,\\\\]+ breaks it down by commas, spaces, or backslashes
+        List<String> loggerList = new ArrayList<>(
+                Arrays.asList(currentLoggers.split("[\\s,\\\\]+"))
+        );
+
+        String normalizedLoggerName = loggerName == null ? null : loggerName.trim();
+
+        // 2. Remove the specific logger (Case-sensitive)
+        // iterator.remove() is the safe way to remove while looping
+        Iterator<String> iterator = loggerList.iterator();
+        while (iterator.hasNext()) {
+            String name = iterator.next().trim();
+            if (name.isEmpty() || (name.equals(normalizedLoggerName))) {
+                iterator.remove();
+            }
+        }
+
+        // 3. Rebuild the string with commas as separators, ensuring no trailing commas or extra spaces
+        StringBuilder formatted = new StringBuilder();
+
+        for (int i = 0; i < loggerList.size(); i++) {
+            String logger = loggerList.get(i);
+
+            // Add comma separator for everyone except the first item
+            if (i > 0) {
+                formatted.append(", ");
+            }
+
+            formatted.append(logger);
+        }
+        return formatted.toString();
+    }
+
+    private List<String> getLogConfigEntriesToDelete(String loggerName) {
+
+        // 1. Identify the prefix (e.g., "logger.opentelemetry-trace.")
+        String loggerPrefix = LOGGER_PREFIX + loggerName + ".";
+
+        // 2. Dynamically clear ALL properties starting with this prefix
+        // This handles .name, .level, .appenderRef, .additivity, etc.
+        List<String> keysToDelete = new ArrayList<>();
+        Iterator<String> keys = this.config.getKeys();
+
+        while (keys.hasNext()) {
+            String key = keys.next();
+            if (key.startsWith(loggerPrefix)) {
+                keysToDelete.add(key);
+            }
+        }
+        return keysToDelete;
     }
 
     private JSONObject updateLoggerData(String performedBy, JSONObject info,
@@ -352,9 +484,18 @@ public class LoggingResource extends APIResource {
 
     private JSONObject createJsonError(String message, Object exception,
                                        org.apache.axis2.context.MessageContext axis2MessageContext) {
-        log.error(message + exception);
+        return this.createJsonError(message, exception, Constants.BAD_REQUEST, axis2MessageContext);
+    }
+
+    private JSONObject createJsonError(String message, Object exception, String statusCode,
+                                       org.apache.axis2.context.MessageContext axis2MessageContext) {
+        if (exception instanceof Throwable) {
+            log.error(message, (Throwable) exception);
+        } else {
+            log.error(message + exception);
+        }
         JSONObject jsonBody = Utils.createJsonErrorObject(message);
-        axis2MessageContext.setProperty(Constants.HTTP_STATUS_CODE, Constants.BAD_REQUEST);
+        axis2MessageContext.setProperty(Constants.HTTP_STATUS_CODE, statusCode);
         return jsonBody;
     }
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/resources/management-api.yaml
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/resources/management-api.yaml
@@ -1477,6 +1477,59 @@ paths:
                     example: Successfully added logger for ('org-apache-hadoop-hive') with level DEBUG
       security:
         - BearerAuth: []
+    delete:
+      summary: Delete Logger
+      description: |
+        Deletes a specific logger configuration by providing the logger name as a query parameter.
+        The root logger cannot be deleted.
+
+        Example:
+        ```
+        DELETE /management/logging?loggerName=org-apache-coyote
+        ```
+      tags:
+        - Logging
+      parameters:
+        - in: query
+          name: loggerName
+          schema:
+            type: string
+            example: org-apache-coyote
+          required: true
+          description: The name of the logger to delete.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Successfully deleted logger for ('org-apache-coyote')
+        '400':
+          description: Bad request - Logger name is missing or logger not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Error:
+                    type: string
+                    example: Specified logger name ('org-apache-coyote') not found
+        '403':
+          description: Forbidden - User is not authorized or attempting to delete root logger
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Error:
+                    type: string
+                    example: Root logger cannot be deleted
+      security:
+        - BearerAuth: []
   /configs:
     get:
       summary: Get Correlation Logging Configuration Status


### PR DESCRIPTION

Fixes: https://github.com/wso2/product-integrator-mi/issues/4815

API Call:
DELETE https://localhost:9164/management/logging?loggerName=org-apache-coyote
Authorization: Bearer <access_token>
