### PR TITLE
Fix query-param attribute case mismatch in call-query serialization

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QuerySerializer.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/QuerySerializer.java
@@ -281,7 +281,7 @@ public class QuerySerializer {
         for (WithParam withParam : callQuery.getWithParams().values()) {
             withParamEl = fac.createOMElement(new QName(DBSFields.WITH_PARAM));
             withParamEl.addAttribute(DBSFields.NAME, withParam.getName(), null);
-            withParamEl.addAttribute(withParam.getParamType(), withParam.getParam(), null);
+            withParamEl.addAttribute(withParam.getParamType(), withParam.getOriginalName(), null);
             callQueryEl.addChild(withParamEl);
         }
         parentEl.addChild(callQueryEl);


### PR DESCRIPTION
## Purpose
Fix query-param attribute case mismatch in call-query serialization. 

Fixes: https://github.com/wso2/product-integrator-mi/issues/4983