### PR TITLE
Expose faulty standalone data service deployments via Management API

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBDeployer.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/DBDeployer.java
@@ -102,6 +102,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -109,6 +111,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -165,6 +168,16 @@ public class DBDeployer extends AbstractDeployer {
 	private static final String secureVaultRegex = "\\{(.*?):vault-lookup\\('(.*?)'\\)\\}";
 	private static Pattern vaultLookupPattern = Pattern.compile(secureVaultRegex);
 
+	/**
+	 * Tracks data services that failed to deploy, keyed by absolute file path.
+	 * Entries are added on deploy failure and removed on undeploy.
+	 */
+	private static final Map<String, FaultyDataService> faultyDataServices = new ConcurrentHashMap<>();
+
+	public static Collection<FaultyDataService> getFaultyDataServices() {
+		return Collections.unmodifiableCollection(faultyDataServices.values());
+	}
+
 	public ConfigurationContext getConfigContext() {
 		return configCtx;
 	}
@@ -178,7 +191,9 @@ public class DBDeployer extends AbstractDeployer {
         /* If there's already a faulty service corresponding to this particular service,
            remove it */
         if (isFaultyService(deploymentFileData)) {
-            this.axisConfig.removeFaultyService(deploymentFileData.getFile().getAbsolutePath());
+            String path = deploymentFileData.getFile().getAbsolutePath();
+            this.axisConfig.removeFaultyService(path);
+            faultyDataServices.remove(path);
         }
 
 		String serviceHierarchy = Utils.getServiceHierarchy(
@@ -191,14 +206,20 @@ public class DBDeployer extends AbstractDeployer {
 		boolean successfullyDeployed = false;
 		/* used to store the error message if there is a problem in deploying */
 		String errorMessage = null;
+		/* full stack trace for the faulty service store and Axis2 fault map */
+		String faultStackTrace = null;
+		/* service name parsed from .dbs content; used to populate the faulty store */
+		String parsedServiceName = null;
+		/* effective deployed identifier (includes hierarchy/version prefix); used as the fault store key */
+		String serviceGroupName = null;
 		/* Axis2 service to be deployed */
 		AxisService service = null;
 
 		try {
 			/* In the context of dataservices one service group will only contain one dataservice.
             *  Hence assigning the service group as the service group name */
-            String serviceGroupName = serviceHierarchy +
-                    this.getServiceNameFromDSContents(deploymentFileData.getFile());
+            parsedServiceName = this.getServiceNameFromDSContents(deploymentFileData.getFile());
+            serviceGroupName = serviceHierarchy + parsedServiceName;
 
 			if (SynapsePropertiesLoader.getBooleanProperty(SynapseConstants.EXPOSE_VERSIONED_SERVICES, false)) {
 				if (deploymentFileData.isVersionedDeployment()) {
@@ -262,7 +283,8 @@ public class DBDeployer extends AbstractDeployer {
 			successfullyDeployed = true;
 
 		} catch (DataServiceFault e) {
-			errorMessage = DBUtils.getStacktraceFromException(e);
+			faultStackTrace = DBUtils.getStacktraceFromException(e);
+			errorMessage = e.getMessage();
 			log.error(Messages.getMessage(DeploymentErrorMsgs.INVALID_SERVICE, deploymentFileData.getName()), e);
 			/* if there is a request to re-schedule in the exception, do it .. */
 			if (DBConstants.FaultCodes.CONNECTION_UNAVAILABLE_ERROR.equals(e.getCode())) {
@@ -282,7 +304,8 @@ public class DBDeployer extends AbstractDeployer {
 					DeploymentErrorMsgs.INVALID_SERVICE,
 					deploymentFileData.getName()), e);
 		} catch (Throwable e) {
-			errorMessage = DBUtils.getStacktraceFromException(e);
+			faultStackTrace = DBUtils.getStacktraceFromException(e);
+			errorMessage = e.getMessage();
 			log.error(Messages.getMessage(DeploymentErrorMsgs.INVALID_SERVICE, deploymentFileData.getName()), e);
 			throw new DeploymentException(Messages.getMessage(
 					DeploymentErrorMsgs.INVALID_SERVICE,
@@ -291,13 +314,22 @@ public class DBDeployer extends AbstractDeployer {
 			if (!successfullyDeployed)	{
 				String deploymentFilePath = deploymentFileData.getFile().getAbsolutePath();
 				/* Register the faulty service */
-				this.axisConfig.getFaultyServices().put(deploymentFilePath, errorMessage);
+				this.axisConfig.getFaultyServices().put(deploymentFilePath, faultStackTrace);
                 try {
                 	CarbonUtils.registerFaultyService(deploymentFilePath,
                     		DBConstants.DB_SERVICE_TYPE, configCtx);
                 } catch (Exception e) {
                     log.error("Cannot register faulty service with Carbon", e);
                 }
+                /* Track in the dedicated faulty data service store for Management API exposure.
+                 * Use serviceGroupName (includes hierarchy/version prefix) so the stored name
+                 * matches what the list API returns and the fault endpoint can resolve it. */
+                String filename = deploymentFileData.getFile().getName();
+                String dsName = (serviceGroupName != null) ? serviceGroupName
+                        : (parsedServiceName != null) ? parsedServiceName
+                        : (filename.contains(".") ? filename.substring(0, filename.lastIndexOf('.')) : filename);
+                faultyDataServices.put(deploymentFilePath,
+                        new FaultyDataService(dsName, deploymentFilePath, errorMessage, faultStackTrace));
 			}
 		}
 	}
@@ -475,6 +507,7 @@ public class DBDeployer extends AbstractDeployer {
                    axisConfiguration itself.
                    */
                 this.axisConfig.removeFaultyService(servicePath);
+                faultyDataServices.remove(servicePath);
 				return;
 			}
 			String serviceHierarchy = Utils.getServiceHierarchy(servicePath, this.repoDir);
@@ -488,6 +521,7 @@ public class DBDeployer extends AbstractDeployer {
 //			CarbonContext cCtx = CarbonContextrbonContext.getThreadLocalCarbonContext();
 			if (serviceGroup == null) { /* must be a faulty service */
 				this.axisConfig.removeFaultyService(servicePath);
+				faultyDataServices.remove(servicePath);
 				for (String configID : dataService.getConfigs().keySet()) {
 					if (dataService.getConfig(configID).isODataEnabled()) {
 						removeODataHandler(org.wso2.micro.core.Constants.SUPER_TENANT_DOMAIN_NAME, dataService.getName() + configID);

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/FaultyDataService.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/FaultyDataService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.micro.integrator.dataservices.core;
+
+/**
+ * Holds deployment failure details for a data service that failed to deploy.
+ * Populated by DBDeployer on deploy failure and cleared on undeploy.
+ */
+public class FaultyDataService {
+
+    private final String serviceName;
+    private final String errorMessage;
+    private final String faultStackTrace;
+
+    public FaultyDataService(String serviceName, String filePath, String errorMessage, String faultStackTrace) {
+        this.serviceName = serviceName;
+        this.errorMessage = errorMessage;
+        this.faultStackTrace = faultStackTrace;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public String getFaultStackTrace() {
+        return faultStackTrace;
+    }
+}

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/Constants.java
@@ -42,6 +42,8 @@ public class Constants {
     public static final String PREFIX_USERS = "/users";
     public static final String PATH_PARAM_USER = "/" + "{userId}";
     public static final String PREFIX_DATA_SERVICES = "/data-services";
+    public static final String PATH_PARAM_DATA_SERVICE_NAME = "/" + "{name}";
+    public static final String PATH_PARAM_DATA_SERVICE_FAULT = PATH_PARAM_DATA_SERVICE_NAME + "/fault";
     public static final String PREFIX_TEMPLATES = "/templates";
     public static final String PREFIX_MESSAGE_STORE = "/message-stores";
     public static final String PREFIX_MESSAGE_PROCESSORS = "/message-processors";

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/DataServiceResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/DataServiceResource.java
@@ -98,7 +98,7 @@ public class DataServiceResource extends APIResource {
             log.debug("Handling fault detail request for data service: " + pathParamName);
             try {
                 populateFaultyDataServiceData(msgCtx, pathParamName);
-            } catch (Exception exception) {
+            } catch (RuntimeException exception) {
                 log.error("Error while populating faulty data service: ", exception);
                 msgCtx.setProperty(Constants.HTTP_STATUS_CODE, Constants.INTERNAL_SERVER_ERROR);
             }

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/DataServiceResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/DataServiceResource.java
@@ -17,7 +17,6 @@
 package org.wso2.micro.integrator.management.apis;
 
 import com.google.gson.Gson;
-import org.apache.axis2.AxisFault;
 import org.apache.axis2.description.AxisService;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.commons.logging.Log;
@@ -28,7 +27,9 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.json.JSONObject;
 import org.wso2.carbon.inbound.endpoint.internal.http.api.APIResource;
 import org.wso2.micro.integrator.dataservices.common.DBConstants;
+import org.wso2.micro.integrator.dataservices.core.DBDeployer;
 import org.wso2.micro.integrator.dataservices.core.DBUtils;
+import org.wso2.micro.integrator.dataservices.core.FaultyDataService;
 import org.wso2.micro.integrator.dataservices.core.description.config.Config;
 import org.wso2.micro.integrator.dataservices.core.description.operation.Operation;
 import org.wso2.micro.integrator.dataservices.core.description.query.Query;
@@ -37,7 +38,6 @@ import org.wso2.micro.integrator.dataservices.core.engine.DataService;
 import org.wso2.micro.integrator.dataservices.core.engine.DataServiceSerializer;
 import org.wso2.micro.integrator.management.apis.models.dataServices.DataServiceInfo;
 import org.wso2.micro.integrator.management.apis.models.dataServices.DataServiceSummary;
-import org.wso2.micro.integrator.management.apis.models.dataServices.DataServicesList;
 import org.wso2.micro.integrator.management.apis.models.dataServices.DataSourceInfo;
 import org.wso2.micro.integrator.management.apis.models.dataServices.OperationInfo;
 import org.wso2.micro.integrator.management.apis.models.dataServices.QuerySummary;
@@ -45,26 +45,34 @@ import org.wso2.micro.integrator.management.apis.models.dataServices.ResourceInf
 import org.wso2.micro.service.mgt.ServiceAdmin;
 import org.wso2.micro.service.mgt.ServiceMetaData;
 
-import java.util.Set;
-import java.util.List;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
-
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.wso2.micro.integrator.management.apis.Constants.NOT_FOUND;
 import static org.wso2.micro.integrator.management.apis.Constants.SEARCH_KEY;
 
 public class DataServiceResource extends APIResource {
 
     private static final Log log = LogFactory.getLog(DataServiceResource.class);
 
+    private static final String FAULT_PATH_SUFFIX = "/fault";
+
     private static ServiceAdmin serviceAdmin = null;
+
+    private final String urlTemplate;
 
     public DataServiceResource(String urlTemplate) {
         super(urlTemplate);
+        this.urlTemplate = urlTemplate;
     }
 
     @Override
@@ -80,6 +88,24 @@ public class DataServiceResource extends APIResource {
         if (serviceAdmin == null) {
             serviceAdmin = Utils.getServiceAdmin(msgCtx);
         }
+
+        org.apache.axis2.context.MessageContext axis2MessageContext =
+                ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
+
+        // Fault detail request: GET /management/data-services/{name}/fault
+        if (urlTemplate.endsWith(FAULT_PATH_SUFFIX)) {
+            String pathParamName = Utils.getPathParameter(msgCtx, "name");
+            log.debug("Handling fault detail request for data service: " + pathParamName);
+            try {
+                populateFaultyDataServiceData(msgCtx, pathParamName);
+            } catch (Exception exception) {
+                log.error("Error while populating faulty data service: ", exception);
+                msgCtx.setProperty(Constants.HTTP_STATUS_CODE, Constants.INTERNAL_SERVER_ERROR);
+            }
+            axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
+            return true;
+        }
+
         String param = Utils.getQueryParameter(msgCtx, "dataServiceName");
         String searchKey = Utils.getQueryParameter(msgCtx, SEARCH_KEY);
 
@@ -88,7 +114,7 @@ public class DataServiceResource extends APIResource {
                 // data-service specified by name
                 populateDataServiceByName(msgCtx, param);
             } else if (Objects.nonNull(searchKey) && !searchKey.trim().isEmpty()) {
-                populateSearchResults(msgCtx, searchKey.toLowerCase());
+                populateSearchResults(msgCtx, searchKey);
             } else {
                 // list of all data-services
                 populateDataServiceList(msgCtx);
@@ -98,50 +124,96 @@ public class DataServiceResource extends APIResource {
             msgCtx.setProperty(Constants.HTTP_STATUS_CODE, Constants.INTERNAL_SERVER_ERROR);
         }
 
-        org.apache.axis2.context.MessageContext axis2MessageContext = ((Axis2MessageContext) msgCtx)
-                .getAxis2MessageContext();
-
         axis2MessageContext.removeProperty(Constants.NO_ENTITY_BODY);
         return true;
     }
 
-    private List<String> getSearchResults(MessageContext messageContext, String searchKey) throws AxisFault {
-        SynapseConfiguration configuration = messageContext.getConfiguration();
-        AxisConfiguration axisConfiguration = configuration.getAxisConfiguration();
-        return Arrays.stream(DBUtils.getAvailableDS(axisConfiguration))
-                .filter(serviceName -> serviceName.toLowerCase().contains(searchKey)).collect(Collectors.toList());
-    }
-
-    private void populateSearchResults(MessageContext messageContext, String searchKey) throws Exception {
-        List<String> resultsList = getSearchResults(messageContext, searchKey);
-        setResponseBody(resultsList, messageContext);
-    }
-
-    private void setResponseBody(List<String> dataServicesNames, MessageContext messageContext) throws Exception {
+    private void populateSearchResults(MessageContext msgCtx, String searchKey) throws Exception {
 
         org.apache.axis2.context.MessageContext axis2MessageContext =
-                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+                ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
 
-        DataServicesList dataServicesList = new DataServicesList(dataServicesNames.size());
-
-        for (String dataServiceName : dataServicesNames) {
-            DataService dataService = getDataServiceByName(messageContext, dataServiceName);
-            ServiceMetaData serviceMetaData = getServiceMetaData(dataService);
-            // initiate summary model
-            DataServiceSummary summary = null;
-            if (serviceMetaData != null) {
-                summary = new DataServiceSummary(serviceMetaData.getName(), serviceMetaData.getWsdlURLs());
-            }
-            dataServicesList.addServiceSummary(summary);
-        }
-        String stringPayload = new Gson().toJson(dataServicesList);
-        Utils.setJsonPayLoad(axis2MessageContext, new JSONObject(stringPayload));
-    }
-    private void populateDataServiceList(MessageContext msgCtx) throws Exception {
         SynapseConfiguration configuration = msgCtx.getConfiguration();
         AxisConfiguration axisConfiguration = configuration.getAxisConfiguration();
-        List<String> dataServicesNames = Arrays.stream(DBUtils.getAvailableDS(axisConfiguration)).collect(Collectors.toList());
-        setResponseBody(dataServicesNames, msgCtx);
+
+        String normalized = searchKey.toLowerCase(Locale.ROOT);
+
+        // Active matches
+        List<String> matchedNames = Arrays.stream(DBUtils.getAvailableDS(axisConfiguration))
+                .filter(name -> name.toLowerCase(Locale.ROOT).contains(normalized))
+                .collect(Collectors.toList());
+        List<DataServiceSummary> summaryList = new ArrayList<>();
+        for (String dataServiceName : matchedNames) {
+            AxisService axisService = axisConfiguration.getServiceForActivation(dataServiceName);
+            if (axisService == null) {
+                continue;
+            }
+            DataService dataService = (DataService) axisService.getParameter(DBConstants.DATA_SERVICE_OBJECT).getValue();
+            ServiceMetaData serviceMetaData = getServiceMetaData(dataService);
+            if (serviceMetaData != null) {
+                summaryList.add(new DataServiceSummary(serviceMetaData.getName(), serviceMetaData.getWsdlURLs()));
+            }
+        }
+        // Faulty matches
+        List<FaultyDataService> faultyMatches = DBDeployer.getFaultyDataServices().stream()
+                .filter(fds -> fds.getServiceName().toLowerCase(Locale.ROOT).contains(normalized))
+                .collect(Collectors.toList());
+        List<Map<String, String>> faultyEntries = new ArrayList<>();
+        for (FaultyDataService fds : faultyMatches) {
+            Map<String, String> entry = new LinkedHashMap<>();
+            entry.put("name", fds.getServiceName());
+            entry.put("errorMessage", fds.getErrorMessage() != null ? fds.getErrorMessage() : "");
+            faultyEntries.add(entry);
+        }
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("count", summaryList.size());
+        response.put("list", summaryList);
+        response.put("faultyCount", faultyMatches.size());
+        response.put("faultyList", faultyEntries);
+
+        Utils.setJsonPayLoad(axis2MessageContext, new Gson().toJson(response));
+    }
+
+    private void populateDataServiceList(MessageContext msgCtx) throws Exception {
+
+        org.apache.axis2.context.MessageContext axis2MessageContext =
+                ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
+
+        SynapseConfiguration configuration = msgCtx.getConfiguration();
+        AxisConfiguration axisConfiguration = configuration.getAxisConfiguration();
+        List<String> dataServicesNames =
+                Arrays.stream(DBUtils.getAvailableDS(axisConfiguration)).collect(Collectors.toList());
+
+        // Build active list
+        List<DataServiceSummary> summaryList = new ArrayList<>();
+        for (String dataServiceName : dataServicesNames) {
+            AxisService axisService = axisConfiguration.getServiceForActivation(dataServiceName);
+            if (axisService == null) {
+                continue;
+            }
+            DataService dataService = (DataService) axisService.getParameter(DBConstants.DATA_SERVICE_OBJECT).getValue();
+            ServiceMetaData serviceMetaData = getServiceMetaData(dataService);
+            if (serviceMetaData != null) {
+                summaryList.add(new DataServiceSummary(serviceMetaData.getName(), serviceMetaData.getWsdlURLs()));
+            }
+        }
+        Collection<FaultyDataService> faultyCollection = DBDeployer.getFaultyDataServices();
+        List<Map<String, String>> faultyEntries = new ArrayList<>();
+        for (FaultyDataService fds : faultyCollection) {
+            Map<String, String> entry = new LinkedHashMap<>();
+            entry.put("name", fds.getServiceName());
+            entry.put("errorMessage", fds.getErrorMessage() != null ? fds.getErrorMessage() : "");
+            faultyEntries.add(entry);
+        }
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("count", summaryList.size());
+        response.put("list", summaryList);
+        response.put("faultyCount", faultyCollection.size());
+        response.put("faultyList", faultyEntries);
+
+        Utils.setJsonPayLoad(axis2MessageContext, new Gson().toJson(response));
     }
 
     private void populateDataServiceByName(MessageContext msgCtx, String serviceName) throws Exception {
@@ -177,6 +249,30 @@ public class DataServiceResource extends APIResource {
             String stringPayload = new Gson().toJson(dataServiceInfo);
             Utils.setJsonPayLoad(axis2MessageContext, new JSONObject(stringPayload));
         }
+    }
+
+    private void populateFaultyDataServiceData(MessageContext msgCtx, String serviceName) {
+
+        org.apache.axis2.context.MessageContext axis2MessageContext =
+                ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
+
+        FaultyDataService faultyDs = DBDeployer.getFaultyDataServices().stream()
+                .filter(fds -> serviceName.equals(fds.getServiceName()))
+                .findFirst().orElse(null);
+
+        if (faultyDs == null) {
+            log.warn("Faulty data service not found for the given name: " + serviceName);
+            Utils.setJsonPayLoad(axis2MessageContext,
+                    Utils.createJsonError("Faulty data service not found for the given name: " + serviceName,
+                            axis2MessageContext, NOT_FOUND));
+            return;
+        }
+
+        Map<String, String> jsonBody = new LinkedHashMap<>();
+        jsonBody.put("serviceName", faultyDs.getServiceName());
+        jsonBody.put("errorMessage", faultyDs.getErrorMessage() != null ? faultyDs.getErrorMessage() : "");
+        jsonBody.put("faultStackTrace", faultyDs.getFaultStackTrace() != null ? faultyDs.getFaultStackTrace() : "");
+        Utils.setJsonPayLoad(axis2MessageContext, new Gson().toJson(jsonBody));
     }
 
     private DataService getDataServiceByName(MessageContext msgCtx, String serviceName) {

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementInternalApi.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ManagementInternalApi.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_CARBON_APP_FAULT;
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_CARBON_APP_NAME;
+import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_DATA_SERVICE_FAULT;
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_EXTERNAL_VAULT_NAME;
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_ROLE;
 import static org.wso2.micro.integrator.management.apis.Constants.PATH_PARAM_TRANSACTION;
@@ -87,6 +88,7 @@ public class ManagementInternalApi implements InternalAPI {
         resourcesList.add(new TaskResource(PREFIX_TASKS));
         resourcesList.add(new SequenceResource(PREFIX_SEQUENCES));
         resourcesList.add(new DataServiceResource(PREFIX_DATA_SERVICES));
+        resourcesList.add(new DataServiceResource(PREFIX_DATA_SERVICES + PATH_PARAM_DATA_SERVICE_FAULT));
         resourcesList.add(new TemplateResource(PREFIX_TEMPLATES));
         resourcesList.add(new LoggingResource(PREFIX_LOGGING));
         resourcesList.add(new ApiResourceAdapter(PREFIX_MESSAGE_STORE, new MessageStoreResource()));

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/resources/management-api.yaml
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/resources/management-api.yaml
@@ -1307,6 +1307,12 @@ paths:
           schema:
             type: string
           description: The name of the data service to retrieve information for.
+        - name: searchKey
+          in: query
+          required: false
+          schema:
+            type: string
+          description: A keyword to filter data services by name (case-insensitive).
       responses:
         '200':
           description: Successful response
@@ -1318,7 +1324,7 @@ paths:
                   count:
                     type: integer
                     example: 1
-                    description: The number of data services deployed.
+                    description: The number of successfully deployed data services.
                   list:
                     type: array
                     items:
@@ -1336,6 +1342,59 @@ paths:
                           type: string
                           example: http://Sachiths-MacBook-Pro.local:8290/services/StudentDataService?wsdl2
                           description: The WSDL 2.0 URL of the data service.
+                  faultyCount:
+                    type: integer
+                    example: 1
+                    description: The number of data services that failed to deploy.
+                  faultyList:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          example: FaultyDataService
+                          description: The name of the faulty data service.
+                        errorMessage:
+                          type: string
+                          example: "Cannot connect to the database."
+                          description: A short description of the deployment failure.
+      security:
+        - BearerAuth: []
+  /data-services/{name}/fault:
+    get:
+      summary: Get Faulty Data Service Details
+      description: Retrieves the full deployment failure details for a data service that failed to deploy.
+      tags:
+        - Data Services
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the faulty data service.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  serviceName:
+                    type: string
+                    example: FaultyDataService
+                    description: The name of the faulty data service.
+                  errorMessage:
+                    type: string
+                    example: "Cannot connect to the database."
+                    description: A short description of the deployment failure.
+                  faultStackTrace:
+                    type: string
+                    description: The full stack trace of the deployment failure.
+        '404':
+          description: No faulty data service found with the given name.
       security:
         - BearerAuth: []
   /data-sources:


### PR DESCRIPTION
## Purpose
Standalone .dbs data services that fail to deploy are now tracked in DBDeployer and exposed through the Management API, enabling ICP to surface deployment failures.

1. The faulty data services are added to the `GET /management/data-services`
```
{
  "count": 2,
  "list": [...],
  "faultyCount": 1,
  "faultyList": [
        {
            "name": "capp-f-2",
            "errorMessage": "DS Fault Message: Access denied for user 'root'@'localhost' (using password: YES)\nNested Exception:-\njava.sql.SQLException: Access denied for user 'root'@'localhost' (using password: YES)\nSource Data Service:-\nName: capp-f-2\nLocation: /Users/dedunukarunarathne/Documents/RRT/dbs-fault/wso2mi-4.5.0/tmp/carbonapps/-1234/1781084510806data-service-fault_1.0.0.car/capp-f-2_1.0.0/capp-f-2-1.0.0.dbs\nDescription: \nDefault Namespace: http://ws.wso2.org/dataservice\nDS Code: CONNECTION_UNAVAILABLE_ERROR\n",
        }
    ]
}
```

2. Introduced a new resource to get the stack trace `GET /management/data-services/{name}/fault`

```
{
  "serviceName": "BrokenDS",
  "errorMessage": "",
  "faultStackTrace": ""
}
```

Fixes: https://github.com/wso2/product-integrator-mi/issues/4940