### PR TITLE
Fix Issues in CApp Deployment and File Operations

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/AppDeployerUtils.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/AppDeployerUtils.java
@@ -694,11 +694,11 @@ public final class AppDeployerUtils {
 
         zipFile = new ZipFile(sourcePath);
         entries = zipFile.entries();
+        String canonicalDirPath = new File(destPath).getCanonicalPath();
 
         while (entries.hasMoreElements()) {
             ZipEntry entry = (ZipEntry) entries.nextElement();
             String canonicalEntryPath = new File(destPath + entry.getName()).getCanonicalPath();
-            String canonicalDirPath = new File(destPath).getCanonicalPath();
             if (!canonicalEntryPath.startsWith(canonicalDirPath)) {
                 throw new DeploymentException("Entry is outside of the target dir: " + entry.getName());
             }

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/AppDeployerUtils.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/application/deployer/AppDeployerUtils.java
@@ -697,6 +697,12 @@ public final class AppDeployerUtils {
 
         while (entries.hasMoreElements()) {
             ZipEntry entry = (ZipEntry) entries.nextElement();
+            String canonicalEntryPath = new File(destPath + entry.getName()).getCanonicalPath();
+            String canonicalDirPath = new File(destPath).getCanonicalPath();
+            if (!canonicalEntryPath.startsWith(canonicalDirPath)) {
+                throw new DeploymentException("Entry is outside of the target dir: " + entry.getName());
+            }
+
             // we don't need to copy the META-INF dir
             if (entry.getName().startsWith("META-INF/")) {
                 continue;

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/CarbonAppResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/CarbonAppResource.java
@@ -262,21 +262,45 @@ public class CarbonAppResource extends APIResource {
      */
     private DataHandler createDataHandler(String cAppName) {
         ByteArrayDataSource bytArrayDS;
-        Path cAppPath = Paths.get(Utils.getCAppPath(), cAppName);
-        File file = new File(cAppPath.toString());
-        if (file.exists() && !file.isDirectory()) {
-            try (InputStream is = new BufferedInputStream(new FileInputStream(cAppPath.toString()))) {
-                bytArrayDS = new ByteArrayDataSource(is, Constants.MEDIA_TYPE_APPLICATION_OCTET_STREAM);
-                return new DataHandler(bytArrayDS);
-            } catch (FileNotFoundException e) {
-                log.error("Could not find the requested file : " + cAppName + " in : " + cAppPath.toString(), e);
-                return null;
-            } catch (IOException e) {
-                log.error("Error occurred while reading the file : " + cAppName + " in : " + cAppPath.toString(), e);
+
+        try {
+            // Reject if fileName contains path separators
+            if (cAppName.contains("/") || cAppName.contains("\\")) {
+                log.error("Invalid characters in cApp name : " + cAppName);
                 return null;
             }
-        } else {
-            log.error("Could not find the requested file : " + cAppName + " in : " + cAppPath.toString());
+
+            // Canonicalize the intended base directory
+            Path cAppBasePath = Paths.get(Utils.getCAppPath()).toRealPath();
+
+            // Resolve and normalize the full target path
+            Path cAppPath = cAppBasePath.resolve(cAppName).normalize();
+
+            // Validate the resolved path is still within the cApp directory
+            if (!cAppPath.startsWith(cAppBasePath)) {
+                log.error("Path traversal attempt detected for cApp : " + cAppName);
+                return null;
+            }
+
+            File file = cAppPath.toFile();
+            if (file.exists() && !file.isDirectory()) {
+                try (InputStream is = new BufferedInputStream(new FileInputStream(file))) {
+                    bytArrayDS = new ByteArrayDataSource(is, Constants.MEDIA_TYPE_APPLICATION_OCTET_STREAM);
+                    return new DataHandler(bytArrayDS);
+                } catch (FileNotFoundException e) {
+                    log.error("Could not find the requested file : " + cAppName + " in : " + cAppPath, e);
+                    return null;
+                } catch (IOException e) {
+                    log.error("Error occurred while reading the file : " + cAppName + " in : " + cAppPath, e);
+                    return null;
+                }
+            } else {
+                log.error("Could not find the requested file : " + cAppName + " in : " + cAppPath);
+                return null;
+            }
+
+        } catch (IOException e) {
+            log.error("Error resolving cApp file path for : " + cAppName, e);
             return null;
         }
     }
@@ -300,10 +324,33 @@ public class CarbonAppResource extends APIResource {
                     if (!iterator.hasNext()) {
                         String fileName = fileElement.getAttributeValue(new QName("filename"));
                         if (fileName != null && fileName.endsWith(".car")) {
-                            byte[] bytes = Base64.getDecoder().decode(fileElement.getText());
-                            Path cAppDirectoryPath = Paths.get(Utils.getCarbonHome(), "repository", "deployment",
-                                    "server", "carbonapps", fileName);
                             try {
+                                // Reject early before any filesystem operation
+                                if (fileName.contains("/") || fileName.contains("\\")) {
+                                    log.error("Invalid characters in file name : " + fileName);
+                                    jsonResponse = Utils.createJsonError("Error when deploying the Carbon "
+                                            + "Application. Invalid file name.", axisMsgCtx, BAD_REQUEST);
+                                    Utils.setJsonPayLoad(axisMsgCtx, jsonResponse);
+                                    return;
+                                }
+
+                                // Canonicalize the intended base directory
+                                Path cAppBasePath = Paths.get(Utils.getCarbonHome(), "repository", "deployment",
+                                        "server", "carbonapps").toRealPath();
+
+                                // Resolve and normalize — collapses any ../ sequences
+                                Path cAppDirectoryPath = cAppBasePath.resolve(fileName).normalize();
+
+                                // Enforce boundary — reject if resolved path escapes base dir
+                                if (!cAppDirectoryPath.startsWith(cAppBasePath)) {
+                                    log.error("Path traversal attempt detected for file : " + fileName);
+                                    jsonResponse = Utils.createJsonError("Error when deploying the Carbon "
+                                            + "Application. Invalid file name.", axisMsgCtx, BAD_REQUEST);
+                                    Utils.setJsonPayLoad(axisMsgCtx, jsonResponse);
+                                    return;
+                                }
+
+                                byte[] bytes = Base64.getDecoder().decode(fileElement.getText());
                                 Files.write(cAppDirectoryPath, bytes);
                                 log.info("Successfully added Carbon Application : " + fileName);
                                 jsonResponse.put(Constants.MESSAGE_JSON_ATTRIBUTE, "Successfully added Carbon Application "

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LogFilesResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/LogFilesResource.java
@@ -172,22 +172,44 @@ public class LogFilesResource extends APIResource {
     private DataHandler downloadArchivedLogFiles(String logFile) {
 
         ByteArrayDataSource bytArrayDS;
-        Path logFilePath = Paths.get(Utils.getCarbonLogsPath(), logFile);
 
-        File file = new File(logFilePath.toString());
-        if (file.exists() && !file.isDirectory()) {
-            try (InputStream is = new BufferedInputStream(new FileInputStream(logFilePath.toString()))) {
-                bytArrayDS = new ByteArrayDataSource(is, "text/xml");
-                return new DataHandler(bytArrayDS);
-            } catch (FileNotFoundException e) {
-                log.error("Could not find the requested file : " + logFile + " in : " + logFilePath.toString(), e);
-                return null;
-            } catch (IOException e) {
-                log.error("Error occurred while reading the file : " + logFile + " in : " + logFilePath.toString(), e);
+        try {
+            // Reject if fileName contains path separators
+            if (logFile.contains("/") || logFile.contains("\\")) {
+                log.error("Invalid characters in file name : " + logFile);
                 return null;
             }
-        } else {
-            log.error("Could not find the requested file : " + logFile + " in : " + logFilePath.toString());
+
+            // Canonicalize the intended base directory
+            Path logsBasePath = Paths.get(Utils.getCarbonLogsPath()).toRealPath();
+
+            // Resolve and normalize the full target path
+            Path logFilePath = logsBasePath.resolve(logFile).normalize();
+
+            // Validate the resolved path is still within the logs directory
+            if (!logFilePath.startsWith(logsBasePath)) {
+                log.error("Path traversal attempt detected for file : " + logFile);
+                return null;
+            }
+
+            File file = logFilePath.toFile();
+            if (file.exists() && !file.isDirectory()) {
+                try (InputStream is = new BufferedInputStream(new FileInputStream(file))) {
+                    bytArrayDS = new ByteArrayDataSource(is, "text/xml");
+                    return new DataHandler(bytArrayDS);
+                } catch (FileNotFoundException e) {
+                    log.error("Could not find the requested file : " + logFile + " in : " + logFilePath, e);
+                    return null;
+                } catch (IOException e) {
+                    log.error("Error occurred while reading the file : " + logFile + " in : " + logFilePath, e);
+                    return null;
+                }
+            } else {
+                log.error("Could not find the requested file : " + logFile + " in : " + logFilePath);
+                return null;
+            }
+        } catch (IOException e) {
+            log.error("Error resolving log file path for : " + logFile, e);
             return null;
         }
     }


### PR DESCRIPTION
This is to validate the files inside the capp before extracting and validate file paths before performing file operations.