### PR TITLE
Improve CiphertextRepository to support both legacy and novel providers vault lookup

### DIFF
--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/CiphertextRepository.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/CiphertextRepository.java
@@ -48,7 +48,8 @@ public class CiphertextRepository implements SecretRepository {
     @Override
     public String getSecret(String alias) {
         SecretManager secretManager = SecretManager.getInstance();
-        return secretManager.getSecret(alias);
+        // this resolves the secret by looking up both legacy and external vault providers
+        return secretManager.resolveSecret(alias);
     }
 
     @Override


### PR DESCRIPTION
$subject

This will utilize the new resolveSecret method in CipherTextRepository to support external vaults in lookup function. Related PR : https://github.com/wso2/carbon-secvault/pull/72

This helps with the implementation of https://github.com/wso2/product-integrator-mi/issues/4827