### PR TITLE
Improve vault lookup to check registry for secrets

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -192,6 +192,19 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
 		}
     }
 
+    /**
+     * Returns true if the given registry path is write-protected against CAPP deployment.
+     * Protection is only enforced when {@code vault.registry.lookup.enabled=true}
+     * in synapse.properties, so that the constraint is inactive in the default deployment.
+     */
+    public static boolean isWriteProtected(String path) {
+        if (!org.apache.synapse.config.SynapsePropertiesLoader.getBooleanProperty(
+                MicroIntegratorRegistryConstants.PROP_VAULT_REGISTRY_LOOKUP_ENABLED, false)) {
+            return false;
+        }
+        return MicroIntegratorRegistryConstants.CONNECTOR_SECURE_VAULT_CONFIG_REPOSITORY.equals(path);
+    }
+
     private String getUri(String defaultFSRegRoot, String subDirectory) {
         return Paths.get(defaultFSRegRoot + subDirectory).toUri().normalize().toString()
                 + MicroIntegratorRegistryConstants.URL_SEPARATOR;

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
@@ -63,6 +63,13 @@ public class MicroIntegratorRegistryConstants {
     public static final String DEFAULT_MEDIA_TYPE = "text/plain";
 
     public static final String CONNECTOR_SECURE_VAULT_CONFIG_REPOSITORY = "conf:/repository/components/secure-vault";
+
+    /**
+     * synapse.properties key that enables registry-backed vault lookup.
+     * When true, the secure-vault registry path is also write-protected against CAPP deployment.
+     */
+    public static final String PROP_VAULT_REGISTRY_LOOKUP_ENABLED = "vault.registry.lookup.enabled";
+
     public static final String TYPE_KEY = "type";
     public static final String NAME_KEY = "name";
     public static final String ERROR_KEY = "error";

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/RegistrySecretRepository.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/RegistrySecretRepository.java
@@ -69,17 +69,22 @@ public class RegistrySecretRepository implements SecretRepository {
 				}
 			}
 		}
+
+		if (propertyValue.isEmpty()) {
+			return null;
+		}
+
 		DecryptionProvider decyptProvider = CipherInitializer.getInstance().getDecryptionProvider();
 
 		if (decyptProvider == null) {
-			log.error("Can not proceed decyption due to the secret repository intialization error");
+			log.error("Can not proceed decryption due to the secret repository initialization error");
 			return null;
 		}
 
 		String decryptedText = new String(decyptProvider.decrypt(propertyValue.trim().getBytes()));
 
 		if (log.isDebugEnabled()) {
-			log.info("evaluation completed succesfully " + decryptedText);
+			log.debug("Registry vault lookup completed for alias: " + alias);
 		}
 		return decryptedText;
 

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecretCipherHander.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecretCipherHander.java
@@ -19,6 +19,8 @@ package org.wso2.micro.integrator.mediation.security.vault;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.config.SynapsePropertiesLoader;
+import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
 
 /**
@@ -31,7 +33,18 @@ class SecretCipherHander {
 	/* Root Secret Repository */
 	private CiphertextRepository parentRepository = CiphertextRepository.getInstance();
 	private FileSecretRepository fileSecretRepository = new FileSecretRepository();
