### PR TITLE
Gracefull error handling when removing registry resources- #1275

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -531,6 +531,14 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
             }
 
             String[] children = file.list();
+            if (children == null) {
+                // The directory was removed or became unreadable after the isDirectory() check above.
+                if (log.isDebugEnabled()) {
+                    log.debug("Unable to list the children of " + file.getPath()
+                            + ". It may have been removed concurrently.");
+                }
+                return null;
+            }
             RegistryEntry[] entries = new RegistryEntry[children.length];
 
             for (int i = 0; i < children.length; i++) {
@@ -839,9 +847,38 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
         }
     }
 
+    /**
+     * Recursively deletes the given directory.
+     * <p>
+     * Deletion is treated as a convergent operation: the desired end state is that the directory is
+     * absent. The registry is not guarded against concurrent modification, so the same directory
+     * can be removed underneath us while we are deleting it. In a cluster this happens when the
+     * same CApp is hot-undeployed on several nodes that share the registry location, but it can
+     * equally be another thread of this node or an external process. In all of those cases the
+     * directory being already gone is a success, not a failure, so this method does not throw.
+     * Genuine failures (permission issues, IO errors, content being re-created underneath us)
+     * are logged so that they remain visible.
+     *
+     * @param dir directory to delete
+     */
     private void deleteDirectory(File dir) {
 
         File[] children = dir.listFiles();
+        if (children == null) {
+            // listFiles() returns null when the directory no longer exists, is not a directory,
+            // or could not be read.
+            if (!dir.exists()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Unable to delete the resource as " + dir.getPath()
+                        + " does not exist. It may have already been deleted concurrently.");
+                }
+                return;
+            }
+            log.warn("Unable to list the contents of the registry directory: " + dir.getPath()
+                + ". Skipping the deletion of the directory.");
+            return;
+        }
+
         for (File child : children) {
             if (child != null) {
                 if (child.isFile()) {
@@ -854,7 +891,17 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
 
         boolean success = dir.delete();
         if (!success) {
-            handleException("Unable to delete the resource: " + dir.getName());
+            if (!dir.exists()) {
+                // The directory was removed in the meantime. The desired end state is already reached.
+                if (log.isDebugEnabled()) {
+                    log.debug("The registry directory " + dir.getPath()
+                            + " has already been deleted concurrently while it was being removed.");
+                }
+            } else {
+                log.error("Unable to delete the resource: " + dir.getPath()
+                        + ". The directory still exists, it could be due to another process holding or re-creating "
+                        + "its content.");
+            }
         }
     }
 

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/RegistryHelper.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/RegistryHelper.java
@@ -70,14 +70,27 @@ public class RegistryHelper {
     }
 
     /**
-     * Check whether the directory is empty
+     * Check whether the directory is empty.
+     * <p>
+     * Returns false when the path is not an existing directory or when its content cannot be
+     * listed, which includes the case where the directory was removed concurrently. Callers use
+     * this method to decide whether a directory should be cleaned up, so reporting false for a
+     * directory that is already gone correctly skips that cleanup.
      *
-     * @param directory  directory path
+     * @param directory directory path
      */
     public static boolean isDirectoryEmpty (String directory) {
         File file = new File(directory);
         if (file.isDirectory()) {
-            return file.list().length == 0;
+            String[] children = file.list();
+            if (children == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Unable to list the contents of " + directory
+                        + ". It may have been removed concurrently.");
+                }
+                return false;
+            }
+            return children.length == 0;
         } else {
             return false;
         }

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/FileRegistryResourceDeployer.java
@@ -127,8 +127,24 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
             if (log.isDebugEnabled()) {
                 log.debug("Undeploying registry artifact: " + artifact.getName());
             }
-            RegistryConfig regConfig = buildRegistryConfig(artifact, parentAppName);
-            removeArtifactFromRegistry(regConfig);
+            // Undeployment of registry artifacts is best effort. A failure to clean up one artifact
+            // must not abort the undeployment of the remaining artifacts, nor propagate to the CApp
+            // undeployment handler chain, since that would leave the CApp registered as deployed
+            // and prevent it from ever being deployed again.
+            try {
+                RegistryConfig regConfig = buildRegistryConfig(artifact, parentAppName);
+                if (regConfig == null) {
+                    log.error("Unable to build the registry configuration of artifact: "
+                        + artifact.getName()
+                        + ". Skipping the removal of its registry resources.");
+                    return;
+                }
+                removeArtifactFromRegistry(regConfig);
+            } catch (Exception e) {
+                log.error(
+                    "Error occurred while undeploying the registry artifact: " + artifact.getName()
+                        + ". Continuing with the remaining registry artifacts.", e);
+            }
         });
     }
 
@@ -272,7 +288,13 @@ public class FileRegistryResourceDeployer implements AppDeploymentHandler {
             }
             String resourcePath = AppDeployerUtils.computeResourcePath(createRegistryPath(resource.getPath()),
                                                                        resource.getFileName(), registryConfig);
-            lightweightRegistry.delete(resourcePath);
+            // Isolate the failure of a single resource so that the rest of the resources are still cleaned up.
+            try {
+                lightweightRegistry.delete(resourcePath);
+            } catch (Exception e) {
+                log.error("Error occurred while removing the registry resource: " + resourcePath
+                        + ". Continuing with the remaining resources.", e);
+            }
         }
 
         // get collections


### PR DESCRIPTION
## Purpose
> Fix a race condition in the registry happening when other nodes in the cluster remove the resources before the current node. Fixes wso2/product-integrator-mi/issues/4985