### PR TITLE
Fix env-file last-line drop when trailing newline missing (#4234)

### DIFF
--- a/distribution/src/scripts/micro-integrator.sh
+++ b/distribution/src/scripts/micro-integrator.sh
@@ -130,7 +130,7 @@ export_env_file() {
   fi
 
   # Read the .env file and export each variable to the environment
-  while IFS='=' read -r key value; do
+  while IFS='=' read -r key value || [ -n "$key" ]; do
       # Ignore lines starting with '#' (comments) or empty lines
       case "$key" in
           \#*|"")

--- a/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/resource/test/api/ApiWithConfigurablePropertyTestCase.java
+++ b/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/resource/test/api/ApiWithConfigurablePropertyTestCase.java
@@ -34,19 +34,24 @@ import org.wso2.esb.integration.common.utils.common.ServerConfigurationManager;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class ApiWithConfigurablePropertyTestCase extends ESBIntegrationTest {
 
     private ServerConfigurationManager serverConfigurationManager;
+    private CarbonLogReader carbonLogReader;
 
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
         super.init();
-        CarbonLogReader carbonLogReader = new CarbonLogReader();
+        carbonLogReader = new CarbonLogReader();
         carbonLogReader.start();
         serverConfigurationManager = new ServerConfigurationManager(context);
         File capp = new File(getESBResourceLocation() + File.separator + "config.var" + File.separator +
@@ -110,6 +115,75 @@ public class ApiWithConfigurablePropertyTestCase extends ESBIntegrationTest {
         Assert.assertEquals(StringUtils.normalizeSpace(httpResponse.getData()),
                 StringUtils.normalizeSpace("{ \"name\": \"env\", \"msg\": \"Hello\" }"),
                 StringUtils.normalizeSpace(httpResponse.getData()));
+    }
+
+    @Test(groups = {"wso2.esb"},
+            description = "Regression for product-integrator-mi#4234: the launcher's export_env_file() loop "
+                    + "must export the last KEY=VALUE line of an --env-file even when the file lacks a "
+                    + "trailing newline.",
+            priority = 5)
+    public void testConfigurablePropertyWithEnvVariableNoTrailingNewline()
+            throws IOException, AutomationUtilException, InterruptedException {
+        // Build a .env file whose LAST line is `name=env` and which has NO trailing newline.
+        // Pre-fix, the POSIX `read` loop in micro-integrator.sh would silently drop this last line,
+        // leaving `name` undefined in the JVM environment and producing a "{name: , msg: Hello}"-style
+        // response (and a `ConfigDeployer ... is not found` error in the log).
+        Path envFile = Files.createTempFile("issue-4234-no-newline-", ".env");
+        envFile.toFile().deleteOnExit();
+        String contents = "msg=Hello\nname=env"; // no trailing '\n' — bug's trigger condition
+        Files.write(envFile, contents.getBytes(StandardCharsets.UTF_8));
+
+        carbonLogReader.clearLogs();
+        Map<String, String> commands = new HashMap<>();
+        commands.put("--env-file", envFile.toAbsolutePath().toString());
+        serverConfigurationManager.restartMicroIntegrator(commands);
+
+        Map<String, String> headers = new HashMap<>();
+        URL endpoint = new URL(getApiInvocationURL("apiConfig/test_api"));
+        HttpResponse httpResponse = HttpRequestUtil.doGet(endpoint.toString(), headers);
+        Assert.assertEquals(httpResponse.getResponseCode(), 200);
+        Assert.assertEquals(StringUtils.normalizeSpace(httpResponse.getData()),
+                StringUtils.normalizeSpace("{ \"name\": \"env\", \"msg\": \"Hello\" }"),
+                StringUtils.normalizeSpace(httpResponse.getData()));
+
+        // The deployer logs `The value of the key:[<key>] is not found.` for any configurable
+        // property that the launcher failed to export. With the fix, neither `name` nor `msg`
+        // should hit that branch.
+        assertFalse(carbonLogReader.assertIfLogExists("The value of the key:[name] is not found."),
+                "ConfigDeployer logged a missing-key error for `name`; the launcher dropped the last "
+                        + "line of the no-trailing-newline .env file. See product-integrator-mi#4234.");
+        assertFalse(carbonLogReader.assertIfLogExists("The value of the key:[msg] is not found."),
+                "ConfigDeployer logged a missing-key error for `msg`.");
+    }
+
+    @Test(groups = {"wso2.esb"},
+            description = "Regression for product-integrator-mi#4234: a single-line --env-file with no "
+                    + "trailing newline must still be exported in full.",
+            priority = 6)
+    public void testConfigurablePropertyWithSingleLineEnvFileNoTrailingNewline()
+            throws IOException, AutomationUtilException, InterruptedException {
+        // Edge case from the IA: a 1-line env file with no terminator. The base API needs both
+        // `name` and `msg` resolved, so the unsupplied one falls back to a system property here.
+        Path envFile = Files.createTempFile("issue-4234-single-line-", ".env");
+        envFile.toFile().deleteOnExit();
+        Files.write(envFile, "name=env".getBytes(StandardCharsets.UTF_8)); // single line, no '\n'
+
+        carbonLogReader.clearLogs();
+        Map<String, String> commands = new HashMap<>();
+        commands.put("--env-file", envFile.toAbsolutePath().toString());
+        commands.put("-Dmsg", "Hello");
+        serverConfigurationManager.restartMicroIntegrator(commands);
+
+        Map<String, String> headers = new HashMap<>();
+        URL endpoint = new URL(getApiInvocationURL("apiConfig/test_api"));
+        HttpResponse httpResponse = HttpRequestUtil.doGet(endpoint.toString(), headers);
+        Assert.assertEquals(httpResponse.getResponseCode(), 200);
+        Assert.assertEquals(StringUtils.normalizeSpace(httpResponse.getData()),
+                StringUtils.normalizeSpace("{ \"name\": \"env\", \"msg\": \"Hello\" }"),
+                StringUtils.normalizeSpace(httpResponse.getData()));
+        assertFalse(carbonLogReader.assertIfLogExists("The value of the key:[name] is not found."),
+                "ConfigDeployer logged a missing-key error for `name`; the launcher dropped the only "
+                        + "line of a single-line, unterminated .env file. See product-integrator-mi#4234.");
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
## Summary

Fixes #4234

When `--env-file=<path>` is used to start WSO2 Micro Integrator, the last variable in the `.env` file is silently dropped if the file does not end with a trailing newline. This causes `ConfigDeployer` to log:

```
ERROR {ConfigDeployer} - The value of the key:[<var>] is not found.
```

even though the variable is correctly specified in the `.env` file.

## Root Cause

`export_env_file()` in `distribution/src/scripts/micro-integrator.sh` parses the `.env` file with a `while IFS='=' read -r key value; do` loop. This is the classic POSIX `read` pitfall: when the last line of a file has no trailing newline, `read` populates `$key` and `$value` with the partial line **but returns a non-zero exit status** (EOF before the line delimiter). The `while` loop treats that non-zero status as the loop-end signal, so the `export` for the final line is never executed — the variable is silently discarded before the JVM is started.

## Fix

**One-token change** to `distribution/src/scripts/micro-integrator.sh` line 133:

```sh
# Before
while IFS='=' read -r key value; do

# After
while IFS='=' read -r key value || [ -n "$key" ]; do
```

The `|| [ -n "$key" ]` clause causes the loop body to execute on the EOF iteration when a non-empty partial line was read, regardless of `read`'s non-zero exit status. For well-formed `.env` files (terminated with `\n`), the EOF iteration has an empty `$key`, so the existing `case "$key" in \#*|"") continue` arm discards it — behaviour for existing users is completely unchanged.

## Verification

- **Direct shell repro (patched, no-newline fixture):** all three vars populated — `HOST=[smtp.gmail.com] PORT=[465] PASSWORD=[werdrktoetkdmwl]`
- **Direct shell repro (unpatched control, no-newline):** `PASSWORD=[]` — confirms the bug and that the fix is what resolves it
- **Direct shell repro (patched, with-newline regression guard):** all three vars populated — happy path unchanged
- **Server-level repro (patched pack, `--env-file=/tmp/env-no-newline.env`):** `ps -p <pid> -E` shows all three `HR_SMTP_*` vars in the JVM environment after boot; no `ConfigDeployer` errors in `wso2carbon.log`

## Tests Added

Two new TestNG regression tests added to `ApiWithConfigurablePropertyTestCase`:

| Priority | Method | What it covers |
|----------|--------|----------------|
| 5 | `testConfigurablePropertyWithEnvVariableNoTrailingNewline` | Multi-var `.env` with no trailing newline — last var `name=env` must resolve correctly via CAPP configurable-property API |
| 6 | `testConfigurablePropertyWithSingleLineEnvFileNoTrailingNewline` | Single-line `.env` (`name=env`, no terminator) — edge case produced by some editors/CLI tools |

Both tests assert:
1. The API response contains the correct resolved value (`{"name":"env","msg":"Hello"}`)
2. `CarbonLogReader` does **not** contain `The value of the key:[name] is not found.`

All 4 pre-existing `ApiWithConfigurablePropertyTestCase` tests and both new tests passed in the full surefire run against the patched pack.

## Files Changed

| File | Change |
|------|--------|
| `distribution/src/scripts/micro-integrator.sh` | Line 133: append `\|\| [ -n "$key" ]` to `while read` predicate |
| `integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/resource/test/api/ApiWithConfigurablePropertyTestCase.java` | Promote `carbonLogReader` to instance field; add priority-5 and priority-6 regression test methods |