-	private EnvironmentSecretRepository environmentSecretRepository =  new EnvironmentSecretRepository();
+	private EnvironmentSecretRepository environmentSecretRepository = new EnvironmentSecretRepository();
+	private RegistrySecretRepository registrySecretRepository;
+	private static final boolean registryEnabled = Boolean.parseBoolean(SynapsePropertiesLoader.getPropertyValue(
+					SecureVaultConstants.PROP_VAULT_REGISTRY_LOOKUP_ENABLED, "false"));
+
+	SecretCipherHander(MessageContext synCtx) {
+		super();
+		if (registryEnabled) {
+			registrySecretRepository = new RegistrySecretRepository();
+			registrySecretRepository.setSynCtx(synCtx);
+		}
+	}
 
 	/**
 	 * Returns the secret corresponding to the given alias name
@@ -58,7 +71,12 @@ class SecretCipherHander {
 			}
 			return environmentSecretRepository.getPlainTextSecret(alias);
 		} else if (VaultType.REG.equals(secretSrcData.getVaultType())) {
-			// For registry type we only support plain text
+			if (registryEnabled) {
+				String secret = registrySecretRepository.getSecret(alias);
+				if (secret != null) {
+					return secret;
+				}
+			}
 			return parentRepository.getSecret(alias);
 		} else {
 			// Will never reach here unless customized

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecureVaultConstants.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecureVaultConstants.java
@@ -59,5 +59,9 @@ public interface SecureVaultConstants {
 
 	String FILE_PROTOCOL_PREFIX = "file:";
 
-
+	/**
+	 * synapse.properties key to enable registry-backed vault lookup.
+	 * When false (default), vault-lookup falls back to cipher-text.properties only.
+	 */
+	String PROP_VAULT_REGISTRY_LOOKUP_ENABLED = "vault.registry.lookup.enabled";
 }

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecureVaultLookupHandlerImpl.java
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/src/main/java/org/wso2/micro/integrator/mediation/security/vault/SecureVaultLookupHandlerImpl.java
@@ -74,13 +74,13 @@ public class SecureVaultLookupHandlerImpl implements SecureVaultLookupHandler {
 					return cacheContext.getDecryptedValue();
 				} else {
 					decryptedCacheMap.remove(aliasPasword);
-					return vaultLookup(aliasPasword, secretSrcData, decryptedCacheMap);
+					return vaultLookup(aliasPasword, secretSrcData, decryptedCacheMap, synCtx);
 				}
 			} else {
-				return vaultLookup(aliasPasword, secretSrcData, decryptedCacheMap);
+				return vaultLookup(aliasPasword, secretSrcData, decryptedCacheMap, synCtx);
 			}
 		} else {
-			return vaultLookup(aliasPasword, secretSrcData, decryptedCacheMap);
+			return vaultLookup(aliasPasword, secretSrcData, decryptedCacheMap, synCtx);
 		}
 	}
 
