### PR TITLE
Update mediation diagnostics jar name in bin.xml

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -697,7 +697,7 @@
                 <include>commons-net:commons-net</include>
                 <include>com.github.mwiede:jsch</include>
                 <include>org.wso2.runtime.diagnostics:runtime-diagnostics-tool:jar</include>
-                <include>org.wso2.ei:org.wso2.micro.integrator.diagnostics:jar</include>
+                <include>org.wso2.ei:org.wso2.micro.integrator.mediation.diagnostics:jar</include>
                 <include>org.graalvm.sdk:nativeimage:jar</include>
                 <include>org.graalvm.polyglot:polyglot:jar</include>
                 <include>org.graalvm.sdk:word:jar</include>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This is to resolve the following error in the diagnostics tool.

```
2026-05-06 14:00:31 DiagnosticsApp [ERROR] Error on loading custom watcher: org.wso2.carbon.diagnostics.trafficanalyzer.TrafficAnalyzer
java.lang.ClassNotFoundException: org.wso2.carbon.diagnostics.trafficanalyzer.TrafficAnalyzer
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:421)
	at java.base/java.lang.Class.forName(Class.java:412)
	at org.wso2.diagnostics.DiagnosticsApp.loadCustomWatchers(DiagnosticsApp.java:201)
	at org.wso2.diagnostics.DiagnosticsApp.main(DiagnosticsApp.java:141)
```