### PR TITLE
Pass the message from the DynamicControlOperationResult in the successful scenario

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRequestProcessorImpl.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/common/InboundRequestProcessorImpl.java
@@ -127,7 +127,7 @@ public abstract class InboundRequestProcessorImpl implements InboundRequestProce
         taskDescription.setTaskImplClassName(task.getClass().getName());
         taskDescription.addProperty(TaskUtils.TASK_OWNER_PROPERTY, TaskUtils.TASK_BELONGS_TO_INBOUND_ENDPOINT);
         taskDescription.addProperty(TaskUtils.TASK_OWNER_NAME, name);
-        taskDescription.addProperty(TaskUtils.START_IN_PAUSED_MODE, String.valueOf(startInPausedMode));
+        taskDescription.setStartInPausedMode(startInPausedMode);
         return taskDescription;
     }
     

--- a/components/mediation/tasks/org.wso2.micro.integrator.mediation.ntask/src/main/java/org/wso2/micro/integrator/mediation/ntask/NTaskTaskManager.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.mediation.ntask/src/main/java/org/wso2/micro/integrator/mediation/ntask/NTaskTaskManager.java
@@ -116,10 +116,7 @@ public class NTaskTaskManager implements TaskManager, TaskServiceObserver, Serve
                     if (logger.isDebugEnabled()) {
                         logger.debug("Submitting task [ " + taskId(taskDescription) + " ] to the task manager.");
                     }
-                    boolean scheduledInPausedMode =
-                            Objects.nonNull(taskDescription.getProperty(TaskUtils.START_IN_PAUSED_MODE))
-                            && Boolean.parseBoolean((String) taskDescription.getProperty(TaskUtils.START_IN_PAUSED_MODE));
-                    taskManager.handleTask(taskInfo.getName(), scheduledInPausedMode);
+                    taskManager.handleTask(taskInfo.getName(), taskDescription.isStartInPausedMode());
                 }
                 removeTask(taskDescription);
             }

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/TaskUtils.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/TaskUtils.java
@@ -51,8 +51,6 @@ public class TaskUtils {
 
     public static final String TASK_BELONGS_TO_INBOUND_ENDPOINT = "InboundEndpoint";
 
-    public static final String START_IN_PAUSED_MODE = "startInPausedMode";
-
     private static SecretResolver secretResolver;
 
     private static final long DEFAULT_MAX_WAIT_TIME = 180;

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/TaskResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/TaskResource.java
@@ -329,7 +329,7 @@ public class TaskResource extends APIResource {
         if (INACTIVE_STATUS.equalsIgnoreCase(status)) {
             DynamicControlOperationResult result = controllerTask.deactivate();
             if (result.isSuccess()) {
-                jsonResponse.put(Constants.MESSAGE_JSON_ATTRIBUTE, name + " : is deactivated");
+                jsonResponse.put(Constants.MESSAGE_JSON_ATTRIBUTE, result.getMessage());
                 AuditLogger.logAuditMessage(performedBy, Constants.AUDIT_LOG_TYPE_TASK,
                         Constants.AUDIT_LOG_ACTION_DISABLED, info);
             } else {
@@ -338,7 +338,7 @@ public class TaskResource extends APIResource {
         } else if (ACTIVE_STATUS.equalsIgnoreCase(status)) {
             DynamicControlOperationResult result = controllerTask.activate();
             if (result.isSuccess()) {
-                jsonResponse.put(Constants.MESSAGE_JSON_ATTRIBUTE, name + " : is activated");
+                jsonResponse.put(Constants.MESSAGE_JSON_ATTRIBUTE, result.getMessage());
                 AuditLogger.logAuditMessage(performedBy, Constants.AUDIT_LOG_TYPE_TASK,
                         Constants.AUDIT_LOG_ACTION_ENABLE, info);
             } else {
@@ -347,7 +347,7 @@ public class TaskResource extends APIResource {
         } else if (TRIGGER_STATUS.equalsIgnoreCase(status)) {
             DynamicControlOperationResult result = controllerTask.trigger();
             if (result.isSuccess()) {
-                jsonResponse.put(Constants.MESSAGE_JSON_ATTRIBUTE, name + " : is triggered");
+                jsonResponse.put(Constants.MESSAGE_JSON_ATTRIBUTE, result.getMessage());
                 AuditLogger.logAuditMessage(performedBy, Constants.AUDIT_LOG_TYPE_TASK,
                         Constants.AUDIT_LOG_ACTION_TRIGGERED, info);
             } else {


### PR DESCRIPTION
This PR will
- pass the message from the DynamicControlOperationResult in the successful scenario
- use taskDescription.isStartInPausedMode() method instead of maintaining a property
