### PR TITLE
Skip hidden and non-file entries when loading task definitions

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/FileBasedTaskRepository.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/FileBasedTaskRepository.java
@@ -184,7 +184,8 @@ public class FileBasedTaskRepository implements TaskRepository {
             org.wso2.micro.integrator.ntask.core.TaskInfo taskInfo;
             if (taskPaths != null)
                 for (File taskPath : taskPaths) {
-                    if (!taskPath.getName().startsWith("_meta_")) {
+                    if (taskPath.isFile() && !taskPath.getName().startsWith("_meta_")
+                            && !taskPath.getName().startsWith(".")) {
                         try {
                             taskInfo = this.getTaskInfoRegistryPath(taskPath.getAbsolutePath());
                             result.add(taskInfo);


### PR DESCRIPTION
## Summary

Fixes #3967.

`FileBasedTaskRepository#getAllTasks()` iterates every entry in the task definitions directory and attempts to unmarshal each one as an XML task file, only excluding names starting with `_meta_`. If an unrelated file such as macOS's `.DS_Store` is present, the unmarshaller throws and the failure is logged as an error, as reported in the issue.

## Change

In the loop in `getAllTasks()`, skip entries that are not regular files or whose name starts with `.`, in addition to the existing `_meta_` exclusion, before attempting to parse them.

## Test plan

- [x] Built the full `components` reactor (`mvn install -DskipTests`) and confirmed `org.wso2.micro.integrator.ntask.core` builds successfully with this change.
- [x] Standalone `mvn compile` on the module also succeeds.
- [ ] Maintainer to confirm this covers all the cases they intended (e.g. whether other OS-generated hidden files should also be excluded, which this change already covers via the `.` prefix check).