### PR TITLE
Improve ciphertool scripts to preserve backward compatibility for asymmetric secrets

### DIFF
--- a/distribution/src/conf/ciphertool.bat
+++ b/distribution/src/conf/ciphertool.bat
@@ -82,16 +82,15 @@ echo Using CARBON_HOME:   %CARBON_HOME%
 echo Using JAVA_HOME:    %JAVA_HOME%
 set _RUNJAVA="%JAVA_HOME%\bin\java"
 
-rem Set CipherTransformation only when -Dsymmetric is passed as an argument
+rem Use OAEP transformation for asymmetric (RSA) mode by default; suppress it for symmetric mode
 rem Preserve original args in CMD_ARGS before SHIFT loop modifies %1
 set "CMD_ARGS=%*"
-set CIPHER_TRANSFORMATION=
+set "CIPHER_TRANSFORMATION=-Dorg.wso2.CipherTransformation=RSA/ECB/OAEPwithSHA1andMGF1Padding"
 
 :scanArgs
 if "%~1"=="" goto runCipherTool
-if "%~1"=="-Dsymmetric" (
-    set CIPHER_TRANSFORMATION=-Dorg.wso2.CipherTransformation="RSA/ECB/OAEPwithSHA1andMGF1Padding"
-)
+echo %~1 | FINDSTR /B /C:"-Dsymmetric" >nul
+if not errorlevel 1 set CIPHER_TRANSFORMATION=
 shift
 goto scanArgs
 

--- a/distribution/src/conf/ciphertool.sh
+++ b/distribution/src/conf/ciphertool.sh
@@ -124,12 +124,12 @@ fi
 
 # ----- Execute The Requested Command -----------------------------------------
 
-# Set CipherTransformation only when -Dsymmetric is passed as an argument
-CIPHER_TRANSFORMATION=""
+# Use OAEP transformation for asymmetric (RSA) mode by default; suppress it for symmetric mode
+CIPHER_TRANSFORMATION="-Dorg.wso2.CipherTransformation=RSA/ECB/OAEPwithSHA1andMGF1Padding"
 for arg in "$@"; do
   case "$arg" in
     -Dsymmetric|-Dsymmetric=*)
-      CIPHER_TRANSFORMATION="-Dorg.wso2.CipherTransformation=RSA/ECB/OAEPwithSHA1andMGF1Padding"
+      CIPHER_TRANSFORMATION=""
       break
       ;;
   esac


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

We need to preserve the asymmetric algorithm which was used before to support migrating customers.