### PR TITLE
Fix heartbeat mgtApiUrl always using https regardless of configured protocol

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/Constants.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/Constants.java
@@ -61,7 +61,9 @@ public class Constants {
     public static final String FORWARD_SLASH = "/";
     public static final String COLON = ":";
     public static final String HTTPS_PREFIX = "https://";
+    public static final String HTTP_PREFIX = "http://";
     public static final String MANAGEMENT = "management";
+    public static final String MANAGEMENT_API_NAME = "ManagementApi";
     
     // ICP Endpoints
     public static final String ICP_HEARTBEAT_ENDPOINT = "/icp/heartbeat";

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/HeartBeatComponent.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/dashboard/HeartBeatComponent.java
@@ -54,6 +54,7 @@ import static org.wso2.micro.integrator.initializer.dashboard.Constants.DEFAULT_
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.FORWARD_SLASH;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.HEADER_VALUE_APPLICATION_JSON;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.HTTPS_PREFIX;
+import static org.wso2.micro.integrator.initializer.dashboard.Constants.HTTP_PREFIX;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.MANAGEMENT;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.NODE_ID_SYSTEM_PROPERTY;
 import static org.wso2.micro.integrator.initializer.dashboard.Constants.PRODUCT_MI;
@@ -121,9 +122,14 @@ public class HeartBeatComponent {
     }
 
     private static String getMgtApiUrl() {
+        boolean isManagementApiHttps = ConfigurationLoader.getHttpsInternalApis().stream()
+                .anyMatch(api -> Constants.MANAGEMENT_API_NAME.equals(api.getName()));
+        String protocolPrefix = isManagementApiHttps ? HTTPS_PREFIX : HTTP_PREFIX;
+        String httpApiPort = Integer.toString(isManagementApiHttps
+                ? ConfigurationLoader.getInternalInboundHttpsPort() : ConfigurationLoader.getInternalInboundHttpPort());
+
         String serviceIp = System.getProperty("carbon.local.ip");
-        String httpApiPort = Integer.toString(ConfigurationLoader.getInternalInboundHttpsPort());
-        String mgtApiUrl = HTTPS_PREFIX.concat(serviceIp).concat(COLON).concat(httpApiPort).concat(FORWARD_SLASH)
+        String mgtApiUrl = protocolPrefix.concat(serviceIp).concat(COLON).concat(httpApiPort).concat(FORWARD_SLASH)
                                        .concat(MANAGEMENT).concat(FORWARD_SLASH);
 
         Object mgtApiServiceName = configs.get(Constants.DASHBOARD_CONFIG_MANAGEMENT_HOSTNAME);
@@ -132,10 +138,10 @@ public class HeartBeatComponent {
             Object configuredMgtPort = configs.get(Constants.DASHBOARD_CONFIG_MANAGEMENT_PORT);
             if (null != configuredMgtPort) {
                 String servicePort = configuredMgtPort.toString();
-                mgtApiUrl = HTTPS_PREFIX.concat(serviceIp).concat(COLON).concat(servicePort).concat(FORWARD_SLASH)
+                mgtApiUrl = protocolPrefix.concat(serviceIp).concat(COLON).concat(servicePort).concat(FORWARD_SLASH)
                                         .concat(MANAGEMENT).concat(FORWARD_SLASH);
             } else {
-                mgtApiUrl = HTTPS_PREFIX.concat(serviceIp).concat(FORWARD_SLASH).concat(MANAGEMENT)
+                mgtApiUrl = protocolPrefix.concat(serviceIp).concat(FORWARD_SLASH).concat(MANAGEMENT)
                                         .concat(FORWARD_SLASH);
             }
         }


### PR DESCRIPTION
## Summary

Fixes #3975.

`HeartBeatComponent.getMgtApiUrl()` builds the `mgtApiUrl` field sent in the legacy dashboard heartbeat payload. It always used `HTTPS_PREFIX` and `ConfigurationLoader.getInternalInboundHttpsPort()`, regardless of how the `ManagementApi` internal API is actually configured.

`distribution/src/conf/internal-apis.xml` registers the management API with `protocol="https http"` by default. Setting `[management_api] protocols = "http"` in `deployment.toml` restricts it to `http` only, which removes it from `ConfigurationLoader.getHttpsInternalApis()` and leaves it only in `getHttpInternalApis()`. `getMgtApiUrl()` never checked either list, so the URL it built was always `https://...` even when the management API itself only listens on `http`.

## Change

- Added `HTTP_PREFIX` and `MANAGEMENT_API_NAME` constants to the dashboard `Constants` class, matching the existing `HTTPS_PREFIX`/`MANAGEMENT` constants.
- `getMgtApiUrl()` now checks `ConfigurationLoader.getHttpsInternalApis()` for an entry named `ManagementApi` to determine whether it's configured for `https`, and picks the protocol prefix and port (`getInternalInboundHttpsPort()` vs `getInternalInboundHttpPort()`) accordingly.

## Test plan

- [x] `mvn compile` on `components/org.wso2.micro.integrator.initializer` succeeds with this change (BUILD SUCCESS).
- [ ] Maintainer to confirm the heartbeat `mgtApiUrl` uses `http://` when `[management_api] protocols = "http"` is set, per the repro steps in the issue.