@@ -96,9 +96,10 @@ public class SecureVaultLookupHandlerImpl implements SecureVaultLookupHandler {
 	 * @param synCtx synapse message context
 	 * @param decryptedCacheMap decrypted cache map from the message context
 	 * */
-	private String vaultLookup(String aliasPasword, SecretSrcData secretSrcData, Map<String, Object> decryptedCacheMap) {
+	private String vaultLookup(String aliasPasword, SecretSrcData secretSrcData, Map<String, Object> decryptedCacheMap,
+	                           MessageContext synCtx) {
 		synchronized (decryptlockObj) {
-			SecretCipherHander secretManager = new SecretCipherHander();
+			SecretCipherHander secretManager = new SecretCipherHander(synCtx);
 			String decryptedValue = secretManager.getSecret(aliasPasword, secretSrcData);
 			if (decryptedCacheMap == null) {
 				return null;

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
@@ -102,14 +102,17 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
      * @param artifacts     - list of artifacts to be deployed
      * @param parentAppName - name of the parent cApp
      */
-    private void deployRegistryArtifacts(List<Artifact> artifacts, String parentAppName) {
-        artifacts.stream().filter(artifact -> REGISTRY_RESOURCE_TYPE.equals(artifact.getType())).forEach(artifact -> {
+    private void deployRegistryArtifacts(List<Artifact> artifacts, String parentAppName) throws DeploymentException {
+        for (Artifact artifact : artifacts) {
+            if (!REGISTRY_RESOURCE_TYPE.equals(artifact.getType())) {
+                continue;
+            }
             if (log.isDebugEnabled()) {
                 log.debug("Deploying registry artifact: " + artifact.getName());
             }
             RegistryConfig regConfig = buildRegistryConfig(artifact, parentAppName);
             writeArtifactToRegistry(regConfig);
-        });
+        }
     }
 
     /**
@@ -190,7 +193,7 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
      *
      * @param registryConfig - Artifact instance
      */
-    private void writeArtifactToRegistry(RegistryConfig registryConfig){
+    private void writeArtifactToRegistry(RegistryConfig registryConfig) throws DeploymentException {
 
         // write resources
         List<RegistryConfig.Resourse> resources = registryConfig.getResources();
@@ -207,9 +210,8 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
             }
             String resourcePath = AppDeployerUtils.computeResourcePath(createRegistryKey(resource), resource.getFileName(), registryConfig);
             if (MicroIntegratorRegistry.isWriteProtected(resourcePath)) {
-                log.warn("Skipping CAPP registry resource deployment: path '" + resourcePath
-                        + "' is write-protected.");
-                continue;
+                throw new DeploymentException("CAPP deployment rejected: registry path '" + resourcePath
+                        + "' is write-protected and cannot be overwritten by a CAPP.");
             }
             String mediaType = resource.getMediaType();
             ((MicroIntegratorRegistry)lightweightRegistry).addNewNonEmptyResource(resourcePath, false, mediaType,
@@ -231,9 +233,8 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
             }
             String directoryRegistryPath = createRegistryPath(collection.getPath());
             if (MicroIntegratorRegistry.isWriteProtected(directoryRegistryPath)) {
-                log.warn("Skipping CAPP registry collection deployment: path '" + directoryRegistryPath
-                        + "' is write-protected.");
-                continue;
+                throw new DeploymentException("CAPP deployment rejected: registry path '" + directoryRegistryPath
+                        + "' is write-protected and cannot be overwritten by a CAPP.");
             }
             ((MicroIntegratorRegistry)lightweightRegistry).addNewNonEmptyResource(
                     directoryRegistryPath, true, "", "",

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
@@ -206,6 +206,11 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
                 continue;
             }
             String resourcePath = AppDeployerUtils.computeResourcePath(createRegistryKey(resource), resource.getFileName(), registryConfig);
+            if (MicroIntegratorRegistry.isWriteProtected(resourcePath)) {
+                log.warn("Skipping CAPP registry resource deployment: path '" + resourcePath
+                        + "' is write-protected.");
+                continue;
+            }
             String mediaType = resource.getMediaType();
             ((MicroIntegratorRegistry)lightweightRegistry).addNewNonEmptyResource(resourcePath, false, mediaType,
                                                                                   readResourceContent(file),
@@ -225,6 +230,11 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
                 continue;
             }
             String directoryRegistryPath = createRegistryPath(collection.getPath());
+            if (MicroIntegratorRegistry.isWriteProtected(directoryRegistryPath)) {
+                log.warn("Skipping CAPP registry collection deployment: path '" + directoryRegistryPath
+                        + "' is write-protected.");
+                continue;
+            }
             ((MicroIntegratorRegistry)lightweightRegistry).addNewNonEmptyResource(
                     directoryRegistryPath, true, "", "",
                     collection.getProperties());

--- a/distribution/src/resources/config-tool/key-mappings.json
+++ b/distribution/src/resources/config-tool/key-mappings.json
@@ -110,6 +110,7 @@
   "mediation.internal_http_api_enable": "synapse_properties.'internal.http.api.enabled'",
   "mediation.internal_http_api_port": "synapse_properties.'internal.http.api.port'",
   "mediation.internal_https_api_port": "synapse_properties.'internal.https.api.port'",
+  "mediation.vault_registry_lookup_enabled": "synapse_properties.'vault.registry.lookup.enabled'",
 
   "mediation.http_client.global_connection_timeout": "synapse_properties.'http.client.global.connection.timeout'",
   "mediation.http_client.global_connection_request_timeout": "synapse_properties.'http.client.global.connection.request.timeout'",


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Resolves https://github.com/wso2/product-integrator-mi/issues/4903

This PR brings the following improvements. 

- Add vault lookup support from registry: wso2:vault-lookup() now checks
  secrets stored as properties on conf:/repository/components/secure-vault
  when vault.registry.lookup.enabled=true in synapse.properties
- Protect conf:/repository/components/secure-vault from accidental CAPP
  deployment overwrites when vault.registry.lookup.enabled=true