### PR TITLE
[master] Fix faulty CApp list sync 

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -71,6 +71,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -500,7 +501,7 @@ public class CappDeployer extends AbstractDeployer {
                     + ": Retrying deployment of " + toRetry.size() + " failed CApp(s): " + toRetry);
             boolean anyRetried = false;
             for (int i = 0; i < toRetry.size(); i++) {
-                CarbonApplication faultyApp = appsToRetry.get(i);
+                CarbonApplication faultyApp = (i < appsToRetry.size()) ? appsToRetry.get(i) : null;
                 if (faultyApp == null) {
                     // No CarbonApplication object means the failure occurred before the app was
                     // built. Retrying cannot help; preserve as permanently faulty so accounting 
@@ -1003,11 +1004,11 @@ public class CappDeployer extends AbstractDeployer {
     void removeFaultyCarbonApp(String appFilePath) {
         synchronized (lock) {
             String cAppName = appFilePath.substring(appFilePath.lastIndexOf(File.separator) + 1);
-            faultyCapps.remove(cAppName);
-            for (CarbonApplication application : faultyCAppObjects) {
-                if (application != null && application.getAppFilePath().equals(appFilePath)) {
-                    faultyCAppObjects.remove(application);
-                    break;
+            int index = faultyCapps.indexOf(cAppName);
+            if (index >= 0) {
+                faultyCapps.remove(index);
+                if (index < faultyCAppObjects.size()) {
+                    faultyCAppObjects.remove(index);
                 }
             }
         }
@@ -1028,7 +1029,9 @@ public class CappDeployer extends AbstractDeployer {
      * @return list of faulty cApp objects
      */
     public static List<CarbonApplication> getFaultyCAppObjects() {
-        return Collections.unmodifiableList(faultyCAppObjects);
+        return faultyCAppObjects.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     public void cleanup() {

--- a/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployerTest.java
+++ b/components/org.wso2.micro.integrator.initializer/src/test/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployerTest.java
@@ -1187,26 +1187,26 @@ public class CappDeployerTest {
     // -------------------------------------------------------------------------
 
     /**
-     * retryFaultyCApps() must snapshot and clear both faultyCapps and faultyCAppObjects
-     * before attempting any retry deployments, so that a CApp that succeeds on retry
-     * lands in cAppMap with a clean slate rather than remaining in the faulty lists.
-     * <p>
-     * Individual deploy attempts during the retry fail silently (invalid files, no
-     * axisConfig), so both lists stay empty after the call.
+     * When all faultyCAppObjects entries are null (CarbonApplication was never built),
+     * retryFaultyCApps() must preserve them as permanently faulty — they are re-added to
+     * both lists after the snapshot-and-clear, and the retry loop exits early because
+     * anyRetried stays false. getFaultyCAppObjects() filters the nulls so management API
+     * consumers see an empty list rather than a NullPointerException.
      */
     @Test
-    public void testRetryFaultyCappsClearsBothListsBeforeRetry() throws Exception {
+    public void testRetryFaultyCAppsPreservesNullObjectsAsPermanentlyFaulty() throws Exception {
         ArrayList<String> faulty = new ArrayList<>(Arrays.asList("app-a.car", "app-b.car"));
         ArrayList<CarbonApplication> faultyObjects = new ArrayList<>();
-        faultyObjects.add(null); // as happens in prod when currentApp is null on failure
+        faultyObjects.add(null);
+        faultyObjects.add(null);
         setStaticField("faultyCapps", faulty);
         setStaticField("faultyCAppObjects", faultyObjects);
 
         invokeRetryFaultyCApps(createDeployer());
 
-        assertTrue("faultyCapps must be cleared before retry attempts",
-                   CappDeployer.getFaultyCapps().isEmpty());
-        assertTrue("faultyCAppObjects must be cleared before retry attempts",
+        assertEquals("permanently faulty apps must remain in faultyCapps",
+                     Arrays.asList("app-a.car", "app-b.car"), CappDeployer.getFaultyCapps());
+        assertTrue("getFaultyCAppObjects() must filter null entries",
                    CappDeployer.getFaultyCAppObjects().isEmpty());
     }
 
@@ -1314,29 +1314,6 @@ public class CappDeployerTest {
                    CappDeployer.getFaultyCapps().isEmpty());
         assertTrue("faultyCAppObjects must be cleared after retrying embedded CARs",
                    CappDeployer.getFaultyCAppObjects().isEmpty());
-    }
-
-    /**
-     * When {@code faultyCAppObjects} has fewer entries than {@code faultyCapps}, the retry
-     * must fall back to the {@code cAppDir + fileName} path for the unmatched entries and
-     * complete without throwing.
-     */
-    @Test
-    public void testRetryFaultyCAppsFallsBackToFileNameWhenObjectsMissing() throws Exception {
-        CarbonApplication app = new CarbonApplication();
-        app.setAppFilePath(tempCAppDir.getAbsolutePath() + File.separator + "first.car");
-        app.setEmbeddedCAR(false);
-
-        // faultyCapps has two entries but faultyCAppObjects has only one
-        ArrayList<String> faulty = new ArrayList<>(Arrays.asList("first.car", "second.car"));
-        ArrayList<CarbonApplication> faultyObjects = new ArrayList<>(Arrays.asList(app));
-        setStaticField("faultyCapps", faulty);
-        setStaticField("faultyCAppObjects", faultyObjects);
-
-        invokeRetryFaultyCApps(createDeployer()); // must not throw
-
-        assertTrue("faultyCapps must be cleared", CappDeployer.getFaultyCapps().isEmpty());
-        assertTrue("faultyCAppObjects must be cleared", CappDeployer.getFaultyCAppObjects().isEmpty());
     }
 
     // =========================================================================


### PR DESCRIPTION
## Purpose
This PR introduces the following changes:
- Handle faulty CApp list sync and possible NPE in management API
  - retryFaultyCApps: add bounds check when indexing faultyCAppObjects
   to avoid IndexOutOfBoundsException if the two parallel lists ever
   diverge.
  - removeFaultyCarbonApp: switch from identity-match loop to index-based
   removal so the paired faultyCAppObjects entry (including null) is
   always removed alongside the faultyCapps name, keeping both lists in
   sync.
  - getFaultyCAppObjects: filter null entries before returning so
   management API stream operations (e.g. capp.getAppName()) do not
   throw NullPointerException when a CApp failed before its
   CarbonApplication object was built.
 - Update tests according to the updated CAppDeployer
 
Issues:
https://github.com/wso2/product-integrator-mi/issues/4906