### PR TITLE
Add integration test for ValidateMediator json-source attribute

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/validate/ValidateJsonSourceAttributeTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/validate/ValidateJsonSourceAttributeTestCase.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.esb.mediator.test.validate;
+
+import org.apache.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.clients.SimpleHttpClient;
+
+import java.io.IOException;
+
+/**
+ * Tests that the json-source attribute on the validate mediator correctly validates JSON
+ * extracted from a multipart/form-data request into a context property. The bug only
+ * manifests with multipart requests — not with a plain JSON body.
+ */
+public class ValidateJsonSourceAttributeTestCase extends ESBIntegrationTest {
+
+    private static final byte[] DUMMY_FILE_CONTENT = "dummy binary content".getBytes();
+    private SimpleHttpClient httpClient;
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+        super.init();
+        httpClient = new SimpleHttpClient();
+    }
+
+    @Test(groups = "wso2.esb",
+            description = "Validate JSON from multipart form field without json-source=true")
+    public void testValidJsonPropertyWithoutJsonSource() throws IOException {
+        String metadataJson = "{\"id\":\"123\",\"title\":\"My Document\"}";
+        HttpResponse response = httpClient.doPostWithMultipartFormData(
+                getApiInvocationURL("validateMediatorJsonSource") + "/withoutSourceType",
+                "metadata", metadataJson, "data.bin", DUMMY_FILE_CONTENT);
+        String responseBody = SimpleHttpClient.responseEntityBodyToString(response);
+        Assert.assertTrue(responseBody.contains("error"),
+                "Without json-source=true, the validate mediator should not validate JSON from a multipart form field. Response: " + responseBody);
+    }
+
+    @Test(groups = "wso2.esb",
+            description = "Validate JSON from multipart form field using json-source=true with valid payload")
+    public void testValidJsonPropertyPassesValidation() throws IOException {
+        String metadataJson = "{\"id\":\"123\",\"title\":\"My Document\"}";
+        HttpResponse response = httpClient.doPostWithMultipartFormData(
+                getApiInvocationURL("validateMediatorJsonSource"),
+                "metadata", metadataJson, "data.bin", DUMMY_FILE_CONTENT);
+        String responseBody = SimpleHttpClient.responseEntityBodyToString(response);
+        Assert.assertTrue(responseBody.contains("success"),
+                "Valid metadata in multipart form should pass JSON schema validation. Response: " + responseBody);
+    }
+
+    @Test(groups = "wso2.esb",
+            description = "Validate JSON from multipart form field using json-source=true with missing required field")
+    public void testMissingRequiredFieldFailsValidation() throws IOException {
+        String metadataJson = "{\"id\":\"123\"}";
+        HttpResponse response = httpClient.doPostWithMultipartFormData(
+                getApiInvocationURL("validateMediatorJsonSource"),
+                "metadata", metadataJson, "data.bin", DUMMY_FILE_CONTENT);
+        String responseBody = SimpleHttpClient.responseEntityBodyToString(response);
+        Assert.assertTrue(responseBody.contains("fail"),
+                "Metadata missing required 'title' field should fail JSON schema validation. Response: " + responseBody);
+    }
+
+    @Test(groups = "wso2.esb",
+            description = "Validate JSON from multipart form field using json-source=true with wrong field type")
+    public void testWrongFieldTypeFailsValidation() throws IOException {
+        String metadataJson = "{\"id\":123,\"title\":\"My Document\"}";
+        HttpResponse response = httpClient.doPostWithMultipartFormData(
+                getApiInvocationURL("validateMediatorJsonSource"),
+                "metadata", metadataJson, "data.bin", DUMMY_FILE_CONTENT);
+        String responseBody = SimpleHttpClient.responseEntityBodyToString(response);
+        Assert.assertTrue(responseBody.contains("fail"),
+                "Metadata with non-string 'id' should fail JSON schema validation. Response: " + responseBody);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/validateMediatorJsonSourceApi.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/validateMediatorJsonSourceApi.xml
@@ -1,0 +1,52 @@
+<api xmlns="http://ws.apache.org/ns/synapse" context="/validateMediatorJsonSource" name="validateMediatorJsonSourceApi">
+    <resource methods="POST">
+        <inSequence>
+            <property name="metadata" expression="//metadata/text()" scope="default"/>
+            <validate source="json-eval($ctx:metadata)" cache-schema="true" json-source="true">
+                <schema key="validateJsonSourceSchema"/>
+                <on-fail>
+                    <payloadFactory media-type="json">
+                        <format>{"result": "fail"}</format>
+                        <args/>
+                    </payloadFactory>
+                    <respond/>
+                </on-fail>
+            </validate>
+            <payloadFactory media-type="json">
+                <format>{"result": "success"}</format>
+                <args/>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+    </resource>
+    <resource methods="POST" uri-template="/withoutSourceType">
+        <inSequence>
+            <property name="metadata" expression="//metadata/text()" scope="default"/>
+            <validate source="json-eval($ctx:metadata)" cache-schema="true">
+                <schema key="validateJsonSourceSchema"/>
+                <on-fail>
+                    <payloadFactory media-type="json">
+                        <format>{"result": "fail"}</format>
+                        <args/>
+                    </payloadFactory>
+                    <respond/>
+                </on-fail>
+            </validate>
+            <payloadFactory media-type="json">
+                <format>{"result": "success"}</format>
+                <args/>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+        <faultSequence>
+            <log level="full">
+                <property name="ERROR" value="Error occurred while processing the request"/>
+            </log>
+            <payloadFactory media-type="json">
+                <format>{"result": "error"}</format>
+                <args/>
+            </payloadFactory>
+            <respond/>
+        </faultSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/local-entries/validateJsonSourceSchema.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/local-entries/validateJsonSourceSchema.xml
@@ -1,0 +1,14 @@
+<localEntry xmlns="http://ws.apache.org/ns/synapse" key="validateJsonSourceSchema"><![CDATA[{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    }
+  },
+  "required": ["id", "title"]
+}]]><description/>
+</localEntry>

--- a/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/SimpleHttpClient.java
+++ b/integration/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/SimpleHttpClient.java
@@ -179,6 +179,17 @@ public class SimpleHttpClient {
         return client.execute(request);
     }
 
+    public HttpResponse doPostWithMultipartFormData(String url, String textFieldName, String textFieldValue,
+                                                     String fileName, byte[] fileContent) throws IOException {
+        MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
+        entityBuilder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
+        entityBuilder.addTextBody(textFieldName, textFieldValue, ContentType.TEXT_PLAIN);
+        entityBuilder.addBinaryBody("file", fileContent, ContentType.APPLICATION_OCTET_STREAM, fileName);
+        HttpPost request = new HttpPost(url);
+        request.setEntity(entityBuilder.build());
+        return client.execute(request);
+    }
+
     public HttpResponse doPutWithMultipart(String url, File file, Map<String, String> header)
             throws IOException {
         MultipartEntityBuilder entitybuilder = MultipartEntityBuilder.create();


### PR DESCRIPTION
## Purpose

Tests that json-source="true" enables JSON schema validation when the source expression points to a JSON value stored in a context property rather than in the message body.

## Related PRs
https://github.com/wso2/wso2-synapse/pull/2587